### PR TITLE
feat(oauth): add `Dropbox` OAuth provider

### DIFF
--- a/docs/src/content/docs/oauth/dropbox.mdx
+++ b/docs/src/content/docs/oauth/dropbox.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dropbox Authorization Provider
-description: Add Dropbox authorization provider to Aura Auth to authentication and authorize
+description: Add Dropbox authorization provider to Aura Auth to authenticate and authorize
 ---
 
 ## Dropbox
@@ -115,6 +115,23 @@ import { createAuth } from "@aura-stack/auth"
 
 export const auth = createAuth({
   oauth: ["dropbox"],
+})
+
+export const { handlers } = auth
+```
+
+#### Custom configuration
+
+```ts title="@/auth" lineNumbers
+import { createAuth } from "@aura-stack/auth"
+import { dropbox } from "@aura-stack/auth/oauth/dropbox"
+
+export const auth = createAuth({
+  oauth: [
+    dropbox({
+      scope: "account_info.read files.content.read",
+    }),
+  ],
 })
 
 export const { handlers } = auth

--- a/docs/src/content/docs/oauth/index.mdx
+++ b/docs/src/content/docs/oauth/index.mdx
@@ -90,6 +90,12 @@ The following OAuth providers are currently supported by Aura Auth:
   <Card title="Twitch (Experimental)" href="/docs/oauth/twitch">
     Twitch OAuth Identity Provider
   </Card>
+  <Card title="Notion (Experimental)" href="/docs/oauth/notion">
+    Notion OAuth Identity Provider
+  </Card>
+  <Card title="Dropbox (Experimental)" href="/docs/oauth/dropbox">
+    Dropbox OAuth Identity Provider
+  </Card>
 </Cards>
 
 ---

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the `Dropbox` OAuth provider to the supported integrations in Aura Auth. [#59](https://github.com/aura-stack-ts/auth/pull/59)
+
 - Added the `Notion` OAuth provider to the supported integrations in Aura Auth. [#49](https://github.com/aura-stack-ts/auth/pull/49)
 
 - Added the `Twitch` OAuth provider to the supported integrations in Aura Auth. [#47](https://github.com/aura-stack-ts/auth/pull/47)

--- a/packages/core/src/@types/index.ts
+++ b/packages/core/src/@types/index.ts
@@ -69,7 +69,13 @@ export interface OAuthProviderConfig<Profile extends object = Record<string, any
               url: string
               headers?: Record<string, string>
           }
-    userInfo: string | { url: string; headers?: Record<string, string> }
+    userInfo:
+        | string
+        | {
+              url: string
+              headers?: Record<string, string>
+              method?: string
+          }
     /**
      * @deprecated
      * use `authorize.params.scope` instead of `scope`

--- a/packages/core/src/actions/callback/userinfo.ts
+++ b/packages/core/src/actions/callback/userinfo.ts
@@ -35,6 +35,7 @@ export const getUserInfo = async (oauthConfig: OAuthProviderCredentials, accessT
     const userInfoConfig = oauthConfig.userInfo
     const userinfoURL = typeof userInfoConfig === "string" ? userInfoConfig : userInfoConfig.url
     const extraHeaders = typeof userInfoConfig === "string" ? undefined : userInfoConfig.headers
+    const method = typeof userInfoConfig === "string" ? "GET" : (userInfoConfig.method ?? "GET").toUpperCase()
 
     try {
         logger?.log("OAUTH_USERINFO_REQUEST_INITIATED", {
@@ -43,7 +44,7 @@ export const getUserInfo = async (oauthConfig: OAuthProviderCredentials, accessT
             },
         })
         const response = await fetchAsync(userinfoURL, {
-            method: "GET",
+            method,
             headers: {
                 "User-Agent": `Aura Auth/${AURA_AUTH_VERSION}`,
                 Accept: "application/json",

--- a/packages/core/src/oauth/dropbox.ts
+++ b/packages/core/src/oauth/dropbox.ts
@@ -1,4 +1,4 @@
-import type { OAuthProviderConfig } from "@/@types/index.js"
+import type { OAuthProviderCredentials } from "@/@types/index.js"
 
 export type AccountType = "basic" | "pro" | "business"
 
@@ -47,20 +47,29 @@ export interface DropboxProfile {
  * @see [Dropbox - My Apps](https://www.dropbox.com/developers/apps)
  * @see [Dropbox - Developer Guide](https://www.dropbox.com/developers/reference/developer-guide)
  */
-export const dropbox: OAuthProviderConfig<DropboxProfile> = {
-    id: "dropbox",
-    name: "Dropbox",
-    authorizeURL: "https://www.dropbox.com/oauth2/authorize",
-    accessToken: "https://api.dropboxapi.com/oauth2/token",
-    userInfo: "https://api.dropboxapi.com/2/users/get_current_account",
-    scope: "account_info.read",
-    responseType: "code",
-    profile(profile) {
-        return {
-            sub: profile.account_id,
-            name: profile.name.display_name,
-            email: profile.email,
-            image: profile.profile_photo_url,
-        }
-    },
+export const dropbox = (
+    options?: Partial<OAuthProviderCredentials<DropboxProfile>>
+): OAuthProviderCredentials<DropboxProfile> => {
+    return {
+        id: "dropbox",
+        name: "Dropbox",
+        authorize: {
+            url: "https://www.dropbox.com/oauth2/authorize",
+            params: { scope: "account_info.read" },
+        },
+        accessToken: "https://api.dropboxapi.com/oauth2/token",
+        userInfo: {
+            method: "POST",
+            url: "https://api.dropboxapi.com/2/users/get_current_account",
+        },
+        profile(profile) {
+            return {
+                sub: profile.account_id,
+                name: profile.name.display_name,
+                email: profile.email,
+                image: profile.profile_photo_url,
+            }
+        },
+        ...options,
+    } as OAuthProviderCredentials<DropboxProfile>
 }

--- a/packages/core/src/oauth/index.ts
+++ b/packages/core/src/oauth/index.ts
@@ -17,6 +17,7 @@ import { mailchimp } from "./mailchimp.ts"
 import { pinterest } from "./pinterest.ts"
 import { twitch } from "./twitch.ts"
 import { notion } from "./notion.ts"
+import { dropbox } from "./dropbox.ts"
 import { OAuthEnvSchema, OAuthProviderCredentialsSchema } from "@/schemas.ts"
 import { AuthInternalError } from "@/errors.ts"
 import { formatZodError } from "@/utils.ts"
@@ -33,6 +34,7 @@ export * from "./mailchimp.ts"
 export * from "./pinterest.ts"
 export * from "./twitch.ts"
 export * from "./notion.ts"
+export * from "./dropbox.ts"
 
 export const builtInOAuthProviders = {
     github,
@@ -47,6 +49,7 @@ export const builtInOAuthProviders = {
     pinterest,
     twitch,
     notion,
+    dropbox,
 } as const
 
 /**

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -24,6 +24,7 @@ const UserInfoConfigSchema = z.union([
     object({
         url: string().url(),
         headers: z.record(string(), string()).optional(),
+        method: string().optional(),
     }),
 ])
 


### PR DESCRIPTION
## Description

This pull request adds the `Dropbox` OAuth provider to the list of supported OAuth integrations in the Aura Auth library.  
With this addition, Aura Auth now supports seven OAuth providers: `GitHub`, `Bitbucket`, `Figma`, `Discord`, `GitLab`, `Spotify`, `X`, `Strava` and  `Dropbox`



### Set up

```ts
import { createAuth } from "@aura-stack/auth"

export const auth = createAuth({
  oauth: ["dropbox"],
})

export const { handlers } = auth
```

### Related Prs
- #109 

