### PR TITLE
perf(core): precompute cookie store for request handling

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,18 +33,17 @@ const createInternalConfig = (authConfig?: AuthConfig): RouterConfig => {
     const useProxyHeaders =
         trustedProxyHeadersEnv === undefined ? (authConfig?.trustedProxyHeaders ?? false) : getEnvBoolean("TRUSTED_PROXY_HEADERS")
     const logger = createProxyLogger(authConfig)
+    const cookiePrefix = authConfig?.cookies?.prefix
+    const cookieOverrides = authConfig?.cookies?.overrides ?? {}
+    const secureCookieStore = createCookieStore(true, cookiePrefix, cookieOverrides, logger)
+    const standardCookieStore = createCookieStore(false, cookiePrefix, cookieOverrides, logger)
 
     return {
         basePath: authConfig?.basePath ?? "/auth",
         onError: createErrorHandler(logger),
         context: {
             oauth: createBuiltInOAuthProviders(authConfig?.oauth),
-            cookies: createCookieStore(
-                useProxyHeaders,
-                authConfig?.cookies?.prefix,
-                authConfig?.cookies?.overrides ?? {},
-                logger
-            ),
+            cookies: standardCookieStore,
             jose: createJoseInstance(authConfig?.secret),
             secret: authConfig?.secret,
             basePath: authConfig?.basePath ?? "/auth",
@@ -56,13 +55,7 @@ const createInternalConfig = (authConfig?: AuthConfig): RouterConfig => {
         use: [
             (ctx) => {
                 const useSecure = useSecureCookies(ctx.request, ctx.context.trustedProxyHeaders)
-                const cookies = createCookieStore(
-                    useSecure,
-                    authConfig?.cookies?.prefix,
-                    authConfig?.cookies?.overrides ?? {},
-                    logger
-                )
-                ctx.context.cookies = cookies
+                ctx.context.cookies = useSecure ? secureCookieStore : standardCookieStore
                 return ctx
             },
         ],


### PR DESCRIPTION
## Description

This pull request optimizes cookie store creation by precomputing cookie store instances for middleware usage and request handling. Previously, the cookie store was instantiated per request, introducing unnecessary overhead and creating a performance bottleneck under high load.

With this change, cookie stores are initialized ahead of time and reused based on the connection context (HTTP or HTTPS), separating secure and non-secure configurations. This reduces per-request resource consumption, improves throughput, and enhances overall runtime efficiency without altering existing cookie behavior.
