### PR TITLE
feat(auth): implement `redirectTo` search parameter for redirection

### DIFF
--- a/packages/core/src/assert.ts
+++ b/packages/core/src/assert.ts
@@ -9,7 +9,6 @@ export const isRequest = (value: unknown): value is Request => {
 export const isValidURL = (value: string): boolean => {
     if (value.includes("\r\n") || value.includes("\n") || value.includes("\r")) return false
     const regex =
-        ///^https?:\/\/(?:[a-zA-Z0-9._-]+|localhost|\[[0-9a-fA-F:]+\])(?::\d{1,5})?(?:\/[a-zA-Z0-9._~!$&'()*+,;=:@-]*)*\/?$/
-        /^(https?:\/\/)(localhost|\d{1,3}(?:\.\d{1,3}){3}|[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)+)(:\d{1,5})?(\/[a-zA-Z0-9._~!$&'()*+,;=:@/-]*)?$/
+        /^https?:\/\/(?:[a-zA-Z0-9._-]+|localhost|\[[0-9a-fA-F:]+\])(?::\d{1,5})?(?:\/[a-zA-Z0-9._~!$&'()*+,;=:@-]*)*\/?$/
     return regex.test(value)
 }

--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -20,6 +20,13 @@ export class InvalidCsrfTokenError extends AuthError {
     }
 }
 
+export class InvalidRedirectToError extends AuthError {
+    constructor(message: string = "The redirectTo parameter does not match the hosted origin.") {
+        super("invalid_redirect_to", message)
+        this.name = "InvalidRedirectToError"
+    }
+}
+
 /**
  * Verifies if the provided error is an instance of AuthError.
  *

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -118,3 +118,22 @@ export const onErrorHandler: RouterConfig["onError"] = (error) => {
     }
     return Response.json({ error: "server_error", error_description: "An unexpected error occurred" }, { status: 500 })
 }
+
+/**
+ * Extracts and normalizes the origin and pathname from a URL string.
+ * Removes query parameters and hash fragments for a clean path.
+ * Falls back to the original string if URL parsing fails.
+ *
+ * @param path - The URL or path string to process
+ * @returns The normalized URL with origin and pathname, or the original path
+ */
+export const getNormalizedOriginPath = (path: string): string => {
+    try {
+        const url = new URL(path)
+        url.hash = ""
+        url.search = ""
+        return `${url.origin}${url.pathname}`
+    } catch {
+        return sanitizeURL(path)
+    }
+}

--- a/packages/core/test/actions/signIn/authorization.test.ts
+++ b/packages/core/test/actions/signIn/authorization.test.ts
@@ -230,26 +230,29 @@ describe("createRedirectTo", () => {
             },
             {
                 description: "with redirectTo parameter provided",
-                request: new Request(`${signInURL}?redirectTo=/auth/signIn`),
+                request: new Request(signInURL),
+                redirectTo: "/auth/signIn",
                 expected: "/auth/signIn",
             },
             {
                 description: "with redirectTo parameter matching hosted origin",
-                request: new Request(`${signInURL}?redirectTo=https://example.com/auth/signIn`),
+                request: new Request(signInURL),
+                redirectTo: "https://example.com/auth/signIn",
                 expected: "/auth/signIn",
             },
             {
                 description: "with redirectTo parameter overriding referer header",
-                request: new Request(`${signInURL}?redirectTo=/auth/signIn`, {
+                request: new Request(signInURL, {
                     headers: { Referer: "https://example.com/dashboard" },
                 }),
+                redirectTo: "/auth/signIn",
                 expected: "/auth/signIn",
             },
         ]
 
-        for (const { description, request, expected } of testCases) {
+        for (const { description, request, expected, redirectTo: redirectToParam } of testCases) {
             test(description, () => {
-                const redirectTo = createRedirectTo(request)
+                const redirectTo = createRedirectTo(request, redirectToParam)
                 expect(redirectTo).toBe(expected)
             })
         }
@@ -421,24 +424,27 @@ describe("createRedirectTo", () => {
             },
             {
                 description: "with redirectTo parameter containing full URL with query",
-                request: new Request(`${signInURL}?redirectTo=https://example.com/auth/signIn?next=123`),
+                request: new Request(signInURL),
+                redirectTo: "https://example.com/auth/signIn?next=123",
                 expected: /The redirectTo parameter does not match the hosted origin./,
             },
             {
                 description: "with redirectTo parameter containing full URL with different origin",
-                request: new Request(`${signInURL}?redirectTo=https://malicious.com/auth/signIn`),
+                request: new Request(signInURL),
+                redirectTo: "https://malicious.com/auth/signIn",
                 expected: /The redirectTo parameter does not match the hosted origin./,
             },
             {
                 description: "with redirectTo parameter containing invalid URL",
-                request: new Request(`${signInURL}?redirectTo=ht!tp://invalid-url`),
+                request: new Request(signInURL),
+                redirectTo: "ht!tp://invalid-url",
                 expected: /Invalid origin \(potential CSRF\)./,
             },
         ]
 
-        for (const { description, request, expected } of testCases) {
+        for (const { description, request, expected, redirectTo } of testCases) {
             test(description, () => {
-                expect(() => createRedirectTo(request)).toThrow(expected)
+                expect(() => createRedirectTo(request, redirectTo)).toThrow(expected)
             })
         }
     })

--- a/packages/core/test/actions/signIn/signIn.test.ts
+++ b/packages/core/test/actions/signIn/signIn.test.ts
@@ -36,7 +36,8 @@ describe("signIn action", () => {
                 const request = await GET(new Request(url))
                 const headers = new Headers(request.headers)
 
-                const stateCookie = getCookie(request, "state", { secure: url.startsWith("https://") })
+                const isSecure = url.startsWith("https://")
+                const stateCookie = getCookie(request, "state", { secure: isSecure, prefix: isSecure ? "__Secure-" : "" })
                 const location = headers.get("Location") as string
                 const searchParams = new URL(location).searchParams
 

--- a/packages/core/test/presets.ts
+++ b/packages/core/test/presets.ts
@@ -30,7 +30,5 @@ export const hostCookieOptions: CookieOptionsInternal = { secure: true, prefix: 
 
 export const { GET, POST } = createAuth({
     oauth: [oauthCustomService],
-    cookies: {
-        flag: "host",
-    },
+    cookies: {},
 }).handlers


### PR DESCRIPTION
## Description

This pull request adds support for the `redirectTo` search parameter in both the **signIn** and **signOut** flows.  This new parameter allows users to specify the URL or path to which the page will be redirected after the process completes successfully.

Two types of `redirectTo` values are supported:

- **pathname**: A path within the same website.
- **url**: A full URL that must match the application's origin.

For security reasons, any URL passed **must match the hosted URL** of the Aura Auth instance (the origin where the auth server is running). This ensures that redirections cannot be made to untrusted or external domains.
