### PR TITLE
chore(release): bump package versions 

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -24,17 +24,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Introduced an `api` object via `createAuth` for retrieving and signing out sessions on the server without calling mounted endpoints, improving resource access in trusted environments. [#112](https://github.com/aura-stack-ts/auth/pull/112)
 
-- Added the `Dropbox` OAuth provider to the supported integrations in Aura Auth. [#59](https://github.com/aura-stack-ts/auth/pull/59)
-
-- Added the `Notion` OAuth provider to the supported integrations in Aura Auth. [#49](https://github.com/aura-stack-ts/auth/pull/49)
-
-- Added the `Twitch` OAuth provider to the supported integrations in Aura Auth. [#47](https://github.com/aura-stack-ts/auth/pull/47)
+- Introduced a new OAuth provider configuration API that enables passing custom values and properties to the `/authorization`, `/access_token`, and `/userinfo` endpoints of OAuth services, improving flexibility and compatibility when integrating with a broader range of providers. [#109](https://github.com/aura-stack-ts/auth/pull/109)
 
 - Added support for loading authentication configuration from environment variables, including `DEBUG`, `LOG_LEVEL`, `TRUSTED_ORIGINS`, and `TRUSTED_PROXY_HEADERS`. Also updated automatic environment variable loading patterns. [#108](https://github.com/aura-stack-ts/auth/pull/108)
 
 - Added the `User-Agent` header to requests sent to the `/userInfo` endpoint, allowing the service to identify the calling client or application. [#105](https://github.com/aura-stack-ts/auth/pull/105)
 
 - Added `timingSafeEqual` function for constant-time string comparison across runtimes. [#99](https://github.com/aura-stack-ts/auth/pull/99)
+
+- Added the `Atlassian` OAuth provider to the supported integrations in Aura Auth. [#60](https://github.com/aura-stack-ts/auth/pull/60)
+
+- Added the `Dropbox` OAuth provider to the supported integrations in Aura Auth. [#59](https://github.com/aura-stack-ts/auth/pull/59)
+
+- Added the `Notion` OAuth provider to the supported integrations in Aura Auth. [#49](https://github.com/aura-stack-ts/auth/pull/49)
+
+- Added the `Twitch` OAuth provider to the supported integrations in Aura Auth. [#47](https://github.com/aura-stack-ts/auth/pull/47)
 
 ### Changed
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
-## [0.4.0] - 2026-03-19
+## [0.5.0] - 2026-03-19
 
 ### Added
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.4.0] - 2026-03-19
+
 ### Added
 
 - Added support for defining the base URL through the `BASE_URL` environment variable or the `baseURL` option in `createAuth`. This value is used to construct the incoming URL. [#117](https://github.com/aura-stack-ts/auth/pull/117)

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -1,14 +1,29 @@
 {
   "name": "@aura-stack/auth",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
   },
   "exports": {
     ".": "./src/index.ts",
-    "./oauth": "./src/oauth/*.ts",
-    "./types": "./src/@types/index.ts"
+    "./oauth": "./src/oauth/index.ts",
+    "./oauth/atlassian": "./src/oauth/atlassian.ts",
+    "./oauth/bitbucket": "./src/oauth/bitbucket.ts",
+    "./oauth/discord": "./src/oauth/discord.ts",
+    "./oauth/dropbox": "./src/oauth/dropbox.ts",
+    "./oauth/figma": "./src/oauth/figma.ts",
+    "./oauth/github": "./src/oauth/github.ts",
+    "./oauth/gitlab": "./src/oauth/gitlab.ts",
+    "./oauth/mailchimp": "./src/oauth/mailchimp.ts",
+    "./oauth/notion": "./src/oauth/notion.ts",
+    "./oauth/pinterest": "./src/oauth/pinterest.ts",
+    "./oauth/spotify": "./src/oauth/spotify.ts",
+    "./oauth/strava": "./src/oauth/strava.ts",
+    "./oauth/twitch": "./src/oauth/twitch.ts",
+    "./oauth/x": "./src/oauth/x.ts",
+    "./types": "./src/@types/index.ts",
+    "./client": "./src/client/index.ts"
   },
   "imports": {
     "@/": "./src/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/auth",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "type": "module",
   "description": "Core auth for @aura-stack/auth",

--- a/packages/core/src/oauth/atlassian.ts
+++ b/packages/core/src/oauth/atlassian.ts
@@ -1,4 +1,4 @@
-import type { LiteralUnion, OAuthProviderCredentials } from "@/@types/index.js"
+import type { LiteralUnion, OAuthProviderCredentials } from "@/@types/index.ts"
 
 export interface ExtendedProfile {
     job_title: string

--- a/packages/core/src/oauth/dropbox.ts
+++ b/packages/core/src/oauth/dropbox.ts
@@ -1,4 +1,4 @@
-import type { OAuthProviderCredentials } from "@/@types/index.js"
+import type { OAuthProviderCredentials } from "@/@types/index.ts"
 
 export type AccountType = "basic" | "pro" | "business"
 

--- a/packages/jose/CHANGELOG.md
+++ b/packages/jose/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.4.0] - 2026-03-19
+
 ### Added
 
 - Introduced type-safe payloads in `createJWT`, `encodeJWT`, `decodeJWT`, `createJWS`, `signJWS` and `verifyJWS` to provide stronger typing for JWT encoding and decoding, including improved autocompletion for payload attributes during creation and verification. [#116](https://github.com/aura-stack-ts/auth/pull/116)

--- a/packages/jose/deno.json
+++ b/packages/jose/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/jose",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts",

--- a/packages/jose/package.json
+++ b/packages/jose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/jose",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": false,
   "type": "module",
   "description": "JOSE utilities for @aura-stack/auth",


### PR DESCRIPTION
## Description

This pull request publishes new releases of the packages to both npm and JSR registries:

- `@aura-stack/auth@0.5.0`
- `@aura-stack/jose@0.4.0`

### Registries

#### NPM
- https://www.npmjs.com/package/@aura-stack/auth
- https://www.npmjs.com/package/@aura-stack/jose

#### JSR
- https://jsr.io/@aura-stack/auth
- https://jsr.io/@aura-stack/jose

These releases introduce new APIs, expanded OAuth provider support, and multiple security improvements, including built-in secure comparisons. Additionally, configuration via environment variables has been enhanced, allowing users to define authentication behavior either programmatically or through environment-based configuration.

Overall, these updates improve compatibility with OAuth providers, strengthen security practices, and enhance the developer experience for both users and contributors.

### Key Changes
**`@aura-stack/auth`**
- #120 
- #117 
- #115 
- #114 
- #112 
- #111 
- #109 
- #108 
- #99 
- #60 
- #59 
- #49 
- #47 

**`@aura-stack/jose`**
- #116 