### PR TITLE
feat(core): add `basePath` configuration option

### DIFF
--- a/packages/core/src/@types/index.ts
+++ b/packages/core/src/@types/index.ts
@@ -1,9 +1,10 @@
 import { z } from "zod/v4"
-import type { OAuthIntegrations } from "@/oauth/index.js"
-import { OAuthAccessTokenErrorResponse, OAuthAuthorizationErrorResponse } from "@/schemas.js"
-import { SESSION_VERSION } from "@/actions/session/session.js"
 import { SerializeOptions } from "cookie"
 import { createJoseInstance } from "@/jose.js"
+import { SESSION_VERSION } from "@/actions/session/session.js"
+import { OAuthAccessTokenErrorResponse, OAuthAuthorizationErrorResponse } from "@/schemas.js"
+import type { RoutePattern } from "@aura-stack/router"
+import type { OAuthIntegrations } from "@/oauth/index.js"
 
 /**
  * Standardized user profile returned by OAuth integrations after fetching user information
@@ -131,6 +132,10 @@ export interface AuthConfig {
      * doesn't exist, it will throw an error during the initialization of the Auth module.
      */
     secret?: string
+    /**
+     * Base path for all authentication routes. Default is `/auth`.
+     */
+    basePath?: RoutePattern
 }
 
 export interface AuthConfigInternal {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ import type { AuthConfig } from "@/@types/index.js"
 
 const createInternalConfig = (authConfig?: AuthConfig): RouterConfig => {
     return {
-        basePath: "/auth",
+        basePath: authConfig?.basePath ?? "/auth",
         onError: onErrorHandler,
         context: {
             oauth: createOAuthIntegrations(authConfig?.oauth),

--- a/packages/core/test/instance.test.ts
+++ b/packages/core/test/instance.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from "vitest"
+import { createAuth } from "@/index.js"
+
+describe("createAuth", () => {
+    describe("add custom basePath config", () => {
+        const auth = createAuth({
+            oauth: ["github"],
+            basePath: "/api/v1/auth",
+        })
+
+        test("valid custom path for get csrfToken", async () => {
+            const response = await auth.handlers.GET(new Request("https://example.com/api/v1/auth/csrfToken"))
+            expect(response.status).toBe(200)
+            const data = await response.json()
+            expect(data).toHaveProperty("csrfToken")
+        })
+
+        test("invalid path for get csrfToken", async () => {
+            const response = await auth.handlers.GET(new Request("https://example.com/auth/csrfToken"))
+            expect(response.status).toBe(404)
+        })
+    })
+})


### PR DESCRIPTION
## Description

This pull request introduces the `basePath` configuration option to the Aura instance created through the `createAuth` function.  
With this new feature, users can override Aura Auth’s default base path (`/auth`) and define custom paths that better fit their application structure.

**Before**  
Route handlers were required to live under the `/auth` base path, depending on the library or framework integrating Aura Auth. For example, in Next.js (App Router), users needed to place their route handler at:

- `/app/auth/[...aura]/route.ts`

**After**  
With the new `basePath` option, users can host and place route handlers anywhere in their backend as supported by their library or framework.   In Next.js, examples now include:

- `/app/api/auth/[...aura]/route.ts`  
- `/app/api/v1/auth/[...aura]/route.ts`  
- `/app/authentication/[...aura]/route.ts`  
- or any other custom API path they define.

This enhancement provides greater flexibility and enables seamless integration into a wider variety of backend and routing structures.
