### PR TITLE
feat(auth): add `signOut` endpoint for session revocation

### DIFF
--- a/packages/core/src/@types/index.ts
+++ b/packages/core/src/@types/index.ts
@@ -84,9 +84,17 @@ export type AuthorizationErrorResponse = z.infer<typeof OAuthAuthorizationErrorR
  */
 export type AccessTokenErrorResponse = z.infer<typeof OAuthAccessTokenErrorResponse>["error"]
 
-export interface OAuthErrorResponse<Errors extends "authorization" | "token"> {
-    error: LiteralUnion<Errors extends "authorization" ? AuthorizationErrorResponse : AccessTokenErrorResponse>
+export type TokenRevocationErrorResponse = "invalid_session_token"
+
+export interface OAuthErrorResponse<Errors extends "authorization" | "token" | "signOut"> {
+    error: LiteralUnion<
+        Errors extends "authorization"
+            ? AuthorizationErrorResponse
+            : Errors extends "token"
+              ? AccessTokenErrorResponse
+              : TokenRevocationErrorResponse
+    >
     error_description?: string
 }
 
-export type ErrorTypes = AuthorizationErrorResponse | AccessTokenErrorResponse
+export type ErrorTypes = AuthorizationErrorResponse | AccessTokenErrorResponse | TokenRevocationErrorResponse

--- a/packages/core/src/actions/callback/callback.ts
+++ b/packages/core/src/actions/callback/callback.ts
@@ -11,6 +11,12 @@ import { createSessionCookie, expiredCookieOptions, getCookiesByNames, setCookie
 import type { JWTPayload } from "@/jose.js"
 import type { AuthConfigInternal, OAuthErrorResponse } from "@/@types/index.js"
 
+const config = createEndpointConfig("/callback/:oauth", {
+    schemas: {
+        searchParams: OAuthAuthorizationResponse,
+    },
+})
+
 export const callbackAction = (authConfig: AuthConfigInternal) => {
     const { oauth: oauthIntegrations } = authConfig
 
@@ -76,9 +82,3 @@ export const callbackAction = (authConfig: AuthConfigInternal) => {
         config
     )
 }
-
-const config = createEndpointConfig("/callback/:oauth", {
-    schemas: {
-        searchParams: OAuthAuthorizationResponse,
-    },
-})

--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -1,3 +1,4 @@
 export { signInAction } from "./signIn/signIn.js"
 export { callbackAction } from "./callback/callback.js"
 export { sessionAction } from "./session/session.js"
+export { signOutAction } from "./signOut.js"

--- a/packages/core/src/actions/session/session.ts
+++ b/packages/core/src/actions/session/session.ts
@@ -10,9 +10,6 @@ export const SESSION_VERSION = "v0.1.0"
 export const sessionAction = createEndpoint("GET", "/session", async (request) => {
     try {
         const session = getCookie(request, "sessionToken")
-        if (!session) {
-            throw new AuthError("session_cookie", "Unauthorized")
-        }
         const decoded = (await decodeJWT(session)) as OAuthUserProfile
         const user: OAuthUserProfileInternal = {
             sub: decoded.sub,

--- a/packages/core/src/actions/signIn/signIn.ts
+++ b/packages/core/src/actions/signIn/signIn.ts
@@ -1,7 +1,7 @@
 import { createEndpoint } from "@aura-stack/router"
 import { generateSecure } from "@/secure.js"
 import { AuraResponse } from "@/response.js"
-import { setCookie, setCookiesByNames } from "@/cookie.js"
+import { setCookie } from "@/cookie.js"
 import { integrations } from "@/oauth/index.js"
 import { AuthError, ERROR_RESPONSE, isAuthError } from "@/error.js"
 import { createAuthorizationURL, createRedirectURI } from "@/actions/signIn/authorization.js"

--- a/packages/core/src/actions/signOut.ts
+++ b/packages/core/src/actions/signOut.ts
@@ -1,0 +1,43 @@
+import z from "zod"
+import { createEndpoint, createEndpointConfig } from "@aura-stack/router"
+import { OAuthErrorResponse } from "@/@types/index.js"
+import { expiredCookieOptions, getCookie, setCookie } from "@/cookie.js"
+import { cacheControl } from "@/headers.js"
+import { decodeJWT } from "@/jose.js"
+import { AuraResponse } from "@/response.js"
+
+const config = createEndpointConfig({
+    schemas: {
+        searchParams: z.object({
+            token_type_hint: z.literal("session_token"),
+        }),
+    },
+})
+
+/**
+ * @todo: supports CSRF protection
+ * @see https://datatracker.ietf.org/doc/html/rfc7009
+ */
+export const signOutAction = createEndpoint(
+    "POST",
+    "/signOut",
+    async (request) => {
+        try {
+            const session = getCookie(request, "sessionToken")
+            await decodeJWT(session)
+            const headers = new Headers(cacheControl)
+            const expiredSessionToken = setCookie("sessionToken", "", expiredCookieOptions)
+            headers.set("Set-Cookie", expiredSessionToken)
+            return Response.json({ message: "Signed out successfully" }, { status: 200, headers })
+        } catch {
+            return AuraResponse.json<OAuthErrorResponse<"signOut">>(
+                {
+                    error: "invalid_session_token",
+                    error_description: "The provided sessionToken is invalid or has already expired",
+                },
+                { status: 400 }
+            )
+        }
+    },
+    config
+)

--- a/packages/core/src/cookie.ts
+++ b/packages/core/src/cookie.ts
@@ -76,7 +76,11 @@ export const getCookie = (request: Request, cookie: LiteralUnion<CookieName>) =>
         throw new AuthError("invalid_request", "No cookies found. There is no active session")
     }
     const parsedCookies = parse(cookies)
-    return parsedCookies[`${COOKIE_PREFIX}.${cookie}`]
+    const value = parsedCookies[`${COOKIE_PREFIX}.${cookie}`]
+    if (value === undefined) {
+        throw new AuthError("invalid_request", `Cookie "${cookie}" not found. There is no active session`)
+    }
+    return value
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 import "dotenv/config"
 import { createRouter, type RouterConfig } from "@aura-stack/router"
-import { signInAction, callbackAction, sessionAction } from "@/actions/index.js"
+import { signInAction, callbackAction, sessionAction, signOutAction } from "@/actions/index.js"
 import { createOAuthIntegrations } from "@/oauth/index.js"
 import type { AuthConfig } from "@/@types/index.js"
 
@@ -32,7 +32,7 @@ const routerConfig: RouterConfig = {
  */
 export const createAuth = (authConfig?: AuthConfig) => {
     const oauth = createOAuthIntegrations(authConfig?.oauth)
-    const router = createRouter([signInAction({ oauth }), callbackAction({ oauth }), sessionAction], routerConfig)
+    const router = createRouter([signInAction({ oauth }), callbackAction({ oauth }), sessionAction, signOutAction], routerConfig)
     return {
         handlers: router,
     }

--- a/packages/core/test/actions/signOut.test.ts
+++ b/packages/core/test/actions/signOut.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect, vi } from "vitest"
+import { signOutAction } from "@/actions/signOut.js"
+import { createRouter } from "@aura-stack/router"
+import { encodeJWT, JWTPayload } from "@/jose.js"
+import { SESSION_VERSION } from "@/actions/session/session.js"
+
+const { POST } = createRouter([signOutAction])
+
+describe("signOut action", () => {
+    test("sessionToken cookie not present", async () => {
+        const response = await POST(
+            new Request("https://example.com/signOut?token_type_hint=session_token", {
+                method: "POST",
+            })
+        )
+        expect(response.status).toBe(400)
+        expect(await response.json()).toEqual({
+            error: "invalid_session_token",
+            error_description: "The provided sessionToken is invalid or has already expired",
+        })
+    })
+
+    test("invalid sessionToken cookie", async () => {
+        const request = await POST(
+            new Request("https://example.com/signOut?token_type_hint=session_token", {
+                method: "POST",
+                headers: {
+                    Cookie: "aura-stack.sessionToken=invalid_token",
+                },
+            })
+        )
+        expect(request.status).toBe(400)
+        expect(await request.json()).toEqual({
+            error: "invalid_session_token",
+            error_description: "The provided sessionToken is invalid or has already expired",
+        })
+    })
+
+    test("expired sessionToken cookie", async () => {
+        const decodeJWTMock = vi.spyOn(await import("@/jose.js"), "decodeJWT").mockImplementation(() => {
+            throw new Error("Token expired")
+        })
+
+        const payload: JWTPayload = {
+            sub: "1234567890",
+            email: "john@example.com",
+            name: "John Doe",
+            image: "https://example.com/image.jpg",
+            integrations: ["github"],
+            version: SESSION_VERSION,
+        }
+        const sessionToken = await encodeJWT(payload)
+        const request = await POST(
+            new Request("https://example.com/signOut?token_type_hint=session_token", {
+                headers: {
+                    Cookie: `aura-stack.sessionToken=${sessionToken}`,
+                },
+            })
+        )
+        expect(request.status).toBe(400)
+        expect(await request.json()).toEqual({
+            error: "invalid_session_token",
+            error_description: "The provided sessionToken is invalid or has already expired",
+        })
+        decodeJWTMock.mockRestore()
+    })
+
+    test("valid sessionToken cookie", async () => {
+        const payload: JWTPayload = {
+            sub: "1234567890",
+            email: "john@example.com",
+            name: "John Doe",
+            image: "https://example.com/image.jpg",
+            integrations: ["github"],
+            version: SESSION_VERSION,
+        }
+        const sessionToken = await encodeJWT(payload)
+        const request = await POST(
+            new Request("https://example.com/signOut?token_type_hint=session_token", {
+                method: "POST",
+                headers: {
+                    Cookie: `aura-stack.sessionToken=${sessionToken}`,
+                },
+            })
+        )
+        expect(request.status).toBe(200)
+        expect(await request.json()).toEqual({ message: "Signed out successfully" })
+        expect(request.headers.get("Set-Cookie")).toContain("aura-stack.sessionToken=;")
+    })
+})


### PR DESCRIPTION
## Description

This pull request introduces the `signOut` endpoint for session revocation.   The new endpoint allows users to terminate and revoke an active session.  The implementation follows the **OAuth 2.0 Token Revocation** specification.   For more details, see the [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009).

### Key Changes
- Introduce the `signOut` endpoint.
- Add tests to verify correct sign-out behavior.
- Align implementation with RFC 7009.
