### PR TITLE
refactor(core): randomize code verifier length for PKCE flow

### DIFF
--- a/packages/core/src/secure.ts
+++ b/packages/core/src/secure.ts
@@ -26,7 +26,6 @@ export const createPKCE = async (verifier?: string) => {
     const byteLength = verifier ? undefined : Math.floor(Math.random() * (96 - 32 + 1) + 32)
     const codeVerifier = verifier ?? generateSecure(byteLength ?? 64)
     if (codeVerifier.length < 43 || codeVerifier.length > 128) {
-        console.log(codeVerifier.length)
         throw new AuthSecurityError("PKCE_VERIFIER_INVALID", "The code verifier must be between 43 and 128 characters in length.")
     }
     const codeChallenge = createHash(codeVerifier, "base64url")


### PR DESCRIPTION
## Description

This pull request introduces randomization of the **PKCE code verifier length** using the `createPKCE` function. With this change, the `code_verifier` length varies on each request, using a randomized length between **42 and 128 characters**, as defined by the PKCE RFC specification.

This improves security by avoiding predictable verifier lengths while remaining fully compliant with the PKCE standard.

### Resources
- [PKCE – Client Creates a Code Verifier](https://datatracker.ietf.org/doc/html/rfc7636#section-4.1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PKCE verifier handling: when no verifier is supplied, the system now generates verifier bytes with a variable secure length rather than a fixed size. Added validation that enforces acceptable verifier length ranges and surfaces an error if values fall outside those bounds. Verifier-to-challenge flow remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->