### PR TITLE
feat(core): standardize API and client options and return types

### DIFF
--- a/apps/react-router/app/lib/auth.ts
+++ b/apps/react-router/app/lib/auth.ts
@@ -9,4 +9,5 @@ export const {
 } = createAuth({
     oauth,
     basePath: "/api/auth",
+    baseURL: "http://localhost:5174",
 })

--- a/apps/react-router/app/routes/index.tsx
+++ b/apps/react-router/app/routes/index.tsx
@@ -1,9 +1,9 @@
-import { Fingerprint, LayoutDashboard } from "lucide-react"
-import { AuthClient } from "~/components/auth-client"
+import { api } from "~/lib/auth"
 import { Form } from "react-router"
 import { Button } from "~/components/ui/button"
+import { AuthClient } from "~/components/auth-client"
+import { Fingerprint, LayoutDashboard } from "lucide-react"
 import type { Route } from "./+types/index"
-import { api } from "~/lib/auth"
 
 export const loader = async ({ request }: Route.LoaderArgs) => {
     const session = await api.getSession({
@@ -16,13 +16,16 @@ export const action = async ({ request }: Route.ActionArgs) => {
     const formData = await request.formData()
     const action = formData.get("action")
     if (action === "signOut") {
-        return await api.signOut({
+        const out = await api.signOut({
+            request: request,
             headers: request.headers,
         })
+        return out
     } else if (action === "signIn") {
-        return await api.signIn(formData.get("provider") as string, {
+        const signIn = await api.signIn(formData.get("provider") as string, {
             request,
         })
+        return signIn
     }
     return null
 }

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "tsup": "^8.5.1",
         "turbo": "^2.7.5",
         "typescript": "catalog:typescript",
-        "vitest": "^4.1.0",
+        "vitest": "catalog:vitest",
       },
     },
     "apps/astro": {
@@ -307,6 +307,7 @@
         "@aura-stack/tsconfig": "workspace:*",
         "@aura-stack/tsup-config": "workspace:*",
         "typescript": "catalog:typescript",
+        "vitest": "catalog:vitest",
       },
     },
     "packages/elysia": {
@@ -319,6 +320,7 @@
         "@aura-stack/tsconfig": "workspace:*",
         "@aura-stack/tsup-config": "workspace:*",
         "elysia": "^1.2.22",
+        "vitest": "catalog:vitest",
       },
       "peerDependencies": {
         "elysia": ">=1.0.0",
@@ -337,6 +339,7 @@
         "@types/supertest": "^6.0.3",
         "express": "catalog:express",
         "supertest": "^7.2.2",
+        "vitest": "catalog:vitest",
       },
       "peerDependencies": {
         "express": ">=4.0.0",
@@ -353,6 +356,7 @@
         "@aura-stack/tsup-config": "workspace:*",
         "@types/bun": "catalog:bun",
         "hono": "catalog:hono",
+        "vitest": "catalog:vitest",
       },
       "peerDependencies": {
         "hono": ">=4.0.0",
@@ -368,6 +372,7 @@
         "@aura-stack/tsconfig": "workspace:*",
         "@aura-stack/tsup-config": "workspace:*",
         "typescript": "catalog:typescript",
+        "vitest": "catalog:vitest",
       },
     },
     "packages/next": {
@@ -395,6 +400,7 @@
       "devDependencies": {
         "@aura-stack/tsconfig": "workspace:*",
         "@aura-stack/tsup-config": "workspace:*",
+        "vitest": "catalog:vitest",
       },
     },
     "packages/react": {
@@ -410,6 +416,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/react": "catalog:react",
         "react": "catalog:react",
+        "vitest": "catalog:vitest",
       },
       "peerDependencies": {
         "@types/react": ">=19.0.0",
@@ -484,6 +491,9 @@
     },
     "vite": {
       "vite": "^7.1.7",
+    },
+    "vitest": {
+      "vitest": "4.1.4",
     },
     "zod-v3": {
       "zod": "3.25.76",
@@ -1667,17 +1677,17 @@
 
     "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.0", "", { "dependencies": { "@bcoe/v8-coverage": "1.0.2", "@vitest/utils": "4.1.0", "ast-v8-to-istanbul": "1.0.0", "istanbul-lib-coverage": "3.2.2", "istanbul-lib-report": "3.0.1", "istanbul-reports": "3.2.0", "magicast": "0.5.2", "obug": "2.1.1", "std-env": "4.0.0", "tinyrainbow": "3.1.0" }, "peerDependencies": { "vitest": "4.1.0" } }, "sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.0", "", { "dependencies": { "@standard-schema/spec": "1.1.0", "@types/chai": "5.2.3", "@vitest/spy": "4.1.0", "@vitest/utils": "4.1.0", "chai": "6.2.2", "tinyrainbow": "3.1.0" } }, "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA=="],
+    "@vitest/expect": ["@vitest/expect@4.1.4", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.0", "", { "dependencies": { "@vitest/spy": "4.1.0", "estree-walker": "3.0.3", "magic-string": "0.30.21" }, "optionalDependencies": { "vite": "7.3.1" } }, "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.4", "", { "dependencies": { "@vitest/spy": "4.1.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.0", "", { "dependencies": { "tinyrainbow": "3.1.0" } }, "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.4", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.0", "", { "dependencies": { "@vitest/utils": "4.1.0", "pathe": "2.0.3" } }, "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ=="],
+    "@vitest/runner": ["@vitest/runner@4.1.4", "", { "dependencies": { "@vitest/utils": "4.1.4", "pathe": "^2.0.3" } }, "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.0", "", { "dependencies": { "@vitest/pretty-format": "4.1.0", "@vitest/utils": "4.1.0", "magic-string": "0.30.21", "pathe": "2.0.3" } }, "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "@vitest/utils": "4.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.0", "", {}, "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw=="],
+    "@vitest/spy": ["@vitest/spy@4.1.4", "", {}, "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ=="],
 
     "@vitest/utils": ["@vitest/utils@4.1.0", "", { "dependencies": { "@vitest/pretty-format": "4.1.0", "convert-source-map": "2.0.0", "tinyrainbow": "3.1.0" } }, "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw=="],
 
@@ -3577,7 +3587,7 @@
 
     "vitefu": ["vitefu@1.1.2", "", { "optionalDependencies": { "vite": "7.3.1" } }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
 
-    "vitest": ["vitest@4.1.0", "", { "dependencies": { "@vitest/expect": "4.1.0", "@vitest/mocker": "4.1.0", "@vitest/pretty-format": "4.1.0", "@vitest/runner": "4.1.0", "@vitest/snapshot": "4.1.0", "@vitest/spy": "4.1.0", "@vitest/utils": "4.1.0", "es-module-lexer": "2.0.0", "expect-type": "1.3.0", "magic-string": "0.30.21", "obug": "2.1.1", "pathe": "2.0.3", "picomatch": "4.0.3", "std-env": "4.0.0", "tinybench": "2.9.0", "tinyexec": "1.0.4", "tinyglobby": "0.2.15", "tinyrainbow": "3.1.0", "why-is-node-running": "2.3.0" }, "optionalDependencies": { "@types/node": "24.12.0", "jsdom": "27.4.0" }, "peerDependencies": { "vite": "7.3.1" }, "bin": { "vitest": "vitest.mjs" } }, "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw=="],
+    "vitest": ["vitest@4.1.4", "", { "dependencies": { "@vitest/expect": "4.1.4", "@vitest/mocker": "4.1.4", "@vitest/pretty-format": "4.1.4", "@vitest/runner": "4.1.4", "@vitest/snapshot": "4.1.4", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.4", "@vitest/browser-preview": "4.1.4", "@vitest/browser-webdriverio": "4.1.4", "@vitest/coverage-istanbul": "4.1.4", "@vitest/coverage-v8": "4.1.4", "@vitest/ui": "4.1.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg=="],
 
     "volar-service-css": ["volar-service-css@0.0.70", "", { "dependencies": { "vscode-css-languageservice": "6.3.10", "vscode-languageserver-textdocument": "1.0.12", "vscode-uri": "3.1.0" }, "optionalDependencies": { "@volar/language-service": "2.4.28" } }, "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw=="],
 
@@ -3724,6 +3734,10 @@
     "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@cloudflare/unenv-preset/workerd": ["workerd@1.20260310.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260310.1", "@cloudflare/workerd-darwin-arm64": "1.20260310.1", "@cloudflare/workerd-linux-64": "1.20260310.1", "@cloudflare/workerd-linux-arm64": "1.20260310.1", "@cloudflare/workerd-windows-64": "1.20260310.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-yawXhypXXHtArikJj15HOMknNGikpBbSg2ZDe6lddUbqZnJXuCVSkgc/0ArUeVMG1jbbGvpst+REFtKwILvRTQ=="],
+
+    "@cloudflare/vitest-pool-workers/@vitest/runner": ["@vitest/runner@4.1.0", "", { "dependencies": { "@vitest/utils": "4.1.0", "pathe": "2.0.3" } }, "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ=="],
+
+    "@cloudflare/vitest-pool-workers/@vitest/snapshot": ["@vitest/snapshot@4.1.0", "", { "dependencies": { "@vitest/pretty-format": "4.1.0", "@vitest/utils": "4.1.0", "magic-string": "0.30.21", "pathe": "2.0.3" } }, "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg=="],
 
     "@cloudflare/vitest-pool-workers/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
@@ -3880,6 +3894,14 @@
     "@vitejs/plugin-vue/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.2", "", {}, "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw=="],
 
     "@vitejs/plugin-vue-jsx/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.10", "", {}, "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg=="],
+
+    "@vitest/expect/@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
+
+    "@vitest/runner/@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
+
+    "@vitest/snapshot/@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
+
+    "@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@4.1.0", "", { "dependencies": { "tinyrainbow": "3.1.0" } }, "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A=="],
 
     "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
@@ -4113,6 +4135,8 @@
 
     "vite-plugin-checker/npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "4.0.0", "unicorn-magic": "0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
 
+    "vitest/@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
+
     "vitest/tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
     "vscode-json-languageservice/jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
@@ -4150,6 +4174,8 @@
     "@cloudflare/unenv-preset/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260310.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-sxv4CxnN4ZR0uQGTFVGa0V4KTqwdej/czpIc5tYS86G8FQQoGIBiAIs2VvU7b8EROPcandxYHDBPTb+D9HIMPw=="],
 
     "@cloudflare/unenv-preset/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260310.1", "", { "os": "win32", "cpu": "x64" }, "sha512-+1ZTViWKJypLfgH/luAHCqkent0DEBjAjvO40iAhOMHRLYP/SPphLvr4Jpi6lb+sIocS8Q1QZL4uM5Etg1Wskg=="],
+
+    "@cloudflare/vitest-pool-workers/@vitest/snapshot/@vitest/pretty-format": ["@vitest/pretty-format@4.1.0", "", { "dependencies": { "tinyrainbow": "3.1.0" } }, "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A=="],
 
     "@cloudflare/vitest-pool-workers/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@aura-stack/auth-root",
       "devDependencies": {
         "@types/node": "catalog:node",
-        "@vitest/coverage-v8": "^4.0.14",
+        "@vitest/coverage-v8": "catalog:vitest",
         "eslint": "^9.35.0",
         "oxfmt": "^0.41.0",
         "oxlint": "^1.56.0",
@@ -493,6 +493,7 @@
       "vite": "^7.1.7",
     },
     "vitest": {
+      "@vitest/coverage-v8": "4.1.4",
       "vitest": "4.1.4",
     },
     "zod-v3": {
@@ -1675,7 +1676,7 @@
 
     "@vitejs/plugin-vue-jsx": ["@vitejs/plugin-vue-jsx@5.1.5", "", { "dependencies": { "@babel/core": "7.29.0", "@babel/plugin-syntax-typescript": "7.28.6", "@babel/plugin-transform-typescript": "7.28.6", "@rolldown/pluginutils": "1.0.0-rc.10", "@vue/babel-plugin-jsx": "2.0.1" }, "peerDependencies": { "vite": "7.3.1", "vue": "3.5.30" } }, "sha512-jIAsvHOEtWpslLOI2MeElGFxH7M8pM83BU/Tor4RLyiwH0FM4nUW3xdvbw20EeU9wc5IspQwMq225K3CMnJEpA=="],
 
-    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.0", "", { "dependencies": { "@bcoe/v8-coverage": "1.0.2", "@vitest/utils": "4.1.0", "ast-v8-to-istanbul": "1.0.0", "istanbul-lib-coverage": "3.2.2", "istanbul-lib-report": "3.0.1", "istanbul-reports": "3.2.0", "magicast": "0.5.2", "obug": "2.1.1", "std-env": "4.0.0", "tinyrainbow": "3.1.0" }, "peerDependencies": { "vitest": "4.1.0" } }, "sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ=="],
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.4", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.4", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.4", "vitest": "4.1.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w=="],
 
     "@vitest/expect": ["@vitest/expect@4.1.4", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww=="],
 
@@ -1689,7 +1690,7 @@
 
     "@vitest/spy": ["@vitest/spy@4.1.4", "", {}, "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.0", "", { "dependencies": { "@vitest/pretty-format": "4.1.0", "convert-source-map": "2.0.0", "tinyrainbow": "3.1.0" } }, "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw=="],
+    "@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
 
     "@volar/kit": ["@volar/kit@2.4.28", "", { "dependencies": { "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "typesafe-path": "0.2.2", "vscode-languageserver-textdocument": "1.0.12", "vscode-uri": "3.1.0" }, "peerDependencies": { "typescript": "5.9.3" } }, "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg=="],
 
@@ -3895,14 +3896,6 @@
 
     "@vitejs/plugin-vue-jsx/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.10", "", {}, "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg=="],
 
-    "@vitest/expect/@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
-
-    "@vitest/runner/@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
-
-    "@vitest/snapshot/@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
-
-    "@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@4.1.0", "", { "dependencies": { "tinyrainbow": "3.1.0" } }, "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A=="],
-
     "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "@vue/compiler-core/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
@@ -4135,8 +4128,6 @@
 
     "vite-plugin-checker/npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "4.0.0", "unicorn-magic": "0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
 
-    "vitest/@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
-
     "vitest/tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
     "vscode-json-languageservice/jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
@@ -4175,7 +4166,11 @@
 
     "@cloudflare/unenv-preset/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260310.1", "", { "os": "win32", "cpu": "x64" }, "sha512-+1ZTViWKJypLfgH/luAHCqkent0DEBjAjvO40iAhOMHRLYP/SPphLvr4Jpi6lb+sIocS8Q1QZL4uM5Etg1Wskg=="],
 
+    "@cloudflare/vitest-pool-workers/@vitest/runner/@vitest/utils": ["@vitest/utils@4.1.0", "", { "dependencies": { "@vitest/pretty-format": "4.1.0", "convert-source-map": "2.0.0", "tinyrainbow": "3.1.0" } }, "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw=="],
+
     "@cloudflare/vitest-pool-workers/@vitest/snapshot/@vitest/pretty-format": ["@vitest/pretty-format@4.1.0", "", { "dependencies": { "tinyrainbow": "3.1.0" } }, "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A=="],
+
+    "@cloudflare/vitest-pool-workers/@vitest/snapshot/@vitest/utils": ["@vitest/utils@4.1.0", "", { "dependencies": { "@vitest/pretty-format": "4.1.0", "convert-source-map": "2.0.0", "tinyrainbow": "3.1.0" } }, "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw=="],
 
     "@cloudflare/vitest-pool-workers/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
@@ -4532,6 +4527,8 @@
     "@astrojs/node/send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "@aura-stack/express/express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "@cloudflare/vitest-pool-workers/@vitest/runner/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@4.1.0", "", { "dependencies": { "tinyrainbow": "3.1.0" } }, "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A=="],
 
     "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260310.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-hF2VpoWaMb1fiGCQJqCY6M8I+2QQqjkyY4LiDYdTL5D/w6C1l5v1zhc0/jrjdD1DXfpJtpcSMSmEPjHse4p9Ig=="],
 

--- a/deno.lock
+++ b/deno.lock
@@ -17,7 +17,6 @@
     "npm:@testing-library/dom@^10.4.1": "10.4.1",
     "npm:@testing-library/react@^16.3.2": "16.3.2_@testing-library+dom@10.4.1_react@19.2.4_react-dom@19.2.4__react@19.2.4",
     "npm:@types/supertest@^6.0.3": "6.0.3",
-    "npm:@vitest/coverage-v8@^4.0.14": "4.1.0_vitest@4.1.0__vite@8.0.0",
     "npm:elysia@^1.2.22": "1.4.28_@sinclair+typebox@0.34.49_exact-mirror@0.2.7__@sinclair+typebox@0.34.49_file-type@21.3.4_openapi-types@12.1.3",
     "npm:eslint@^9.35.0": "9.39.4",
     "npm:hono@4": "4.12.1",
@@ -105,54 +104,21 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dependencies": [
         "@babel/helper-validator-identifier",
-        "js-tokens@4.0.0",
+        "js-tokens",
         "picocolors"
       ]
-    },
-    "@babel/helper-string-parser@7.27.1": {
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="
     },
     "@babel/helper-validator-identifier@7.28.5": {
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="
     },
-    "@babel/parser@7.29.2": {
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dependencies": [
-        "@babel/types"
-      ],
-      "bin": true
-    },
     "@babel/runtime@7.28.6": {
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="
-    },
-    "@babel/types@7.29.0": {
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dependencies": [
-        "@babel/helper-string-parser",
-        "@babel/helper-validator-identifier"
-      ]
-    },
-    "@bcoe/v8-coverage@1.0.2": {
-      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="
     },
     "@borewit/text-codec@0.2.2": {
       "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="
     },
-    "@emnapi/core@1.9.0": {
-      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
-      "dependencies": [
-        "@emnapi/wasi-threads",
-        "tslib"
-      ]
-    },
     "@emnapi/runtime@1.9.0": {
       "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
-      "dependencies": [
-        "tslib"
-      ]
-    },
-    "@emnapi/wasi-threads@1.2.0": {
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
       "dependencies": [
         "tslib"
       ]
@@ -541,14 +507,6 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@napi-rs/wasm-runtime@1.1.1": {
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
-      "dependencies": [
-        "@emnapi/core",
-        "@emnapi/runtime",
-        "@tybys/wasm-util"
-      ]
-    },
     "@next/env@16.2.3": {
       "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA=="
     },
@@ -594,12 +552,6 @@
     },
     "@noble/hashes@1.8.0": {
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="
-    },
-    "@oxc-project/runtime@0.115.0": {
-      "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ=="
-    },
-    "@oxc-project/types@0.115.0": {
-      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw=="
     },
     "@oxfmt/binding-android-arm-eabi@0.41.0": {
       "integrity": "sha512-REfrqeMKGkfMP+m/ScX4f5jJBSmVNYcpoDF8vP8f8eYPDuPGZmzp56NIUsYmx3h7f6NzC6cE3gqh8GDWrJHCKw==",
@@ -797,86 +749,6 @@
         "@noble/hashes"
       ]
     },
-    "@rolldown/binding-android-arm64@1.0.0-rc.9": {
-      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
-      "os": ["android"],
-      "cpu": ["arm64"]
-    },
-    "@rolldown/binding-darwin-arm64@1.0.0-rc.9": {
-      "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
-      "os": ["darwin"],
-      "cpu": ["arm64"]
-    },
-    "@rolldown/binding-darwin-x64@1.0.0-rc.9": {
-      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
-      "os": ["darwin"],
-      "cpu": ["x64"]
-    },
-    "@rolldown/binding-freebsd-x64@1.0.0-rc.9": {
-      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
-      "os": ["freebsd"],
-      "cpu": ["x64"]
-    },
-    "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9": {
-      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
-      "os": ["linux"],
-      "cpu": ["arm"]
-    },
-    "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9": {
-      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@rolldown/binding-linux-arm64-musl@1.0.0-rc.9": {
-      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9": {
-      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
-      "os": ["linux"],
-      "cpu": ["ppc64"]
-    },
-    "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9": {
-      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
-      "os": ["linux"],
-      "cpu": ["s390x"]
-    },
-    "@rolldown/binding-linux-x64-gnu@1.0.0-rc.9": {
-      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@rolldown/binding-linux-x64-musl@1.0.0-rc.9": {
-      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@rolldown/binding-openharmony-arm64@1.0.0-rc.9": {
-      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
-      "os": ["openharmony"],
-      "cpu": ["arm64"]
-    },
-    "@rolldown/binding-wasm32-wasi@1.0.0-rc.9": {
-      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
-      "dependencies": [
-        "@napi-rs/wasm-runtime"
-      ],
-      "cpu": ["wasm32"]
-    },
-    "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9": {
-      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
-      "os": ["win32"],
-      "cpu": ["arm64"]
-    },
-    "@rolldown/binding-win32-x64-msvc@1.0.0-rc.9": {
-      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
-      "os": ["win32"],
-      "cpu": ["x64"]
-    },
-    "@rolldown/pluginutils@1.0.0-rc.9": {
-      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw=="
-    },
     "@rollup/rollup-android-arm-eabi@4.59.0": {
       "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "os": ["android"],
@@ -1005,9 +877,6 @@
     "@sinclair/typebox@0.34.49": {
       "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="
     },
-    "@standard-schema/spec@1.1.0": {
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
-    },
     "@swc/helpers@0.5.15": {
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "dependencies": [
@@ -1076,27 +945,11 @@
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "@tybys/wasm-util@0.10.1": {
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dependencies": [
-        "tslib"
-      ]
-    },
     "@types/aria-query@5.0.4": {
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
     },
-    "@types/chai@5.2.3": {
-      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-      "dependencies": [
-        "@types/deep-eql",
-        "assertion-error"
-      ]
-    },
     "@types/cookiejar@2.1.5": {
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q=="
-    },
-    "@types/deep-eql@4.0.2": {
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="
     },
     "@types/estree@1.0.8": {
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
@@ -1134,78 +987,6 @@
       "dependencies": [
         "@types/methods",
         "@types/superagent"
-      ]
-    },
-    "@vitest/coverage-v8@4.1.0_vitest@4.1.0__vite@8.0.0": {
-      "integrity": "sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==",
-      "dependencies": [
-        "@bcoe/v8-coverage",
-        "@vitest/utils",
-        "ast-v8-to-istanbul",
-        "istanbul-lib-coverage",
-        "istanbul-lib-report",
-        "istanbul-reports",
-        "magicast",
-        "obug",
-        "std-env",
-        "tinyrainbow",
-        "vitest"
-      ]
-    },
-    "@vitest/expect@4.1.0": {
-      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
-      "dependencies": [
-        "@standard-schema/spec",
-        "@types/chai",
-        "@vitest/spy",
-        "@vitest/utils",
-        "chai",
-        "tinyrainbow"
-      ]
-    },
-    "@vitest/mocker@4.1.0_vite@8.0.0": {
-      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
-      "dependencies": [
-        "@vitest/spy",
-        "estree-walker",
-        "magic-string",
-        "vite"
-      ],
-      "optionalPeers": [
-        "vite"
-      ]
-    },
-    "@vitest/pretty-format@4.1.0": {
-      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
-      "dependencies": [
-        "tinyrainbow"
-      ]
-    },
-    "@vitest/runner@4.1.0": {
-      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
-      "dependencies": [
-        "@vitest/utils",
-        "pathe"
-      ]
-    },
-    "@vitest/snapshot@4.1.0": {
-      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
-      "dependencies": [
-        "@vitest/pretty-format",
-        "@vitest/utils",
-        "magic-string",
-        "pathe"
-      ]
-    },
-    "@vitest/spy@4.1.0": {
-      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw=="
-    },
-    "@vitest/utils@4.1.0": {
-      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
-      "dependencies": [
-        "@vitest/pretty-format",
-        "convert-source-map",
-        "tinyrainbow"
       ]
     },
     "abort-controller@3.0.0": {
@@ -1269,17 +1050,6 @@
     "asap@2.0.6": {
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
-    "assertion-error@2.0.1": {
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="
-    },
-    "ast-v8-to-istanbul@1.0.0": {
-      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
-      "dependencies": [
-        "@jridgewell/trace-mapping",
-        "estree-walker",
-        "js-tokens@10.0.0"
-      ]
-    },
     "asynckit@0.4.0": {
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
@@ -1337,9 +1107,6 @@
     "caniuse-lite@1.0.30001772": {
       "integrity": "sha512-mIwLZICj+ntVTw4BT2zfp+yu/AqV6GMKfJVJMx3MwPxs+uk/uj2GLl2dH8LQbjiLDX66amCga5nKFyDgRR43kg=="
     },
-    "chai@6.2.2": {
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="
-    },
     "chalk@4.1.2": {
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dependencies": [
@@ -1391,9 +1158,6 @@
     },
     "consola@3.4.2": {
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="
-    },
-    "convert-source-map@2.0.0": {
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "cookie-signature@1.2.2": {
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
@@ -1468,9 +1232,6 @@
     },
     "es-errors@1.3.0": {
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-    },
-    "es-module-lexer@2.0.0": {
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="
     },
     "es-object-atoms@1.1.1": {
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
@@ -1599,12 +1360,6 @@
     "estraverse@5.3.0": {
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
     },
-    "estree-walker@3.0.3": {
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dependencies": [
-        "@types/estree"
-      ]
-    },
     "esutils@2.0.3": {
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
@@ -1619,9 +1374,6 @@
       "optionalPeers": [
         "@sinclair/typebox"
       ]
-    },
-    "expect-type@1.3.0": {
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="
     },
     "fast-decode-uri-component@1.0.1": {
       "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
@@ -1791,9 +1543,6 @@
     "hono@4.12.1": {
       "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw=="
     },
-    "html-escaper@2.0.2": {
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
-    },
     "https-proxy-agent@7.0.6": {
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dependencies": [
@@ -1838,32 +1587,11 @@
     "isexe@2.0.0": {
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "istanbul-lib-coverage@3.2.2": {
-      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="
-    },
-    "istanbul-lib-report@3.0.1": {
-      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dependencies": [
-        "istanbul-lib-coverage",
-        "make-dir",
-        "supports-color"
-      ]
-    },
-    "istanbul-reports@3.2.0": {
-      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dependencies": [
-        "html-escaper",
-        "istanbul-lib-report"
-      ]
-    },
     "jose@6.2.1": {
       "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="
     },
     "joycon@3.1.1": {
       "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="
-    },
-    "js-tokens@10.0.0": {
-      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="
     },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
@@ -1897,80 +1625,6 @@
         "type-check"
       ]
     },
-    "lightningcss-android-arm64@1.32.0": {
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "os": ["android"],
-      "cpu": ["arm64"]
-    },
-    "lightningcss-darwin-arm64@1.32.0": {
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "os": ["darwin"],
-      "cpu": ["arm64"]
-    },
-    "lightningcss-darwin-x64@1.32.0": {
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "os": ["darwin"],
-      "cpu": ["x64"]
-    },
-    "lightningcss-freebsd-x64@1.32.0": {
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "os": ["freebsd"],
-      "cpu": ["x64"]
-    },
-    "lightningcss-linux-arm-gnueabihf@1.32.0": {
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "os": ["linux"],
-      "cpu": ["arm"]
-    },
-    "lightningcss-linux-arm64-gnu@1.32.0": {
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "lightningcss-linux-arm64-musl@1.32.0": {
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "lightningcss-linux-x64-gnu@1.32.0": {
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "lightningcss-linux-x64-musl@1.32.0": {
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "lightningcss-win32-arm64-msvc@1.32.0": {
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "os": ["win32"],
-      "cpu": ["arm64"]
-    },
-    "lightningcss-win32-x64-msvc@1.32.0": {
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "os": ["win32"],
-      "cpu": ["x64"]
-    },
-    "lightningcss@1.32.0": {
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dependencies": [
-        "detect-libc"
-      ],
-      "optionalDependencies": [
-        "lightningcss-android-arm64",
-        "lightningcss-darwin-arm64",
-        "lightningcss-darwin-x64",
-        "lightningcss-freebsd-x64",
-        "lightningcss-linux-arm-gnueabihf",
-        "lightningcss-linux-arm64-gnu",
-        "lightningcss-linux-arm64-musl",
-        "lightningcss-linux-x64-gnu",
-        "lightningcss-linux-x64-musl",
-        "lightningcss-win32-arm64-msvc",
-        "lightningcss-win32-x64-msvc"
-      ]
-    },
     "lilconfig@3.1.3": {
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="
     },
@@ -1997,20 +1651,6 @@
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dependencies": [
         "@jridgewell/sourcemap-codec"
-      ]
-    },
-    "magicast@0.5.2": {
-      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-      "dependencies": [
-        "@babel/parser",
-        "@babel/types",
-        "source-map-js"
-      ]
-    },
-    "make-dir@4.0.0": {
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dependencies": [
-        "semver"
       ]
     },
     "math-intrinsics@1.1.0": {
@@ -2084,7 +1724,7 @@
         "@swc/helpers",
         "baseline-browser-mapping",
         "caniuse-lite",
-        "postcss@8.4.31",
+        "postcss",
         "react",
         "react-dom",
         "styled-jsx"
@@ -2128,9 +1768,6 @@
     },
     "object-inspect@1.13.4": {
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
-    },
-    "obug@2.1.1": {
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="
     },
     "once@1.4.0": {
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
@@ -2286,14 +1923,6 @@
         "source-map-js"
       ]
     },
-    "postcss@8.5.8": {
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dependencies": [
-        "nanoid",
-        "picocolors",
-        "source-map-js"
-      ]
-    },
     "prelude-ls@1.2.1": {
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
@@ -2341,31 +1970,6 @@
     },
     "resolve-from@5.0.0": {
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
-    },
-    "rolldown@1.0.0-rc.9": {
-      "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
-      "dependencies": [
-        "@oxc-project/types",
-        "@rolldown/pluginutils"
-      ],
-      "optionalDependencies": [
-        "@rolldown/binding-android-arm64",
-        "@rolldown/binding-darwin-arm64",
-        "@rolldown/binding-darwin-x64",
-        "@rolldown/binding-freebsd-x64",
-        "@rolldown/binding-linux-arm-gnueabihf",
-        "@rolldown/binding-linux-arm64-gnu",
-        "@rolldown/binding-linux-arm64-musl",
-        "@rolldown/binding-linux-ppc64-gnu",
-        "@rolldown/binding-linux-s390x-gnu",
-        "@rolldown/binding-linux-x64-gnu",
-        "@rolldown/binding-linux-x64-musl",
-        "@rolldown/binding-openharmony-arm64",
-        "@rolldown/binding-wasm32-wasi",
-        "@rolldown/binding-win32-arm64-msvc",
-        "@rolldown/binding-win32-x64-msvc"
-      ],
-      "bin": true
     },
     "rollup@4.59.0": {
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
@@ -2489,9 +2093,6 @@
         "side-channel-weakmap"
       ]
     },
-    "siginfo@2.0.0": {
-      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="
-    },
     "signal-exit@4.1.0": {
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
     },
@@ -2500,12 +2101,6 @@
     },
     "source-map@0.7.6": {
       "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="
-    },
-    "stackback@0.0.2": {
-      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
-    },
-    "std-env@4.0.0": {
-      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="
     },
     "strip-json-comments@3.1.1": {
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
@@ -2597,14 +2192,8 @@
         "any-promise"
       ]
     },
-    "tinybench@2.9.0": {
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="
-    },
     "tinyexec@0.3.2": {
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="
-    },
-    "tinyexec@1.0.4": {
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="
     },
     "tinyglobby@0.2.15_picomatch@4.0.3": {
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
@@ -2615,9 +2204,6 @@
     },
     "tinypool@2.1.0": {
       "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="
-    },
-    "tinyrainbow@3.1.0": {
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="
     },
     "token-types@6.1.2": {
       "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
@@ -2657,7 +2243,7 @@
         "rollup",
         "source-map",
         "sucrase",
-        "tinyexec@0.3.2",
+        "tinyexec",
         "tinyglobby",
         "tree-kill"
       ],
@@ -2696,47 +2282,6 @@
         "punycode"
       ]
     },
-    "vite@8.0.0": {
-      "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
-      "dependencies": [
-        "@oxc-project/runtime",
-        "lightningcss",
-        "picomatch",
-        "postcss@8.5.8",
-        "rolldown",
-        "tinyglobby"
-      ],
-      "optionalDependencies": [
-        "fsevents"
-      ],
-      "bin": true
-    },
-    "vitest@4.1.0_vite@8.0.0": {
-      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
-      "dependencies": [
-        "@vitest/expect",
-        "@vitest/mocker",
-        "@vitest/pretty-format",
-        "@vitest/runner",
-        "@vitest/snapshot",
-        "@vitest/spy",
-        "@vitest/utils",
-        "es-module-lexer",
-        "expect-type",
-        "magic-string",
-        "obug",
-        "pathe",
-        "picomatch",
-        "std-env",
-        "tinybench",
-        "tinyexec@1.0.4",
-        "tinyglobby",
-        "tinyrainbow",
-        "vite",
-        "why-is-node-running"
-      ],
-      "bin": true
-    },
     "web-streams-polyfill@3.3.3": {
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
     },
@@ -2757,14 +2302,6 @@
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dependencies": [
         "isexe"
-      ],
-      "bin": true
-    },
-    "why-is-node-running@2.3.0": {
-      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-      "dependencies": [
-        "siginfo",
-        "stackback"
       ],
       "bin": true
     },
@@ -2793,7 +2330,6 @@
   "workspace": {
     "packageJson": {
       "dependencies": [
-        "npm:@vitest/coverage-v8@^4.0.14",
         "npm:eslint@^9.35.0",
         "npm:oxfmt@0.41",
         "npm:oxlint@^1.56.0",

--- a/deno.lock
+++ b/deno.lock
@@ -31,7 +31,6 @@
     "npm:supertest@^7.2.2": "7.2.2",
     "npm:tsup@^8.5.1": "8.5.1_esbuild@0.27.4",
     "npm:turbo@^2.7.5": "2.8.18",
-    "npm:vitest@^4.1.0": "4.1.0_vite@8.0.0",
     "npm:zod@4.3.5": "4.3.5"
   },
   "jsr": {
@@ -2799,8 +2798,7 @@
         "npm:oxfmt@0.41",
         "npm:oxlint@^1.56.0",
         "npm:tsup@^8.5.1",
-        "npm:turbo@^2.7.5",
-        "npm:vitest@^4.1.0"
+        "npm:turbo@^2.7.5"
       ],
       "overrides": {
         "dompurify": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "catalog:node",
-    "@vitest/coverage-v8": "^4.0.14",
+    "@vitest/coverage-v8": "catalog:vitest",
     "eslint": "^9.35.0",
     "oxfmt": "^0.41.0",
     "oxlint": "^1.56.0",
@@ -104,7 +104,8 @@
         "react-router": "7.12.0"
       },
       "vitest": {
-        "vitest": "4.1.4"
+        "vitest": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "tsup": "^8.5.1",
     "turbo": "^2.7.5",
     "typescript": "catalog:typescript",
-    "vitest": "^4.1.0"
+    "vitest": "catalog:vitest"
   },
   "packageManager": "pnpm@10.15.0",
   "workspaces": {
@@ -102,6 +102,9 @@
       },
       "react-router": {
         "react-router": "7.12.0"
+      },
+      "vitest": {
+        "vitest": "4.1.4"
       }
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -92,6 +92,7 @@
   "devDependencies": {
     "@aura-stack/tsconfig": "workspace:*",
     "@aura-stack/tsup-config": "workspace:*",
-    "typescript": "catalog:typescript"
+    "typescript": "catalog:typescript",
+    "vitest": "catalog:vitest"
   }
 }

--- a/packages/core/src/@types/config.ts
+++ b/packages/core/src/@types/config.ts
@@ -193,6 +193,7 @@ export type CookieStrategyAttributes = StandardCookie | SecureCookie | HostCooki
  */
 export type CookieName = "sessionToken" | "csrfToken" | "state" | "codeVerifier" | "redirectTo" | "redirectURI"
 
+/** Resolved cookie names and serialization attributes for each logical auth cookie. */
 export type CookieStoreConfig = Record<CookieName, { name: string; attributes: CookieStrategyAttributes }>
 
 export interface CookieConfig {
@@ -242,20 +243,32 @@ export interface Logger {
     log?: (args: SyslogOptions) => void
 }
 
+/**
+ * Programmatic auth API returned with the auth instance: `getSession`, `signIn`, `signInCredentials`, `signOut`, `updateSession`.
+ * Each method returns a result object plus `headers` and `toResponse()` for HTTP responses.
+ */
 export type AuthAPI<DefaultUser extends User = User> = ReturnType<typeof createAuthAPI<DefaultUser>>
+
+/** JWT and crypto helpers bound to the configured identity schema (sign, verify, claims). */
 export type JoseInstance<DefaultUser extends User = User> = ReturnType<typeof createJoseInstance<DefaultUser>>
 
+/** Normalized internal logger with resolved level and structured log function. */
 export interface InternalLogger {
     level: LogLevel
     log: typeof createLogEntry
 }
 
+/**
+ * Identity validation settings used when building session strategy and OAuth profile mapping.
+ * Controls the Zod schema and how unknown keys are handled on user objects.
+ */
 export interface IdentityConfig<Schema extends ZodObject<any> = typeof UserIdentity> {
     schema?: Schema
     skipValidation?: boolean
     unknownKeys?: "passthrough" | "strict" | "strip"
 }
 
+/** Payload sent to the credentials sign-in endpoint (username/password flow). */
 export interface CredentialsPayload {
     username: string
     password: string
@@ -295,6 +308,10 @@ export interface CredentialsProvider<Identity extends EditableShape<UserShape> =
     ) => Promise<ShapeToObject<Identity> | null> | ShapeToObject<Identity> | null
 }
 
+/**
+ * Runtime context passed into auth actions and API handlers: OAuth map, cookies, JWT, session strategy, trusted origins, etc.
+ * This is the fully resolved configuration surface after `createAuth` initializes defaults.
+ */
 export interface RouterGlobalContext<DefaultUser extends User = User> {
     oauth: OAuthProviderRecord
     credentials?: CredentialsProvider<any>
@@ -320,6 +337,9 @@ export interface RouterGlobalContext<DefaultUser extends User = User> {
  */
 export type AuthRuntimeConfig<DefaultUser extends User = User> = RouterGlobalContext<DefaultUser>
 
+/**
+ * Public auth instance: programmatic {@link AuthAPI}, {@link JoseInstance}, and HTTP {@link AuthClient} handlers.
+ */
 export interface AuthInstance<DefaultUser extends User = User> {
     api: AuthAPI<DefaultUser>
     jose: JoseInstance<DefaultUser>
@@ -331,6 +351,9 @@ export interface AuthInstance<DefaultUser extends User = User> {
     }
 }
 
+/**
+ * Extended context used inside the library with both secure and standard cookie materializations.
+ */
 export type InternalContext<Identity extends EditableShape<UserShape>> = RouterGlobalContext<ShapeToObject<Identity> & User> & {
     cookieConfig: {
         secure: CookieStoreConfig

--- a/packages/core/src/@types/errors.ts
+++ b/packages/core/src/@types/errors.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4"
 import { OAuthAccessTokenErrorResponse, OAuthAuthorizationErrorResponse } from "@/schemas.ts"
 
+/** Map of field or logical keys to API validation error payloads (code + message). */
 export type APIErrorMap = Record<string, { code: string; message: string }>
 
 /**
@@ -29,8 +30,13 @@ export type AccessTokenError = OAuthError<z.infer<typeof OAuthAccessTokenErrorRe
  */
 export type TokenRevocationError = OAuthError<"invalid_session_token">
 
+/** Union of all OAuth-related `error` string values exposed by this package. */
 export type ErrorType = AuthorizationError["error"] | AccessTokenError["error"] | TokenRevocationError["error"]
 
+/**
+ * Machine-readable codes for internal auth failures (configuration, crypto, environment, etc.).
+ * Used with {@link AuthInternalError} and logging.
+ */
 export type AuthInternalErrorCode =
     | "INVALID_OAUTH_CONFIGURATION"
     | "INVALID_JWT_TOKEN"
@@ -48,6 +54,9 @@ export type AuthInternalErrorCode =
     | "CREDENTIALS_PROVIDER_NOT_CONFIGURED"
     | "IDENTITY_VALIDATION_FAILED"
 
+/**
+ * Machine-readable codes for security-sensitive failures (CSRF, session, open redirect, OAuth state).
+ */
 export type AuthSecurityErrorCode =
     | "INVALID_STATE"
     | "MISMATCHING_STATE"

--- a/packages/core/src/@types/index.ts
+++ b/packages/core/src/@types/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Public type entry for `@aura-stack/auth` and `@aura-stack/auth/types`: configuration, session, OAuth, API results, and utilities.
+ */
 import { z } from "zod/v4"
 import { OAuthEnvSchema } from "@/schemas.ts"
 import type { JWTPayload } from "@/jose.ts"
@@ -25,10 +28,18 @@ export type JWTStandardClaims = Pick<JWTPayload, "exp" | "iat" | "jti" | "nbf" |
  */
 export type JWTPayloadWithToken = JWTPayload & { token: string }
 
+/** Environment variables for OAuth client credentials, inferred from `OAuthEnvSchema`. */
 export type OAuthEnv = z.infer<typeof OAuthEnvSchema>
 
+/**
+ * HTTP route handlers exposed by the auth instance (`GET`, `POST`, `PATCH`, `ALL`) for mounting on your app router.
+ */
 export type AuthClient = ReturnType<typeof createAuthInstance>["handlers"]
 
+/**
+ * Options for {@link createAuthClient} (browser HTTP client). Extends the router client with an optional `baseURL`
+ * when the client runs outside the browser (e.g. server-side fetch to your app origin).
+ */
 export type AuthClientOptions = Prettify<
     Omit<ClientOptions, "baseURL"> & {
         baseURL?: string

--- a/packages/core/src/@types/oauth.ts
+++ b/packages/core/src/@types/oauth.ts
@@ -4,10 +4,12 @@ import type { BuiltInOAuthProvider } from "@/oauth/index.ts"
 
 export type { BuiltInOAuthProvider } from "@/oauth/index.ts"
 
+/** Known query parameter names supported when building an OAuth authorization URL. */
 export type AuthorizeParams = LiteralUnion<
     "clientId" | "prompt" | "scope" | "responseMode" | "audience" | "loginHint" | "nonce" | "display"
 >
 
+/** OAuth 2.0 `response_type` values used in authorization requests. */
 export type ResponseType = LiteralUnion<"code" | "token" | "refresh_token" | "id_token">
 
 /**
@@ -74,6 +76,10 @@ export type OAuthProvider<
     DefaultUser extends User = User,
 > = OAuthProviderCredentials<Profile, DefaultUser>
 
+/**
+ * Lookup table of configured OAuth providers keyed by built-in id or custom id.
+ * Values are full credential configs used at runtime for authorize/token/userinfo.
+ */
 export type OAuthProviderRecord<DefaultUser extends User = User> = Record<
     LiteralUnion<BuiltInOAuthProvider>,
     OAuthProviderCredentials<any, DefaultUser>

--- a/packages/core/src/@types/router.d.ts
+++ b/packages/core/src/@types/router.d.ts
@@ -1,3 +1,6 @@
+/**
+ * Augments `@aura-stack/router` so route `GlobalContext` matches Aura Auth’s {@link RouterGlobalContext}.
+ */
 import type { GlobalContext } from "@aura-stack/router"
 import type { RouterGlobalContext } from "./index.ts"
 

--- a/packages/core/src/@types/session.ts
+++ b/packages/core/src/@types/session.ts
@@ -1,4 +1,4 @@
-import { EditableShape, Prettify, ShapeToObject } from "./utility.ts"
+import { DeepPartial, EditableShape, Prettify, ShapeToObject } from "./utility.ts"
 import type { TypedJWTPayload } from "@aura-stack/jose"
 import type { UserIdentityType, UserShape } from "@/shared/identity.ts"
 import type {
@@ -165,8 +165,9 @@ export type StatelessStrategyConfig = {
  */
 export type SessionConfig = StatelessStrategyConfig
 
-export type DeepPartial<T> = {
-    [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P]
+export interface GetStatelessSessionReturn<DefaultUser extends User = User> {
+    session: Session<DefaultUser> | null
+    headers: Headers
 }
 
 /**
@@ -177,7 +178,7 @@ export interface SessionStrategy<DefaultUser extends User = User> {
      * Read and validate the session from an incoming request.
      * Returns null if absent, invalid, or expired. Never throws on auth failure.
      */
-    getSession(request: Headers): Promise<GetSessionReturn<DefaultUser>>
+    getSession(request: Headers): Promise<GetStatelessSessionReturn<DefaultUser>>
 
     /**
      * Create a session after successful authentication.
@@ -234,32 +235,24 @@ export type JWTManager<DefaultUser extends User = User> = {
 }
 
 // #region API Types
+export type AuthActionReturn =
+    | {
+          ok: true
+          headers: Headers
+          redirectURL?: string
+          toResponse: () => Response
+      }
+    | {
+          ok: false
+          headers: Headers
+          toResponse: () => Response
+      }
+
 export type FunctionAPIContext<Options extends object> = Prettify<
     {
         ctx: RouterGlobalContext
     } & Options
 >
-
-export interface SignInOptions {
-    redirect?: boolean
-    redirectTo?: string
-}
-
-export interface SignInAPIOptions<Redirect extends boolean = boolean> {
-    headers?: HeadersInit
-    redirect?: Redirect
-    redirectTo?: string
-    request?: Request
-}
-
-export type SignInReturn<Redirect extends boolean = boolean> = Redirect extends true
-    ? Response
-    : { redirect: false; signInURL: string }
-
-export interface GetSessionReturn<DefaultUser extends User = User> {
-    session: Session<DefaultUser> | null
-    headers: Headers
-}
 
 export interface GetSessionOptions {
     headers: HeadersInit
@@ -267,9 +260,47 @@ export interface GetSessionOptions {
 
 export type GetSessionAPIOptions = GetSessionOptions
 
-export type SessionResponse<DefaultUser extends User = User> =
-    | { session: Session<DefaultUser>; headers: Headers; authenticated: true }
-    | { session: null; headers: Headers; authenticated: false }
+export type SessionReturn<DefaultUser extends User = User> =
+    | { success: true; session: Session<DefaultUser>; headers: Headers; toResponse: () => Response }
+    | { success: false; session: null; headers: Headers; toResponse: () => Response }
+
+export interface SignInOptions {
+    redirect?: boolean
+    redirectTo?: string
+}
+
+export interface SignInAPIOptions<Redirect extends boolean = boolean> {
+    request?: Request
+    headers?: HeadersInit
+    redirect?: Redirect
+    redirectTo?: string
+}
+
+export interface SignInReturn<Redirect extends boolean = boolean> {
+    redirect: Redirect
+    success: boolean
+    signInURL: string
+    toResponse: () => Response
+}
+
+export type SignInCredentialsOptions = FunctionAPIContext<{
+    payload: CredentialsPayload
+    request?: Request
+    headers?: HeadersInit
+    redirectTo?: string
+}>
+
+export interface SignInCredentialsAPIOptions {
+    payload: CredentialsPayload
+    request?: Request
+    headers?: HeadersInit
+    redirect?: boolean
+    redirectTo?: string
+}
+
+export type SignInCredentialsReturn =
+    | { success: true; headers: Headers; redirectURL: string }
+    | { success: false; headers: Headers; redirectURL?: null }
 
 export interface SignOutOptions {
     redirect?: boolean
@@ -293,22 +324,3 @@ export interface UpdateSessionAPIOptions<DefaultUser extends User = User> {
 export type UpdateSessionReturn<DefaultUser extends User = User> =
     | { session: Session<DefaultUser>; headers: Headers; updated: true }
     | { session: null; headers: Headers; updated: false }
-
-export type SignInCredentialsOptions = FunctionAPIContext<{
-    payload: CredentialsPayload
-    request?: Request
-    headers?: HeadersInit
-    redirectTo?: string
-}>
-
-export interface SignInCredentialsAPIOptions {
-    payload: CredentialsPayload
-    request?: Request
-    headers?: HeadersInit
-    redirect?: boolean
-    redirectTo?: string
-}
-
-export type SignInCredentialsReturn =
-    | { success: true; headers: Headers; redirectURL: string }
-    | { success: false; headers: Headers; redirectURL?: null }

--- a/packages/core/src/@types/session.ts
+++ b/packages/core/src/@types/session.ts
@@ -285,7 +285,7 @@ export interface SignInOptions<Redirect extends boolean = boolean> {
 /** Client `signIn` return: `void` when redirecting in-browser, otherwise a small JSON result with `signInURL`. */
 export type SignInReturn<Redirect extends boolean = boolean> = Redirect extends true
     ? void
-    : { success: boolean; redirect: false; signInURL: string | null }
+    : { success: true; redirect: false; signInURL: string } | { success: false; redirect: false; signInURL: null }
 
 /** Server/programmatic OAuth sign-in: optional `Request`, headers, and redirect behavior for the HTTP handler. */
 export interface SignInAPIOptions {
@@ -340,7 +340,7 @@ export interface SignOutOptions<Redirect extends boolean = boolean> {
 /** Client `signOut` return: `void` when redirecting, otherwise JSON-like `{ success, redirectURL }`. */
 export type SignOutReturn<Redirect extends boolean = boolean> = Redirect extends true
     ? void
-    : { success: boolean; redirect: false; redirectURL: string }
+    : { success: true; redirect: false; redirectURL: string } | { success: false; redirect: false; redirectURL: null }
 
 /** Server sign-out: requires headers (cookies); optional redirect target and CSRF bypass for trusted callers. */
 export interface SignOutAPIOptions {
@@ -351,9 +351,7 @@ export interface SignOutAPIOptions {
 }
 
 /** Result of sign-out: success includes resolved `redirectURL`; failure uses `redirectURL: null`. */
-export type SignOutAPIReturn = AuthActionAPIReturn<
-    { success: true; redirectURL: string } | { success: false; redirectURL: null }
->
+export type SignOutAPIReturn = AuthActionAPIReturn<{ success: true; redirectURL: string } | { success: false; redirectURL: null }>
 
 /** Partial session update accepted by the client (`updateSession`): user fields and/or expiry. */
 export type UpdateSessionOptions<DefaultUser extends User = User> = DeepPartial<Session<DefaultUser>>

--- a/packages/core/src/@types/session.ts
+++ b/packages/core/src/@types/session.ts
@@ -1,4 +1,4 @@
-import { DeepPartial, EditableShape, Prettify, ShapeToObject } from "./utility.ts"
+import { AuthResponse, DeepPartial, EditableShape, Prettify, ShapeToObject } from "./utility.ts"
 import type { TypedJWTPayload } from "@aura-stack/jose"
 import type { UserIdentityType, UserShape } from "@/shared/identity.ts"
 import type {
@@ -234,19 +234,15 @@ export type JWTManager<DefaultUser extends User = User> = {
     verifyToken(token: string): Promise<TypedJWTPayload<DefaultUser>>
 }
 
-// #region API Types
-export type AuthActionReturn =
-    | {
-          success: true
-          headers: Headers
-          redirectURL?: string
-          toResponse: () => Response
-      }
-    | {
+// #region API/Client API Types
+
+type AuthActionAPIReturn<Body> =
+    | (Extract<Body, { success: true }> & { headers: Headers; toResponse: () => AuthResponse<Exclude<Body, { success: false }>> })
+    | (Extract<Body, { success: false }> & {
           success: false
           headers: Headers
-          toResponse: () => Response
-      }
+          toResponse: () => AuthResponse<Exclude<Body, { success: true }>>
+      })
 
 export type FunctionAPIContext<Options extends object> = Prettify<
     {
@@ -260,9 +256,9 @@ export interface GetSessionOptions {
 
 export type GetSessionAPIOptions = GetSessionOptions
 
-export type SessionReturn<DefaultUser extends User = User> =
-    | { success: true; session: Session<DefaultUser>; headers: Headers; toResponse: () => Response }
-    | { success: false; session: null; headers: Headers; toResponse: () => Response }
+export type GetSessionAPIReturn<DefaultUser extends User = User> = AuthActionAPIReturn<
+    { success: true; session: Session<DefaultUser> } | { success: false; session: null }
+>
 
 export interface SignInOptions<Redirect extends boolean = boolean> {
     redirect?: Redirect
@@ -271,21 +267,32 @@ export interface SignInOptions<Redirect extends boolean = boolean> {
 
 export type SignInReturn<Redirect extends boolean = boolean> = Redirect extends true
     ? void
-    : { success: boolean; redirect: false; signInURL: string }
+    : { success: boolean; redirect: false; signInURL: string | null }
 
-export interface SignInAPIOptions<Redirect extends boolean = boolean> {
+export interface SignInAPIOptions {
     request?: Request
     headers?: HeadersInit
-    redirect?: Redirect
+    redirect?: boolean
     redirectTo?: string
 }
 
-export interface SignInAPIReturn<Redirect extends boolean = boolean> {
-    redirect: Redirect
-    success: boolean
-    signInURL: string
-    toResponse: () => Response
-}
+export type SignInAPIReturn =
+    | {
+          success: true
+          redirect: true
+          signInURL: string
+          toResponse: () => AuthResponse<{ success: true; redirect: true; signInURL: string }>
+      }
+    | {
+          success: true
+          redirect: false
+          signInURL: string
+          toResponse: () => AuthResponse<{ success: true; redirect: false; signInURL: string }>
+      }
+
+export type SignInCredentialsReturn<Redirect extends boolean = boolean> = Redirect extends true
+    ? void
+    : { success: true; redirectURL: string } | { success: false; redirectURL: null }
 
 export interface SignInCredentialsAPIOptions {
     payload: CredentialsPayload
@@ -294,11 +301,9 @@ export interface SignInCredentialsAPIOptions {
     redirectTo?: string
 }
 
-export type SignInCredentialsReturn = { success: true; redirectURL: string } | { success: false; redirectURL: null }
-
-export type SignInCredentialsAPIReturn =
-    | { success: true; headers: Headers; redirectURL: string; toResponse: () => Response }
-    | { success: false; headers: Headers; redirectURL?: null; toResponse: () => Response }
+export type SignInCredentialsAPIReturn = AuthActionAPIReturn<
+    { success: true; redirectURL: string } | { success: false; redirectURL: null }
+>
 
 export interface SignOutOptions<Redirect extends boolean = boolean> {
     redirect?: Redirect
@@ -316,9 +321,9 @@ export interface SignOutAPIOptions {
     skipCSRFCheck?: boolean
 }
 
-export type SignOutAPIReturn =
-    | { success: true; headers: Headers; redirectURL?: string; toResponse: () => Response }
-    | { success: false; headers: Headers; redirectURL?: null; toResponse: () => Response }
+export type SignOutAPIReturn = AuthActionAPIReturn<
+    { success: true; redirectURL?: string } | { success: false; redirectURL?: null }
+>
 
 export type UpdateSessionOptions<DefaultUser extends User = User> = DeepPartial<Session<DefaultUser>>
 
@@ -332,6 +337,6 @@ export interface UpdateSessionAPIOptions<DefaultUser extends User = User> {
     skipCSRFCheck?: boolean
 }
 
-export type UpdateSessionAPIReturn<DefaultUser extends User = User> =
-    | { session: Session<DefaultUser>; headers: Headers; success: true; toResponse: () => Response }
-    | { session: null; headers: Headers; success: false; toResponse: () => Response }
+export type UpdateSessionAPIReturn<DefaultUser extends User = User> = AuthActionAPIReturn<
+    { success: true; session: Session<DefaultUser> } | { success: false; session: null }
+>

--- a/packages/core/src/@types/session.ts
+++ b/packages/core/src/@types/session.ts
@@ -10,6 +10,7 @@ import type {
     RouterGlobalContext,
 } from "@/@types/config.ts"
 
+/** Application user type, inferred from the configured identity schema (defaults to the built-in user shape). */
 export type User = UserIdentityType
 export type { UserShape } from "@/shared/identity.ts"
 
@@ -30,6 +31,7 @@ export interface Session<DefaultUser extends User = User> {
  */
 export type SecretKey = string | Uint8Array | CryptoKey
 
+/** Asymmetric key pair for signing or key agreement (Web Crypto `CryptoKey` pair). */
 export interface KeyPair {
     privateKey: CryptoKey
     publicKey: CryptoKey
@@ -106,8 +108,10 @@ export type JWTSealedMode = {
     encryptionAlgorithm?: JWTEncryptionAlgorithm
 }
 
+/** Discriminated union of JWT wire format: signed JWS, encrypted JWE, or nested sealed (JWS in JWE). */
 export type JWTConfigBase = JWTSignedMode | JWTEncryptedMode | JWTSealedMode
 
+/** How session/JWT lifetime is enforced relative to `iat`, absolute caps, and sliding windows. */
 export type JWTExpirationStrategy = "fixed" | "rolling" | "absolute" | "sliding"
 
 export type JWTConfig = {
@@ -132,7 +136,7 @@ export type JWTConfig = {
      */
     maxExpiration?: number
     /**
-     *
+     * Policy for renewing or capping token lifetime (pairs with `maxExpiration` where applicable).
      */
     expirationStrategy?: JWTExpirationStrategy
 } & JWTConfigBase
@@ -165,6 +169,7 @@ export type StatelessStrategyConfig = {
  */
 export type SessionConfig = StatelessStrategyConfig
 
+/** Result of reading a stateless (JWT) session from a request: session payload and outgoing header mutations. */
 export interface GetStatelessSessionReturn<DefaultUser extends User = User> {
     session: Session<DefaultUser> | null
     headers: Headers
@@ -213,6 +218,7 @@ export interface SessionStrategy<DefaultUser extends User = User> {
     destroySession(request: Headers, skipCSRFCheck?: boolean): Promise<Headers>
 }
 
+/** Inputs for constructing a session strategy implementation for a given identity schema. */
 export interface CreateSessionStrategyOptions<Identity extends EditableShape<UserShape>> {
     config?: SessionConfig
     jose: JoseInstance<ShapeToObject<Identity> & User>
@@ -221,6 +227,7 @@ export interface CreateSessionStrategyOptions<Identity extends EditableShape<Use
     identity: IdentityConfig
 }
 
+/** Options specialized for the JWT-backed session strategy. */
 export interface JWTStrategyOptions<DefaultUser extends User = User> {
     config?: StatelessStrategyConfig
     jose: JoseInstance<DefaultUser>
@@ -229,6 +236,7 @@ export interface JWTStrategyOptions<DefaultUser extends User = User> {
     identity: IdentityConfig
 }
 
+/** Minimal token issue/verify surface used by session code paths. */
 export type JWTManager<DefaultUser extends User = User> = {
     createToken(user: TypedJWTPayload<Partial<DefaultUser>>): Promise<string>
     verifyToken(token: string): Promise<TypedJWTPayload<DefaultUser>>
@@ -236,6 +244,10 @@ export type JWTManager<DefaultUser extends User = User> = {
 
 // #region API/Client API Types
 
+/**
+ * Internal shape for auth API actions: success and failure variants include `headers` and `toResponse()`
+ * for building {@link AuthResponse} bodies.
+ */
 type AuthActionAPIReturn<Body> =
     | (Extract<Body, { success: true }> & { headers: Headers; toResponse: () => AuthResponse<Exclude<Body, { success: false }>> })
     | (Extract<Body, { success: false }> & {
@@ -244,31 +256,38 @@ type AuthActionAPIReturn<Body> =
           toResponse: () => AuthResponse<Exclude<Body, { success: true }>>
       })
 
+/** Router context (`ctx`) merged with per-handler options (headers, body, redirect flags, etc.). */
 export type FunctionAPIContext<Options extends object> = Prettify<
     {
         ctx: RouterGlobalContext
     } & Options
 >
 
+/** Options for reading the current session from request headers. */
 export interface GetSessionOptions {
     headers: HeadersInit
 }
 
+/** Alias for {@link GetSessionOptions} when calling the programmatic `getSession` API. */
 export type GetSessionAPIOptions = GetSessionOptions
 
+/** Result of `getSession`: session payload on success, or `null` session with error semantics via `toResponse()`. */
 export type GetSessionAPIReturn<DefaultUser extends User = User> = AuthActionAPIReturn<
     { success: true; session: Session<DefaultUser> } | { success: false; session: null }
 >
 
+/** Client-side OAuth sign-in options (browser): whether to navigate and optional post-login path. */
 export interface SignInOptions<Redirect extends boolean = boolean> {
     redirect?: Redirect
     redirectTo?: string
 }
 
+/** Client `signIn` return: `void` when redirecting in-browser, otherwise a small JSON result with `signInURL`. */
 export type SignInReturn<Redirect extends boolean = boolean> = Redirect extends true
     ? void
     : { success: boolean; redirect: false; signInURL: string | null }
 
+/** Server/programmatic OAuth sign-in: optional `Request`, headers, and redirect behavior for the HTTP handler. */
 export interface SignInAPIOptions {
     request?: Request
     headers?: HeadersInit
@@ -276,6 +295,10 @@ export interface SignInAPIOptions {
     redirectTo?: string
 }
 
+/**
+ * Server `signIn` result: includes `signInURL` for both redirect and JSON flows, plus `toResponse()` for the route.
+ * When `redirect` is true, the JSON body still carries the authorization URL for consistency.
+ */
 export type SignInAPIReturn =
     | {
           success: true
@@ -290,10 +313,12 @@ export type SignInAPIReturn =
           toResponse: () => AuthResponse<{ success: true; redirect: false; signInURL: string }>
       }
 
+/** Client credentials sign-in return: `void` on redirect, otherwise success with `redirectURL` or failure with `null`. */
 export type SignInCredentialsReturn<Redirect extends boolean = boolean> = Redirect extends true
     ? void
     : { success: true; redirectURL: string } | { success: false; redirectURL: null }
 
+/** Server credentials sign-in: credentials payload plus optional request/headers and post-login redirect target. */
 export interface SignInCredentialsAPIOptions {
     payload: CredentialsPayload
     request?: Request
@@ -301,19 +326,23 @@ export interface SignInCredentialsAPIOptions {
     redirectTo?: string
 }
 
+/** Result of credentials sign-in: success includes `redirectURL`; failure clears redirect with `null`. */
 export type SignInCredentialsAPIReturn = AuthActionAPIReturn<
     { success: true; redirectURL: string } | { success: false; redirectURL: null }
 >
 
+/** Client-side sign-out options: optional redirect and destination path. */
 export interface SignOutOptions<Redirect extends boolean = boolean> {
     redirect?: Redirect
     redirectTo?: string
 }
 
+/** Client `signOut` return: `void` when redirecting, otherwise JSON-like `{ success, redirectURL }`. */
 export type SignOutReturn<Redirect extends boolean = boolean> = Redirect extends true
     ? void
     : { success: boolean; redirect: false; redirectURL: string }
 
+/** Server sign-out: requires headers (cookies); optional redirect target and CSRF bypass for trusted callers. */
 export interface SignOutAPIOptions {
     request?: Request
     headers: HeadersInit
@@ -321,22 +350,27 @@ export interface SignOutAPIOptions {
     skipCSRFCheck?: boolean
 }
 
+/** Result of sign-out: success includes resolved `redirectURL`; failure uses `redirectURL: null`. */
 export type SignOutAPIReturn = AuthActionAPIReturn<
-    { success: true; redirectURL?: string } | { success: false; redirectURL?: null }
+    { success: true; redirectURL: string } | { success: false; redirectURL: null }
 >
 
+/** Partial session update accepted by the client (`updateSession`): user fields and/or expiry. */
 export type UpdateSessionOptions<DefaultUser extends User = User> = DeepPartial<Session<DefaultUser>>
 
+/** Client `updateSession` outcome: updated session or `null` on failure. */
 export type UpdateSessionReturn<DefaultUser extends User = User> =
     | { success: true; session: Session<DefaultUser> }
     | { success: false; session: null }
 
+/** Server `updateSession`: headers, partial session, optional CSRF bypass for same-origin server calls. */
 export interface UpdateSessionAPIOptions<DefaultUser extends User = User> {
     headers: HeadersInit
     session: DeepPartial<Session<DefaultUser>>
     skipCSRFCheck?: boolean
 }
 
+/** Result of programmatic session refresh/update: current session on success, or `null` with failure response. */
 export type UpdateSessionAPIReturn<DefaultUser extends User = User> = AuthActionAPIReturn<
     { success: true; session: Session<DefaultUser> } | { success: false; session: null }
 >

--- a/packages/core/src/@types/session.ts
+++ b/packages/core/src/@types/session.ts
@@ -237,13 +237,13 @@ export type JWTManager<DefaultUser extends User = User> = {
 // #region API Types
 export type AuthActionReturn =
     | {
-          ok: true
+          success: true
           headers: Headers
           redirectURL?: string
           toResponse: () => Response
       }
     | {
-          ok: false
+          success: false
           headers: Headers
           toResponse: () => Response
       }
@@ -264,10 +264,14 @@ export type SessionReturn<DefaultUser extends User = User> =
     | { success: true; session: Session<DefaultUser>; headers: Headers; toResponse: () => Response }
     | { success: false; session: null; headers: Headers; toResponse: () => Response }
 
-export interface SignInOptions {
-    redirect?: boolean
+export interface SignInOptions<Redirect extends boolean = boolean> {
+    redirect?: Redirect
     redirectTo?: string
 }
+
+export type SignInReturn<Redirect extends boolean = boolean> = Redirect extends true
+    ? void
+    : { success: boolean; redirect: false; signInURL: string }
 
 export interface SignInAPIOptions<Redirect extends boolean = boolean> {
     request?: Request
@@ -276,44 +280,51 @@ export interface SignInAPIOptions<Redirect extends boolean = boolean> {
     redirectTo?: string
 }
 
-export interface SignInReturn<Redirect extends boolean = boolean> {
+export interface SignInAPIReturn<Redirect extends boolean = boolean> {
     redirect: Redirect
     success: boolean
     signInURL: string
     toResponse: () => Response
 }
 
-export type SignInCredentialsOptions = FunctionAPIContext<{
-    payload: CredentialsPayload
-    request?: Request
-    headers?: HeadersInit
-    redirectTo?: string
-}>
-
 export interface SignInCredentialsAPIOptions {
     payload: CredentialsPayload
     request?: Request
     headers?: HeadersInit
-    redirect?: boolean
     redirectTo?: string
 }
 
-export type SignInCredentialsReturn =
-    | { success: true; headers: Headers; redirectURL: string }
-    | { success: false; headers: Headers; redirectURL?: null }
+export type SignInCredentialsReturn = { success: true; redirectURL: string } | { success: false; redirectURL: null }
 
-export interface SignOutOptions {
-    redirect?: boolean
+export type SignInCredentialsAPIReturn =
+    | { success: true; headers: Headers; redirectURL: string; toResponse: () => Response }
+    | { success: false; headers: Headers; redirectURL?: null; toResponse: () => Response }
+
+export interface SignOutOptions<Redirect extends boolean = boolean> {
+    redirect?: Redirect
     redirectTo?: string
 }
+
+export type SignOutReturn<Redirect extends boolean = boolean> = Redirect extends true
+    ? void
+    : { success: boolean; redirect: false; redirectURL: string }
 
 export interface SignOutAPIOptions {
+    request?: Request
     headers: HeadersInit
     redirectTo?: string
     skipCSRFCheck?: boolean
 }
 
+export type SignOutAPIReturn =
+    | { success: true; headers: Headers; redirectURL?: string; toResponse: () => Response }
+    | { success: false; headers: Headers; redirectURL?: null; toResponse: () => Response }
+
 export type UpdateSessionOptions<DefaultUser extends User = User> = DeepPartial<Session<DefaultUser>>
+
+export type UpdateSessionReturn<DefaultUser extends User = User> =
+    | { success: true; session: Session<DefaultUser> }
+    | { success: false; session: null }
 
 export interface UpdateSessionAPIOptions<DefaultUser extends User = User> {
     headers: HeadersInit
@@ -321,6 +332,6 @@ export interface UpdateSessionAPIOptions<DefaultUser extends User = User> {
     skipCSRFCheck?: boolean
 }
 
-export type UpdateSessionReturn<DefaultUser extends User = User> =
-    | { session: Session<DefaultUser>; headers: Headers; updated: true }
-    | { session: null; headers: Headers; updated: false }
+export type UpdateSessionAPIReturn<DefaultUser extends User = User> =
+    | { session: Session<DefaultUser>; headers: Headers; success: true; toResponse: () => Response }
+    | { session: null; headers: Headers; success: false; toResponse: () => Response }

--- a/packages/core/src/@types/utility.ts
+++ b/packages/core/src/@types/utility.ts
@@ -24,6 +24,10 @@ export type DeepRequired<T> = {
     [K in keyof T]-?: T[K] extends object ? DeepRequired<T[K]> : T[K]
 }
 
+export type DeepPartial<T> = {
+    [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P]
+}
+
 export type InferAuthIdentity<Config> = Config extends AuthInstance<infer Identity> ? Prettify<Identity> : User
 
 export type InferShape<T extends ZodObject> = T["shape"]

--- a/packages/core/src/@types/utility.ts
+++ b/packages/core/src/@types/utility.ts
@@ -3,16 +3,29 @@ import type { AuthInstance } from "@/@types/config.ts"
 import type { ZodObject, ZodRawShape, ZodTypeAny } from "zod/v4"
 import type { z } from "zod/v4"
 
+/** Expands intersection types into a single flat object type for readable editor hints. */
 export type Prettify<T> = { [K in keyof T]: T[K] }
 
+/**
+ * A string that must be one of the literals in `T`, or any other string (`U`).
+ * Useful for autocomplete on known keys while still allowing custom values.
+ */
 export type LiteralUnion<T extends U, U = string> = T | (U & Record<never, never>)
 
+/**
+ * Transforms a Zod raw shape so nested `ZodObject` fields become editable (same structure, for config authoring).
+ */
 export type EditableShape<T extends ZodRawShape> = {
     [K in keyof T]: T[K] extends ZodObject<infer Inner extends ZodRawShape> ? ZodObject<EditableShape<Inner>> : ZodTypeAny
 }
 
+/** Merges type `B` over `A`, replacing overlapping keys with `B`. */
 export type Merge<A, B> = Omit<A, keyof B> & B
 
+/**
+ * Infers the runtime object type from a Zod `shape` and intersects it with {@link User}
+ * so identity fields always include the base user contract.
+ */
 export type ShapeToObject<S extends ZodRawShape = ZodRawShape> = Merge<
     {
         [K in keyof S]: z.infer<S[K]>
@@ -20,20 +33,29 @@ export type ShapeToObject<S extends ZodRawShape = ZodRawShape> = Merge<
     User
 >
 
+/** Recursively makes every property required. */
 export type DeepRequired<T> = {
     [K in keyof T]-?: T[K] extends object ? DeepRequired<T[K]> : T[K]
 }
 
+/** Recursively makes every property optional. */
 export type DeepPartial<T> = {
     [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P]
 }
 
+/** Resolves the user identity type from an {@link AuthInstance} config, or falls back to {@link User}. */
 export type InferAuthIdentity<Config> = Config extends AuthInstance<infer Identity> ? Prettify<Identity> : User
 
+/** Shorthand for a Zod object’s `.shape` property. */
 export type InferShape<T extends ZodObject> = T["shape"]
+
+/** Runtime user object type inferred from a Zod identity schema. */
 export type InferIdentity<T extends ZodObject> = ShapeToObject<InferShape<T>>
 
-export type AuthResponse<Body = any> = Prettify<
+/**
+ * HTTP `Response` with `json()` typed to resolve to `Body` (defaults to `unknown`).
+ */
+export type AuthResponse<Body = unknown> = Prettify<
     Omit<Response, "json"> & {
         json(): Promise<Body>
     }

--- a/packages/core/src/@types/utility.ts
+++ b/packages/core/src/@types/utility.ts
@@ -32,3 +32,9 @@ export type InferAuthIdentity<Config> = Config extends AuthInstance<infer Identi
 
 export type InferShape<T extends ZodObject> = T["shape"]
 export type InferIdentity<T extends ZodObject> = ShapeToObject<InferShape<T>>
+
+export type AuthResponse<Body = any> = Prettify<
+    Omit<Response, "json"> & {
+        json(): Promise<Body>
+    }
+>

--- a/packages/core/src/actions/session/session.ts
+++ b/packages/core/src/actions/session/session.ts
@@ -1,28 +1,7 @@
-import { createEndpoint, HeadersBuilder } from "@aura-stack/router"
-import { secureApiHeaders } from "@/shared/headers.ts"
-import { AuthInternalError } from "@/shared/errors.ts"
+import { createEndpoint } from "@aura-stack/router"
 import { getSession } from "@/api/getSession.ts"
-import { expiredCookieAttributes } from "@/cookie.ts"
 
 export const sessionAction = createEndpoint("GET", "/session", async (ctx) => {
-    const {
-        request,
-        context: { cookies },
-    } = ctx
-    try {
-        const { session, headers: headersInit, authenticated } = await getSession({ ctx: ctx.context, headers: request.headers })
-        if (!authenticated) {
-            throw new AuthInternalError("INVALID_JWT_TOKEN", "Session not authenticated")
-        }
-        const headers = new Headers(secureApiHeaders)
-        if (headersInit.has("Set-Cookie")) {
-            headers.set("Set-Cookie", headersInit.get("Set-Cookie")!)
-        }
-        return Response.json({ session, authenticated }, { headers })
-    } catch {
-        const headers = new HeadersBuilder(secureApiHeaders)
-            .setCookie(cookies.sessionToken.name, "", { ...cookies.sessionToken.attributes, ...expiredCookieAttributes })
-            .toHeaders()
-        return Response.json({ session: null, authenticated: false }, { status: 401, headers })
-    }
+    const { toResponse } = await getSession({ ctx: ctx.context, headers: ctx.request.headers })
+    return toResponse()
 })

--- a/packages/core/src/actions/signIn/signIn.ts
+++ b/packages/core/src/actions/signIn/signIn.ts
@@ -25,24 +25,14 @@ export const signInAction = (oauth: OAuthProviderRecord) => {
         "GET",
         "/signIn/:oauth",
         async (ctx) => {
-            const {
-                request,
-                params: { oauth },
-                searchParams: { redirectTo, redirect },
-                context,
-            } = ctx
-
-            const signInResult = await signIn(oauth, {
-                ctx: context,
-                headers: request.headers,
-                redirect,
-                redirectTo,
-                request,
+            const signInReturn = await signIn(ctx.params.oauth, {
+                ctx: ctx.context,
+                request: ctx.request,
+                headers: ctx.request.headers,
+                redirect: ctx.searchParams.redirect,
+                redirectTo: ctx.searchParams.redirectTo,
             })
-            if (!redirect) {
-                return Response.json(signInResult, { status: 200 })
-            }
-            return signInResult as Response
+            return signInReturn.toResponse()
         },
         signInConfig(oauth)
     )

--- a/packages/core/src/actions/signIn/signIn.ts
+++ b/packages/core/src/actions/signIn/signIn.ts
@@ -25,14 +25,14 @@ export const signInAction = (oauth: OAuthProviderRecord) => {
         "GET",
         "/signIn/:oauth",
         async (ctx) => {
-            const signInReturn = await signIn(ctx.params.oauth, {
+            const { toResponse } = await signIn(ctx.params.oauth, {
                 ctx: ctx.context,
                 request: ctx.request,
                 headers: ctx.request.headers,
                 redirect: ctx.searchParams.redirect,
                 redirectTo: ctx.searchParams.redirectTo,
             })
-            return signInReturn.toResponse()
+            return toResponse()
         },
         signInConfig(oauth)
     )

--- a/packages/core/src/actions/signInCredentials/signInCredentials.ts
+++ b/packages/core/src/actions/signInCredentials/signInCredentials.ts
@@ -26,14 +26,14 @@ export const signInCredentialsAction = createEndpoint(
     "/signIn/credentials",
     async (ctx) => {
         const payload = ctx.body
-        const { headers, success, redirectURL } = await signInCredentials({
+        const { toResponse } = await signInCredentials({
             ctx: ctx.context,
             payload,
             request: ctx.request,
             headers: ctx.request.headers,
             redirectTo: ctx.searchParams.redirectTo,
         })
-        return Response.json({ success, redirectURL }, { headers, status: success ? 200 : 401 })
+        return toResponse()
     },
     config
 )

--- a/packages/core/src/actions/signOut/signOut.ts
+++ b/packages/core/src/actions/signOut/signOut.ts
@@ -1,8 +1,6 @@
 import { z } from "zod/v4"
 import { createEndpoint, createEndpointConfig } from "@aura-stack/router"
-import { getBaseURL } from "@/shared/utils.ts"
 import { signOut } from "@/api/signOut.ts"
-import { createRedirectTo } from "@/actions/signIn/authorization.ts"
 
 const config = createEndpointConfig({
     schemas: {
@@ -20,26 +18,13 @@ export const signOutAction = createEndpoint(
     "POST",
     "/signOut",
     async (ctx) => {
-        const {
-            request,
-            searchParams: { redirectTo },
-            context,
-        } = ctx
-
-        const baseURL = getBaseURL(request)
-        const location = await createRedirectTo(
-            new Request(baseURL, {
-                headers: request.headers,
-            }),
-            redirectTo,
-            context
-        )
-
-        return await signOut({
-            ctx: context,
-            headers: request.headers,
-            redirectTo: location,
+        const { toResponse } = await signOut({
+            ctx: ctx.context,
+            request: ctx.request,
+            headers: ctx.request.headers,
+            redirectTo: ctx.searchParams.redirectTo,
         })
+        return toResponse()
     },
     config
 )

--- a/packages/core/src/actions/updateSession/updateSession.ts
+++ b/packages/core/src/actions/updateSession/updateSession.ts
@@ -20,7 +20,7 @@ export const updateSessionAction = (identity: IdentityConfig) => {
         "PATCH",
         "/session",
         async (ctx) => {
-            const updated = await updateSession({
+            const { toResponse } = await updateSession({
                 ctx: ctx.context,
                 headers: ctx.request.headers,
                 session: {
@@ -28,7 +28,7 @@ export const updateSessionAction = (identity: IdentityConfig) => {
                     expires: ctx.body.expires?.toISOString(),
                 },
             })
-            return Response.json(updated, { status: updated.updated ? 200 : 401 })
+            return toResponse()
         },
         config(identity)
     )

--- a/packages/core/src/api/createApi.ts
+++ b/packages/core/src/api/createApi.ts
@@ -4,34 +4,34 @@ import type {
     BuiltInOAuthProvider,
     LiteralUnion,
     GetSessionAPIOptions,
-    SessionReturn,
+    GetSessionAPIReturn,
     SignInAPIOptions,
     SignInAPIReturn,
     SignOutAPIOptions,
     UpdateSessionAPIOptions,
     User,
     SignInCredentialsAPIOptions,
+    SignInCredentialsAPIReturn,
+    SignOutAPIReturn,
+    UpdateSessionAPIReturn,
 } from "@/@types/index.ts"
 
 export const createAuthAPI = <DefaultUser extends User = User>(ctx: GlobalContext) => {
     return {
-        getSession: async (options: GetSessionAPIOptions): Promise<SessionReturn<DefaultUser>> => {
+        getSession: async (options: GetSessionAPIOptions): Promise<GetSessionAPIReturn<DefaultUser>> => {
             const session = await getSession<DefaultUser>({ ctx, headers: options.headers })
             return session
         },
-        signIn: async <Redirect extends boolean = true>(
-            oauth: LiteralUnion<BuiltInOAuthProvider>,
-            options?: SignInAPIOptions<Redirect>
-        ): Promise<SignInAPIReturn<Redirect>> => {
-            return signIn<Redirect>(oauth, { ctx, ...options })
+        signIn: async (oauth: LiteralUnion<BuiltInOAuthProvider>, options?: SignInAPIOptions): Promise<SignInAPIReturn> => {
+            return signIn(oauth, { ctx, ...options })
         },
-        signInCredentials: async (options: SignInCredentialsAPIOptions) => {
+        signInCredentials: async (options: SignInCredentialsAPIOptions): Promise<SignInCredentialsAPIReturn> => {
             return signInCredentials({ ctx, ...options })
         },
-        signOut: async (options: SignOutAPIOptions) => {
+        signOut: async (options: SignOutAPIOptions): Promise<SignOutAPIReturn> => {
             return signOut({ ctx, skipCSRFCheck: true, ...options })
         },
-        updateSession: async (options: UpdateSessionAPIOptions<DefaultUser>) => {
+        updateSession: async (options: UpdateSessionAPIOptions<DefaultUser>): Promise<UpdateSessionAPIReturn<DefaultUser>> => {
             return updateSession<DefaultUser>({ ctx, skipCSRFCheck: true, ...options })
         },
     }

--- a/packages/core/src/api/createApi.ts
+++ b/packages/core/src/api/createApi.ts
@@ -1,4 +1,3 @@
-import { validateRedirectTo } from "@/shared/utils.ts"
 import { getSession, signIn, signInCredentials, signOut, updateSession } from "@/api/index.ts"
 import type { GlobalContext } from "@aura-stack/router"
 import type {
@@ -7,7 +6,7 @@ import type {
     GetSessionAPIOptions,
     SessionReturn,
     SignInAPIOptions,
-    SignInReturn,
+    SignInAPIReturn,
     SignOutAPIOptions,
     UpdateSessionAPIOptions,
     User,
@@ -23,33 +22,17 @@ export const createAuthAPI = <DefaultUser extends User = User>(ctx: GlobalContex
         signIn: async <Redirect extends boolean = true>(
             oauth: LiteralUnion<BuiltInOAuthProvider>,
             options?: SignInAPIOptions<Redirect>
-        ): Promise<SignInReturn<Redirect>> => {
-            return signIn<Redirect>(oauth, {
-                ctx,
-                headers: options?.headers,
-                request: options?.request,
-                redirect: options?.redirect,
-                redirectTo: options?.redirectTo,
-            })
+        ): Promise<SignInAPIReturn<Redirect>> => {
+            return signIn<Redirect>(oauth, { ctx, ...options })
         },
         signInCredentials: async (options: SignInCredentialsAPIOptions) => {
-            return signInCredentials({
-                ctx,
-                payload: options.payload,
-                redirectTo: options.redirectTo,
-            })
+            return signInCredentials({ ctx, ...options })
         },
         signOut: async (options: SignOutAPIOptions) => {
-            const redirectTo = validateRedirectTo(options?.redirectTo ?? "/")
-            return signOut({ ctx, headers: options.headers, redirectTo, skipCSRFCheck: true })
+            return signOut({ ctx, skipCSRFCheck: true, ...options })
         },
         updateSession: async (options: UpdateSessionAPIOptions<DefaultUser>) => {
-            return updateSession<DefaultUser>({
-                ctx,
-                headers: options.headers,
-                session: options.session,
-                skipCSRFCheck: options.skipCSRFCheck,
-            })
+            return updateSession<DefaultUser>({ ctx, skipCSRFCheck: true, ...options })
         },
     }
 }

--- a/packages/core/src/api/createApi.ts
+++ b/packages/core/src/api/createApi.ts
@@ -5,7 +5,7 @@ import type {
     BuiltInOAuthProvider,
     LiteralUnion,
     GetSessionAPIOptions,
-    SessionResponse,
+    SessionReturn,
     SignInAPIOptions,
     SignInReturn,
     SignOutAPIOptions,
@@ -16,7 +16,7 @@ import type {
 
 export const createAuthAPI = <DefaultUser extends User = User>(ctx: GlobalContext) => {
     return {
-        getSession: async (options: GetSessionAPIOptions): Promise<SessionResponse<DefaultUser>> => {
+        getSession: async (options: GetSessionAPIOptions): Promise<SessionReturn<DefaultUser>> => {
             const session = await getSession<DefaultUser>({ ctx, headers: options.headers })
             return session
         },

--- a/packages/core/src/api/createApi.ts
+++ b/packages/core/src/api/createApi.ts
@@ -29,10 +29,10 @@ export const createAuthAPI = <DefaultUser extends User = User>(ctx: GlobalContex
             return signInCredentials({ ctx, ...options })
         },
         signOut: async (options: SignOutAPIOptions): Promise<SignOutAPIReturn> => {
-            return signOut({ ctx, skipCSRFCheck: true, ...options })
+            return signOut({ ctx, ...options, skipCSRFCheck: true })
         },
         updateSession: async (options: UpdateSessionAPIOptions<DefaultUser>): Promise<UpdateSessionAPIReturn<DefaultUser>> => {
-            return updateSession<DefaultUser>({ ctx, skipCSRFCheck: true, ...options })
+            return updateSession<DefaultUser>({ ctx, ...options, skipCSRFCheck: true })
         },
     }
 }

--- a/packages/core/src/api/credentials.ts
+++ b/packages/core/src/api/credentials.ts
@@ -3,7 +3,7 @@ import { secureApiHeaders } from "@/shared/headers.ts"
 import { AuthValidationError } from "@/shared/errors.ts"
 import { createCSRF, hashPassword, verifyPassword } from "@/shared/crypto.ts"
 import { createRedirectTo, getBaseURL, getOriginURL } from "@/actions/signIn/authorization.ts"
-import type { SignInCredentialsOptions, SignInCredentialsReturn } from "@/@types/session.ts"
+import type { FunctionAPIContext, SignInCredentialsAPIOptions, SignInCredentialsAPIReturn } from "@/@types/session.ts"
 
 export const signInCredentials = async ({
     ctx,
@@ -11,7 +11,7 @@ export const signInCredentials = async ({
     request: requestInit,
     headers: headerInit,
     redirectTo,
-}: SignInCredentialsOptions): Promise<SignInCredentialsReturn> => {
+}: FunctionAPIContext<SignInCredentialsAPIOptions>): Promise<SignInCredentialsAPIReturn> => {
     const { cookies, credentials, sessionStrategy, logger } = ctx
     try {
         let request = requestInit
@@ -36,6 +36,7 @@ export const signInCredentials = async ({
         const redirectURL = await createRedirectTo(request, redirectTo, ctx)
 
         const headers = new HeadersBuilder(secureApiHeaders)
+            .setHeader("Location", redirectURL)
             .setCookie(cookies.csrfToken.name, csrfToken, cookies.csrfToken.attributes)
             .setCookie(cookies.sessionToken.name, sessionToken, cookies.sessionToken.attributes)
             .toHeaders()
@@ -43,27 +44,26 @@ export const signInCredentials = async ({
             success: true,
             headers,
             redirectURL,
+            toResponse: () => Response.json({ success: true, redirectURL }, { headers }),
         }
     } catch (error) {
+        const invalidCredentials: SignInCredentialsAPIReturn = {
+            success: false,
+            headers: new Headers(secureApiHeaders),
+            redirectURL: null,
+            toResponse: () => Response.json({ success: false, redirectURL: null }, { headers: secureApiHeaders, status: 401 }),
+        }
         if (error instanceof AuthValidationError) {
             logger?.log("INVALID_CREDENTIALS", {
                 severity: "warning",
                 structuredData: { path: "/signIn/credentials" },
             })
-            return {
-                success: false,
-                headers: new Headers(secureApiHeaders),
-                redirectURL: null,
-            }
+            return invalidCredentials
         }
         logger?.log("CREDENTIALS_SIGN_IN_FAILED", {
             severity: "error",
             structuredData: { path: "/signIn/credentials" },
         })
-        return {
-            success: false,
-            headers: new Headers(secureApiHeaders),
-            redirectURL: null,
-        }
+        return invalidCredentials
     }
 }

--- a/packages/core/src/api/credentials.ts
+++ b/packages/core/src/api/credentials.ts
@@ -47,11 +47,12 @@ export const signInCredentials = async ({
             toResponse: () => Response.json({ success: true, redirectURL }, { headers }),
         }
     } catch (error) {
+        const headers = new Headers(secureApiHeaders)
         const invalidCredentials: SignInCredentialsAPIReturn = {
             success: false,
-            headers: new Headers(secureApiHeaders),
+            headers,
             redirectURL: null,
-            toResponse: () => Response.json({ success: false, redirectURL: null }, { headers: secureApiHeaders, status: 401 }),
+            toResponse: () => Response.json({ success: false, redirectURL: null }, { headers, status: 401 }),
         }
         if (error instanceof AuthValidationError) {
             logger?.log("INVALID_CREDENTIALS", {

--- a/packages/core/src/api/getSession.ts
+++ b/packages/core/src/api/getSession.ts
@@ -1,8 +1,8 @@
-import { getErrorName } from "@/shared/utils.ts"
-import type { FunctionAPIContext, GetSessionAPIOptions, SessionReturn, User } from "@/@types/index.ts"
+import { getErrorName, toUnionHeaders } from "@/shared/utils.ts"
 import { HeadersBuilder } from "@aura-stack/router"
 import { secureApiHeaders } from "@/shared/headers.ts"
 import { expiredCookieAttributes } from "@/cookie.ts"
+import type { FunctionAPIContext, GetSessionAPIOptions, SessionReturn, User } from "@/@types/index.ts"
 
 export const getSession = async <DefaultUser extends User = User>({
     ctx,
@@ -14,15 +14,14 @@ export const getSession = async <DefaultUser extends User = User>({
         .toHeaders()
     const unauthorized: SessionReturn<DefaultUser> = {
         session: null,
-        headers: new Headers(),
+        headers: new Headers(secureApiHeaders),
         success: false,
         toResponse: () => Response.json({ success: false, session: null }, { status: 401, headers }),
     }
     try {
         const { session, headers } = await ctx.sessionStrategy.getSession(new Headers(headersInit))
         if (!session) return unauthorized
-        const newHeaders = new Headers(secureApiHeaders)
-        headers.forEach((value, key) => newHeaders.set(key, value))
+        const newHeaders = toUnionHeaders(headers, secureApiHeaders)
         return {
             session,
             headers: newHeaders,

--- a/packages/core/src/api/getSession.ts
+++ b/packages/core/src/api/getSession.ts
@@ -1,19 +1,34 @@
 import { getErrorName } from "@/shared/utils.ts"
-import type { FunctionAPIContext, GetSessionAPIOptions, SessionResponse, User } from "@/@types/index.ts"
+import type { FunctionAPIContext, GetSessionAPIOptions, SessionReturn, User } from "@/@types/index.ts"
+import { HeadersBuilder } from "@aura-stack/router"
+import { secureApiHeaders } from "@/shared/headers.ts"
+import { expiredCookieAttributes } from "@/cookie.ts"
 
 export const getSession = async <DefaultUser extends User = User>({
     ctx,
     headers: headersInit,
-}: FunctionAPIContext<GetSessionAPIOptions>): Promise<SessionResponse<DefaultUser>> => {
-    const unauthorized: SessionResponse<DefaultUser> = { session: null, headers: new Headers(), authenticated: false }
+}: FunctionAPIContext<GetSessionAPIOptions>): Promise<SessionReturn<DefaultUser>> => {
+    const headers = new HeadersBuilder(secureApiHeaders)
+        .setCookie(ctx.cookies.sessionToken.name, "", { ...ctx.cookies.sessionToken.attributes, ...expiredCookieAttributes })
+        .setCookie(ctx.cookies.csrfToken.name, "", { ...ctx.cookies.csrfToken.attributes, ...expiredCookieAttributes })
+        .toHeaders()
+    const unauthorized: SessionReturn<DefaultUser> = {
+        session: null,
+        headers: new Headers(),
+        success: false,
+        toResponse: () => Response.json({ success: false, session: null }, { status: 401, headers }),
+    }
     try {
         const { session, headers } = await ctx.sessionStrategy.getSession(new Headers(headersInit))
         if (!session) return unauthorized
+        const newHeaders = new Headers(secureApiHeaders)
+        headers.forEach((value, key) => newHeaders.set(key, value))
         return {
             session,
-            headers,
-            authenticated: true,
-        } as SessionResponse<DefaultUser>
+            headers: newHeaders,
+            success: true,
+            toResponse: () => Response.json({ success: true, session }, { headers: newHeaders }),
+        } as SessionReturn<DefaultUser>
     } catch (error) {
         ctx?.logger?.log("AUTH_SESSION_INVALID", { structuredData: { error_type: getErrorName(error) } })
         return unauthorized

--- a/packages/core/src/api/getSession.ts
+++ b/packages/core/src/api/getSession.ts
@@ -2,19 +2,19 @@ import { getErrorName, toUnionHeaders } from "@/shared/utils.ts"
 import { HeadersBuilder } from "@aura-stack/router"
 import { secureApiHeaders } from "@/shared/headers.ts"
 import { expiredCookieAttributes } from "@/cookie.ts"
-import type { FunctionAPIContext, GetSessionAPIOptions, SessionReturn, User } from "@/@types/index.ts"
+import type { FunctionAPIContext, GetSessionAPIOptions, GetSessionAPIReturn, User } from "@/@types/index.ts"
 
 export const getSession = async <DefaultUser extends User = User>({
     ctx,
     headers: headersInit,
-}: FunctionAPIContext<GetSessionAPIOptions>): Promise<SessionReturn<DefaultUser>> => {
+}: FunctionAPIContext<GetSessionAPIOptions>): Promise<GetSessionAPIReturn<DefaultUser>> => {
     const headers = new HeadersBuilder(secureApiHeaders)
         .setCookie(ctx.cookies.sessionToken.name, "", { ...ctx.cookies.sessionToken.attributes, ...expiredCookieAttributes })
         .setCookie(ctx.cookies.csrfToken.name, "", { ...ctx.cookies.csrfToken.attributes, ...expiredCookieAttributes })
         .toHeaders()
-    const unauthorized: SessionReturn<DefaultUser> = {
+    const unauthorized: GetSessionAPIReturn<DefaultUser> = {
         session: null,
-        headers: new Headers(secureApiHeaders),
+        headers,
         success: false,
         toResponse: () => Response.json({ success: false, session: null }, { status: 401, headers }),
     }
@@ -27,7 +27,7 @@ export const getSession = async <DefaultUser extends User = User>({
             headers: newHeaders,
             success: true,
             toResponse: () => Response.json({ success: true, session }, { headers: newHeaders }),
-        } as SessionReturn<DefaultUser>
+        } as GetSessionAPIReturn<DefaultUser>
     } catch (error) {
         ctx?.logger?.log("AUTH_SESSION_INVALID", { structuredData: { error_type: getErrorName(error) } })
         return unauthorized

--- a/packages/core/src/api/signIn.ts
+++ b/packages/core/src/api/signIn.ts
@@ -71,7 +71,7 @@ export const signIn = async (
         redirect: true,
         signInURL: authorization,
         toResponse: () => {
-            return Response.json({ success: true, redirect: true, signInURL: null }, { status: 302, headers: headersList })
+            return Response.json({ success: true, redirect: true, signInURL: authorization }, { status: 302, headers: headersList })
         },
     }
 }

--- a/packages/core/src/api/signIn.ts
+++ b/packages/core/src/api/signIn.ts
@@ -1,9 +1,9 @@
-import { cacheControl } from "@/shared/headers.ts"
+import { cacheControl, secureApiHeaders } from "@/shared/headers.ts"
 import { HeadersBuilder } from "@aura-stack/router"
 import { AuthInternalError } from "@/shared/errors.ts"
 import { createAuthorizationURL } from "@/actions/signIn/authorization-url.ts"
 import { createRedirectTo, createRedirectURI, createSignInURL, getBaseURL } from "@/actions/signIn/authorization.ts"
-import type { BuiltInOAuthProvider, FunctionAPIContext, LiteralUnion, SignInAPIOptions, SignInReturn } from "@/@types/index.ts"
+import type { BuiltInOAuthProvider, FunctionAPIContext, LiteralUnion, SignInAPIOptions, SignInAPIReturn } from "@/@types/index.ts"
 
 /**
  * Initiates the sign-in flow on the server. Called when the client invokes the `signIn` API route.
@@ -17,14 +17,8 @@ import type { BuiltInOAuthProvider, FunctionAPIContext, LiteralUnion, SignInAPIO
  */
 export const signIn = async <Redirect extends boolean = true>(
     oauth: LiteralUnion<BuiltInOAuthProvider>,
-    {
-        ctx,
-        headers: headersInit,
-        redirectTo = "/",
-        redirect,
-        request: requestInit,
-    }: FunctionAPIContext<SignInAPIOptions<Redirect>>
-): Promise<SignInReturn<Redirect>> => {
+    { ctx, request: requestInit, headers: headersInit, redirect, redirectTo }: FunctionAPIContext<SignInAPIOptions<Redirect>>
+): Promise<SignInAPIReturn<Redirect>> => {
     const headers = new Headers(headersInit)
     const provider = ctx.oauth[oauth]
     if (!provider) {
@@ -49,7 +43,10 @@ export const signIn = async <Redirect extends boolean = true>(
             redirect: false as Redirect,
             signInURL,
             toResponse: () => {
-                return Response.json({ success: true, redirect: false, signInURL }, { status: 200, headers: headersList })
+                return Response.json(
+                    { success: true, redirect: false, signInURL },
+                    { status: 200, headers: new Headers(secureApiHeaders) }
+                )
             },
         }
     }

--- a/packages/core/src/api/signIn.ts
+++ b/packages/core/src/api/signIn.ts
@@ -15,10 +15,10 @@ import type { BuiltInOAuthProvider, FunctionAPIContext, LiteralUnion, SignInAPIO
  *   headers: await getAuthHeaders(),
  * })
  */
-export const signIn = async <Redirect extends boolean = true>(
+export const signIn = async (
     oauth: LiteralUnion<BuiltInOAuthProvider>,
-    { ctx, request: requestInit, headers: headersInit, redirect, redirectTo }: FunctionAPIContext<SignInAPIOptions<Redirect>>
-): Promise<SignInAPIReturn<Redirect>> => {
+    { ctx, request: requestInit, headers: headersInit, redirect, redirectTo }: FunctionAPIContext<SignInAPIOptions>
+): Promise<SignInAPIReturn> => {
     const headers = new Headers(headersInit)
     const provider = ctx.oauth[oauth]
     if (!provider) {
@@ -40,7 +40,7 @@ export const signIn = async <Redirect extends boolean = true>(
         const signInURL = await createSignInURL({ request, oauth, ctx, redirectTo })
         return {
             success: true,
-            redirect: false as Redirect,
+            redirect: false,
             signInURL,
             toResponse: () => {
                 return Response.json(
@@ -68,7 +68,7 @@ export const signIn = async <Redirect extends boolean = true>(
         .toHeaders()
     return {
         success: true,
-        redirect: true as Redirect,
+        redirect: true,
         signInURL: authorization,
         toResponse: () => {
             return Response.json({ success: true, redirect: true, signInURL: null }, { status: 302, headers: headersList })

--- a/packages/core/src/api/signIn.ts
+++ b/packages/core/src/api/signIn.ts
@@ -39,8 +39,19 @@ export const signIn = async <Redirect extends boolean = true>(
     }
 
     if (redirect === false) {
+        ctx?.logger?.log("SIGN_IN_INITIATED", {
+            structuredData: { oauth_provider: oauth },
+        })
+
         const signInURL = await createSignInURL({ request, oauth, ctx, redirectTo })
-        return { redirect: false, signInURL } as unknown as SignInReturn<Redirect>
+        return {
+            success: true,
+            redirect: false as Redirect,
+            signInURL,
+            toResponse: () => {
+                return Response.json({ success: true, redirect: false, signInURL }, { status: 200, headers: headersList })
+            },
+        }
     }
 
     const redirectURI = await createRedirectURI(request, oauth, ctx)
@@ -58,12 +69,12 @@ export const signIn = async <Redirect extends boolean = true>(
         .setCookie(ctx.cookies.redirectTo.name, redirectToValue, ctx.cookies.redirectTo.attributes)
         .setCookie(ctx.cookies.codeVerifier.name, codeVerifier, ctx.cookies.codeVerifier.attributes)
         .toHeaders()
-
-    return Response.json(
-        { redirect: redirect ?? true, signInURL: authorization },
-        {
-            status: (redirect ?? true) ? 302 : 200,
-            headers: headersList,
-        }
-    ) as unknown as SignInReturn<Redirect>
+    return {
+        success: true,
+        redirect: true as Redirect,
+        signInURL: authorization,
+        toResponse: () => {
+            return Response.json({ success: true, redirect: true, signInURL: null }, { status: 302, headers: headersList })
+        },
+    }
 }

--- a/packages/core/src/api/signIn.ts
+++ b/packages/core/src/api/signIn.ts
@@ -71,7 +71,10 @@ export const signIn = async (
         redirect: true,
         signInURL: authorization,
         toResponse: () => {
-            return Response.json({ success: true, redirect: true, signInURL: authorization }, { status: 302, headers: headersList })
+            return Response.json(
+                { success: true, redirect: true, signInURL: authorization },
+                { status: 302, headers: headersList }
+            )
         },
     }
 }

--- a/packages/core/src/api/signOut.ts
+++ b/packages/core/src/api/signOut.ts
@@ -19,7 +19,11 @@ export const signOut = async ({
     }
     const redirectToURL = await createRedirectTo(request, redirectTo, ctx)
 
-    const headersList = new HeadersBuilder(headers).setHeader("Location", redirectToURL).toHeaders()
+    const headersBuilder = new HeadersBuilder(headers)
+    if (redirectTo) headersBuilder.setHeader("Location", redirectToURL)
+
+    const headersList = headersBuilder.toHeaders()
+
     return {
         headers: headersList,
         redirectURL: redirectToURL,

--- a/packages/core/src/api/signOut.ts
+++ b/packages/core/src/api/signOut.ts
@@ -20,7 +20,7 @@ export const signOut = async ({
     const redirectToURL = await createRedirectTo(request, redirectTo, ctx)
 
     const headersBuilder = new HeadersBuilder(headers)
-    if (redirectTo) headersBuilder.setHeader("Location", redirectToURL)
+    if (redirectToURL) headersBuilder.setHeader("Location", redirectToURL)
 
     const headersList = headersBuilder.toHeaders()
 

--- a/packages/core/src/api/signOut.ts
+++ b/packages/core/src/api/signOut.ts
@@ -1,20 +1,34 @@
 import { HeadersBuilder } from "@aura-stack/router"
-import type { FunctionAPIContext, SignOutAPIOptions } from "@/@types/index.ts"
+import { createRedirectTo, getBaseURL } from "@/actions/signIn/authorization.ts"
+import type { FunctionAPIContext, SignOutAPIOptions, SignOutAPIReturn } from "@/@types/index.ts"
 
 export const signOut = async ({
     ctx,
+    request: requestInit,
     headers: headersInit,
-    redirectTo = "/",
+    redirectTo,
     skipCSRFCheck = false,
-}: FunctionAPIContext<SignOutAPIOptions>) => {
+}: FunctionAPIContext<SignOutAPIOptions>): Promise<SignOutAPIReturn> => {
     const headers = await ctx.sessionStrategy.destroySession(new Headers(headersInit), skipCSRFCheck)
 
-    const headersList = new HeadersBuilder(headers).setHeader("Location", redirectTo).toHeaders()
-    return Response.json(
-        { redirect: Boolean(redirectTo), url: redirectTo },
-        {
-            status: 202,
-            headers: headersList,
-        }
-    )
+    let request = requestInit
+    if (!request) {
+        const origin = await getBaseURL({ headers })
+        const url = `${origin}${ctx.basePath}/signOut`
+        request = new Request(url, { headers })
+    }
+    const redirectToURL = await createRedirectTo(request, redirectTo, ctx)
+
+    const headersList = new HeadersBuilder(headers).setHeader("Location", redirectToURL).toHeaders()
+    return {
+        headers: headersList,
+        redirectURL: redirectTo,
+        success: true,
+        toResponse: () => {
+            return Response.json(
+                { success: true, redirectURL: redirectToURL },
+                { headers: headersList, status: redirectTo ? 302 : 202 }
+            )
+        },
+    }
 }

--- a/packages/core/src/api/signOut.ts
+++ b/packages/core/src/api/signOut.ts
@@ -22,7 +22,7 @@ export const signOut = async ({
     const headersList = new HeadersBuilder(headers).setHeader("Location", redirectToURL).toHeaders()
     return {
         headers: headersList,
-        redirectURL: redirectTo,
+        redirectURL: redirectToURL,
         success: true,
         toResponse: () => {
             return Response.json(

--- a/packages/core/src/api/updateSession.ts
+++ b/packages/core/src/api/updateSession.ts
@@ -1,15 +1,21 @@
-import { FunctionAPIContext, UpdateSessionAPIOptions, UpdateSessionReturn, User } from "@/@types/session.ts"
+import { secureApiHeaders } from "@/shared/headers.ts"
+import { toUnionHeaders } from "@/shared/utils.ts"
+import type { FunctionAPIContext, UpdateSessionAPIOptions, UpdateSessionAPIReturn, User } from "@/@types/session.ts"
 
 export const updateSession = async <DefaultUser extends User = User>({
     ctx,
     headers: headersInit,
     session: sessionInit,
     skipCSRFCheck = false,
-}: FunctionAPIContext<UpdateSessionAPIOptions<DefaultUser>>): Promise<UpdateSessionReturn<DefaultUser>> => {
+}: FunctionAPIContext<UpdateSessionAPIOptions<DefaultUser>>): Promise<UpdateSessionAPIReturn<DefaultUser>> => {
     const { session, headers } = await ctx.sessionStrategy.refreshSession(new Headers(headersInit), sessionInit, skipCSRFCheck)
+    const newHeaders = toUnionHeaders(headers, secureApiHeaders)
     return {
+        headers: newHeaders,
         session,
-        headers,
-        updated: session !== null,
-    } as UpdateSessionReturn<DefaultUser>
+        success: !!session,
+        toResponse: () => {
+            return Response.json({ success: !!session, session }, { headers: newHeaders, status: session ? 200 : 401 })
+        },
+    } as UpdateSessionAPIReturn<DefaultUser>
 }

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -1,4 +1,4 @@
-import { AuthClientError, isNativeError } from "@/shared/errors.ts"
+import { AuthClientError } from "@/shared/errors.ts"
 import { createClient as createClientAPI } from "@aura-stack/router"
 import type {
     Session,
@@ -11,6 +11,10 @@ import type {
     User,
     CredentialsPayload,
     UpdateSessionOptions,
+    SignInReturn,
+    SignOutReturn,
+    UpdateSessionReturn,
+    SignInCredentialsReturn,
 } from "@/@types/index.ts"
 
 export type { AuthClientOptions }
@@ -46,7 +50,7 @@ export const createAuthClient = <DefaultUser extends User = User>(options: AuthC
             const response = await client.get("/session")
             if (!response.ok) return null
             const session = await response.json()
-            if (!session?.authenticated) return null
+            if (!session.success) return null
             return session.session
         } catch (error) {
             console.error("Error fetching session:", error)
@@ -54,7 +58,10 @@ export const createAuthClient = <DefaultUser extends User = User>(options: AuthC
         }
     }
 
-    const signIn = async (oauth: LiteralUnion<BuiltInOAuthProvider>, options?: SignInOptions) => {
+    const signIn = async <Redirect extends boolean = true>(
+        oauth: LiteralUnion<BuiltInOAuthProvider>,
+        options?: SignInOptions<Redirect>
+    ): Promise<SignInReturn<Redirect>> => {
         try {
             const response = await client.get("/signIn/:oauth", {
                 params: {
@@ -72,11 +79,13 @@ export const createAuthClient = <DefaultUser extends User = User>(options: AuthC
             return json
         } catch (error) {
             console.error("Error during sign-in:", error)
-            return { redirect: false, signInURL: "/" }
+            return { success: false, redirect: false, signInURL: "/" } as SignInReturn<Redirect>
         }
     }
 
-    const signOut = async (options?: SignOutOptions) => {
+    const signOut = async <Redirect extends boolean = true>(
+        options?: SignOutOptions<Redirect>
+    ): Promise<SignOutReturn<Redirect>> => {
         try {
             const csrfToken = await getCSRFToken()
             if (!csrfToken) {
@@ -93,19 +102,17 @@ export const createAuthClient = <DefaultUser extends User = User>(options: AuthC
                 },
             })
             const json = await response.json()
-            if ((options?.redirect ?? true) && typeof window !== "undefined" && json?.url) {
-                window.location.assign(json.url)
+            if ((options?.redirect ?? true) && typeof window !== "undefined" && json?.redirectURL) {
+                window.location.assign(json.redirectURL)
             }
             return json
         } catch (error) {
             console.error("Error during sign-out:", error)
-            throw isNativeError(error)
-                ? error
-                : new AuthClientError("Sign-out failed.", "The sign-out request failed.", { cause: error })
+            return { success: false, redirect: false, redirectURL: "/" } as SignOutReturn<Redirect>
         }
     }
 
-    const updateSession = async (session: UpdateSessionOptions<DefaultUser>) => {
+    const updateSession = async (session: UpdateSessionOptions<DefaultUser>): Promise<UpdateSessionReturn<DefaultUser>> => {
         try {
             const csrfToken = await getCSRFToken()
             if (!csrfToken) {
@@ -123,19 +130,20 @@ export const createAuthClient = <DefaultUser extends User = User>(options: AuthC
                 },
             })
             if (!response.ok) {
-                return { session: null, updated: false }
+                return { session: null, success: false }
             }
             const json = await response.json()
             return json
         } catch (error) {
             console.error("Error updating session:", error)
-            throw isNativeError(error)
-                ? error
-                : new AuthClientError("Session update failed.", "The session update request failed.", { cause: error })
+            return { success: false, session: null }
         }
     }
 
-    const signInCredentials = async (credentials: CredentialsPayload, options?: SignInOptions) => {
+    const signInCredentials = async (
+        credentials: CredentialsPayload,
+        options?: SignInOptions
+    ): Promise<SignInCredentialsReturn> => {
         try {
             const response = await client.post("/signIn/credentials", {
                 body: credentials,

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -83,7 +83,7 @@ export const createAuthClient = <DefaultUser extends User = User>(options: AuthC
             return json as unknown as SignInReturn<Redirect>
         } catch (error) {
             console.error("Error during sign-in:", error)
-            return { success: false, redirect: false, signInURL: "/" } as SignInReturn<Redirect>
+            return { success: false, redirect: false, signInURL: "/" } as unknown as SignInReturn<Redirect>
         }
     }
 
@@ -112,7 +112,7 @@ export const createAuthClient = <DefaultUser extends User = User>(options: AuthC
             return json as unknown as SignOutReturn<Redirect>
         } catch (error) {
             console.error("Error during sign-out:", error)
-            return { success: false, redirect: false, redirectURL: "/" } as SignOutReturn<Redirect>
+            return { success: false, redirect: false, redirectURL: "/" } as unknown as SignOutReturn<Redirect>
         }
     }
 
@@ -161,7 +161,7 @@ export const createAuthClient = <DefaultUser extends User = User>(options: AuthC
             return json
         } catch (error) {
             console.error("Error during credentials sign-in:", error)
-            return { success: false, redirectURL: null }
+            return { success: false, redirectURL: null } as unknown as SignInCredentialsReturn
         }
     }
 

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -15,6 +15,10 @@ import type {
     SignOutReturn,
     UpdateSessionReturn,
     SignInCredentialsReturn,
+    SignInAPIReturn,
+    SignOutAPIReturn,
+    SignInCredentialsAPIReturn,
+    UpdateSessionAPIReturn,
 } from "@/@types/index.ts"
 
 export type { AuthClientOptions }
@@ -37,8 +41,8 @@ export const createAuthClient = <DefaultUser extends User = User>(options: AuthC
         try {
             const response = await client.get("/csrfToken")
             if (!response.ok) return null
-            const data = await response.json()
-            return data.csrfToken
+            const data: { csrfToken?: string } = await response.json()
+            return data.csrfToken ?? null
         } catch (error) {
             console.error("Error fetching CSRF token:", error)
             return null
@@ -72,11 +76,11 @@ export const createAuthClient = <DefaultUser extends User = User>(options: AuthC
                     redirect: false,
                 },
             })
-            const json = await response.json()
+            const json = (await response.json()) as SignInAPIReturn
             if ((options?.redirect ?? true) && typeof window !== "undefined" && json?.signInURL) {
                 window.location.assign(json.signInURL)
             }
-            return json
+            return json as unknown as SignInReturn<Redirect>
         } catch (error) {
             console.error("Error during sign-in:", error)
             return { success: false, redirect: false, signInURL: "/" } as SignInReturn<Redirect>
@@ -101,11 +105,11 @@ export const createAuthClient = <DefaultUser extends User = User>(options: AuthC
                     "X-CSRF-Token": csrfToken,
                 },
             })
-            const json = await response.json()
+            const json: SignOutAPIReturn = await response.json()
             if ((options?.redirect ?? true) && typeof window !== "undefined" && json?.redirectURL) {
                 window.location.assign(json.redirectURL)
             }
-            return json
+            return json as unknown as SignOutReturn<Redirect>
         } catch (error) {
             console.error("Error during sign-out:", error)
             return { success: false, redirect: false, redirectURL: "/" } as SignOutReturn<Redirect>
@@ -118,12 +122,11 @@ export const createAuthClient = <DefaultUser extends User = User>(options: AuthC
             if (!csrfToken) {
                 throw new AuthClientError("Failed to fetch CSRF token for session update.")
             }
-            const { sub: _sub, ...spread } = (session.user ?? {}) as DefaultUser
+            const user = session.user ?? {}
             const response = await client.patch("/session", {
                 body: {
-                    /** @todo: Remove the `as any` cast once the session update endpoint is properly typed to accept partial session updates. */
-                    ...(spread as any),
-                    expires: session.expires,
+                    user,
+                    expires: session.expires ? new Date(session.expires) : undefined,
                 },
                 headers: {
                     "X-CSRF-Token": csrfToken,
@@ -132,7 +135,7 @@ export const createAuthClient = <DefaultUser extends User = User>(options: AuthC
             if (!response.ok) {
                 return { session: null, success: false }
             }
-            const json = await response.json()
+            const json: UpdateSessionAPIReturn<DefaultUser> = await response.json()
             return json
         } catch (error) {
             console.error("Error updating session:", error)
@@ -147,11 +150,13 @@ export const createAuthClient = <DefaultUser extends User = User>(options: AuthC
         try {
             const response = await client.post("/signIn/credentials", {
                 body: credentials,
-                searchParams: {},
+                searchParams: {
+                    redirectTo: options?.redirectTo,
+                },
             })
-            const json = await response.json()
-            if ((options?.redirect ?? true) && typeof window !== "undefined" && json?.signInURL) {
-                window.location.assign(json.signInURL)
+            const json: SignInCredentialsAPIReturn = await response.json()
+            if ((options?.redirect ?? true) && typeof window !== "undefined" && json?.redirectURL) {
+                window.location.assign(json.redirectURL)
             }
             return json
         } catch (error) {

--- a/packages/core/src/oauth/index.ts
+++ b/packages/core/src/oauth/index.ts
@@ -118,7 +118,9 @@ const defineOAuthProviderConfig = (config: BuiltInOAuthProvider | OAuthProviderC
  * // Using built-in provider with explicit credentials via factory
  * createBuiltInOAuthProviders([github({ clientId: "...", clientSecret: "..." })])
  */
-export const createBuiltInOAuthProviders = (oauth: (BuiltInOAuthProvider | OAuthProviderCredentials<any>)[] = []) => {
+export const createBuiltInOAuthProviders = (
+    oauth: (BuiltInOAuthProvider | OAuthProviderCredentials<any>)[] = []
+) => {
     return oauth.reduce((previous, config) => {
         const oauthConfig = defineOAuthProviderConfig(config)
         if (oauthConfig.id in previous) {

--- a/packages/core/src/oauth/index.ts
+++ b/packages/core/src/oauth/index.ts
@@ -118,9 +118,7 @@ const defineOAuthProviderConfig = (config: BuiltInOAuthProvider | OAuthProviderC
  * // Using built-in provider with explicit credentials via factory
  * createBuiltInOAuthProviders([github({ clientId: "...", clientSecret: "..." })])
  */
-export const createBuiltInOAuthProviders = (
-    oauth: (BuiltInOAuthProvider | OAuthProviderCredentials<any>)[] = []
-) => {
+export const createBuiltInOAuthProviders = (oauth: (BuiltInOAuthProvider | OAuthProviderCredentials<any>)[] = []) => {
     return oauth.reduce((previous, config) => {
         const oauthConfig = defineOAuthProviderConfig(config)
         if (oauthConfig.id in previous) {

--- a/packages/core/src/session/stateless.ts
+++ b/packages/core/src/session/stateless.ts
@@ -10,7 +10,7 @@ import type {
     User,
     TypedJWTPayload,
     JWTStrategyOptions,
-    GetSessionReturn,
+    GetStatelessSessionReturn,
     DeepPartial,
 } from "@/@types/index.ts"
 import { createSchemaRegistry } from "@/schema-registry.ts"
@@ -108,7 +108,7 @@ export const createStatelessStrategy = <DefaultUser extends User = User>({
         }
     }
 
-    const getSession = async (headers: Headers): Promise<GetSessionReturn<DefaultUser>> => {
+    const getSession = async (headers: Headers): Promise<GetStatelessSessionReturn<DefaultUser>> => {
         const newHeaders = new Headers()
         try {
             const { sessionToken } = cookieConfig.getCookie(headers)

--- a/packages/core/src/shared/utils.ts
+++ b/packages/core/src/shared/utils.ts
@@ -121,7 +121,11 @@ export const createBasicAuthHeader = (username: string, password: string): strin
 export const toUnionHeaders = (init: Headers, headers: HeadersInit): Headers => {
     new Headers(headers).forEach((value, key) => {
         if (!init.has(key)) {
-            init.set(key, value)
+            if (key.toLowerCase() === "set-cookie") {
+                init.append(key, value)
+            } else {
+                init.set(key, value)
+            }
         }
     })
     return init

--- a/packages/core/src/shared/utils.ts
+++ b/packages/core/src/shared/utils.ts
@@ -117,3 +117,12 @@ export const createBasicAuthHeader = (username: string, password: string): strin
     const binaryCredentials = String.fromCharCode.apply(null, Array.from(encoder.encode(credentials)))
     return `Basic ${btoa(binaryCredentials)}`
 }
+
+export const toUnionHeaders = (init: Headers, headers: HeadersInit): Headers => {
+    new Headers(headers).forEach((value, key) => {
+        if (!init.has(key)) {
+            init.set(key, value)
+        }
+    })
+    return init
+}

--- a/packages/core/test/actions/session/session.test.ts
+++ b/packages/core/test/actions/session/session.test.ts
@@ -20,7 +20,7 @@ describe("sessionAction", () => {
     test("sessionToken cookie not found", async () => {
         const request = await GET(new Request("https://example.com/auth/session"))
         expect(request.status).toBe(401)
-        expect(await request.json()).toEqual({ authenticated: false, session: null })
+        expect(await request.json()).toEqual({ success: false, session: null })
     })
 
     test("invalid sessionToken cookie", async () => {
@@ -32,7 +32,7 @@ describe("sessionAction", () => {
             })
         )
         expect(request.status).toBe(401)
-        expect(await request.json()).toEqual({ authenticated: false, session: null })
+        expect(await request.json()).toEqual({ success: false, session: null })
     })
 
     test("valid sessionToken cookie with correct version", async () => {
@@ -47,7 +47,7 @@ describe("sessionAction", () => {
         )
         expect(request.status).toBe(200)
         expect(await request.json()).toEqual({
-            authenticated: true,
+            success: true,
             session: { user: sessionPayload, expires: expect.any(String) },
         })
     })
@@ -64,7 +64,7 @@ describe("sessionAction", () => {
         )
         expect(request.status).toBe(200)
         expect(await request.json()).toEqual({
-            authenticated: true,
+            success: true,
             session: { user: sessionPayload, expires: expect.any(String) },
         })
     })
@@ -79,7 +79,7 @@ describe("sessionAction", () => {
             })
         )
         expect(request.status).toBe(401)
-        expect(await request.json()).toEqual({ authenticated: false, session: null })
+        expect(await request.json()).toEqual({ success: false, session: null })
     })
 
     test("verify cache control headers are set", async () => {
@@ -215,7 +215,7 @@ describe("sessionAction", () => {
         const session = await requestSession.json()
         const { id, name, image, email } = userInfoMock
         expect(session).toEqual({
-            authenticated: true,
+            success: true,
             session: {
                 user: { sub: id, name, image, email },
                 expires: expect.any(String),

--- a/packages/core/test/actions/signIn/signIn.test.ts
+++ b/packages/core/test/actions/signIn/signIn.test.ts
@@ -21,8 +21,9 @@ describe("signIn action", () => {
         const response = await GET(new Request("https://example.com/auth/signIn/oauth-provider?redirect=true"))
         expect(response.status).toBe(302)
         expect(await response.json()).toEqual({
+            success: true,
             redirect: true,
-            signInURL: expect.any(String),
+            signInURL: null,
         })
     })
 
@@ -30,6 +31,7 @@ describe("signIn action", () => {
         const signIn = await GET(new Request("https://example.com/auth/signIn/oauth-provider?redirect=false"))
         expect(signIn.status).toBe(200)
         expect(await signIn.json()).toEqual({
+            success: true,
             redirect: false,
             signInURL: expect.any(String),
         })

--- a/packages/core/test/actions/signIn/signIn.test.ts
+++ b/packages/core/test/actions/signIn/signIn.test.ts
@@ -23,7 +23,7 @@ describe("signIn action", () => {
         expect(await response.json()).toEqual({
             success: true,
             redirect: true,
-            signInURL: null,
+            signInURL: expect.any(String),
         })
     })
 

--- a/packages/core/test/actions/signOut/signOut.test.ts
+++ b/packages/core/test/actions/signOut/signOut.test.ts
@@ -83,7 +83,7 @@ describe("signOut action", async () => {
             })
         )
         expect(request.status).toBe(202)
-        expect(await request.json()).toEqual({ redirect: true, url: "/" })
+        expect(await request.json()).toEqual({ success: true, redirectURL: "/" })
         expect(request.headers.get("Set-Cookie")).toContain("__Secure-aura-auth.session_token=;")
         expect(request.headers.get("Set-Cookie")).toContain("__Host-aura-auth.csrf_token=;")
     })
@@ -101,7 +101,7 @@ describe("signOut action", async () => {
             })
         )
         expect(request.status).toBe(202)
-        expect(await request.json()).toEqual({ redirect: true, url: "/auth/form" })
+        expect(await request.json()).toEqual({ success: true, redirectURL: "/auth/form" })
         expect(request.headers.get("Set-Cookie")).toContain("__Secure-aura-auth.session_token=;")
         expect(request.headers.get("Set-Cookie")).toContain("__Host-aura-auth.csrf_token=;")
         expect(request.headers.get("Location")).toContain("/auth/form")
@@ -119,7 +119,7 @@ describe("signOut action", async () => {
             })
         )
         expect(request.status).toBe(202)
-        expect(await request.json()).toEqual({ redirect: true, url: "/" })
+        expect(await request.json()).toEqual({ success: true, redirectURL: "/" })
         expect(request.headers.get("Set-Cookie")).toContain("aura-auth.session_token=;")
         expect(request.headers.get("Set-Cookie")).toContain("aura-auth.csrf_token=;")
     })
@@ -153,8 +153,8 @@ describe("signOut action", async () => {
                 },
             })
         )
-        expect(request.status).toBe(202)
-        expect(await request.json()).toEqual({ redirect: true, url: "/custom-logout-page" })
+        expect(request.status).toBe(302)
+        expect(await request.json()).toEqual({ success: true, redirectURL: "/custom-logout-page" })
         expect(request.headers.get("Set-Cookie")).toContain("__Secure-aura-auth.session_token=;")
         expect(request.headers.get("Set-Cookie")).toContain("__Host-aura-auth.csrf_token=;")
         expect(request.headers.get("Location")).toBe("/custom-logout-page")
@@ -171,10 +171,10 @@ describe("signOut action", async () => {
                 },
             })
         )
-        expect(request.status).toBe(202)
+        expect(request.status).toBe(302)
         expect(await request.json()).toEqual({
-            redirect: true,
-            url: "/",
+            success: true,
+            redirectURL: "/",
         })
     })
 })

--- a/packages/core/test/actions/updateSession/updateSession.test.ts
+++ b/packages/core/test/actions/updateSession/updateSession.test.ts
@@ -13,8 +13,7 @@ describe("updateSession action", () => {
         expect(response.status).toBe(401)
         expect(await response.json()).toEqual({
             session: null,
-            headers: {},
-            updated: false,
+            success: false,
         })
     })
 
@@ -52,8 +51,7 @@ describe("updateSession action", () => {
                 },
                 expires: expect.any(String),
             },
-            headers: expect.any(Object),
-            updated: true,
+            success: true,
         })
     })
 
@@ -84,8 +82,7 @@ describe("updateSession action", () => {
         expect(response.status).toBe(401)
         expect(await response.json()).toEqual({
             session: null,
-            headers: {},
-            updated: false,
+            success: false,
         })
     })
 
@@ -126,8 +123,7 @@ describe("updateSession action", () => {
                     image: "https://example.com/alicesmith-avatar.jpg",
                 },
             }),
-            headers: expect.any(Object),
-            updated: true,
+            success: true,
         })
     })
 })

--- a/packages/core/test/api/getSession.test.ts
+++ b/packages/core/test/api/getSession.test.ts
@@ -9,7 +9,7 @@ describe("getSession", () => {
         expect(session).toMatchObject({
             session: null,
             headers: {},
-            authenticated: false,
+            success: false,
         })
     })
 
@@ -20,7 +20,7 @@ describe("getSession", () => {
         expect(session).toMatchObject({
             session: null,
             headers: {},
-            authenticated: false,
+            success: false,
         })
     })
 
@@ -56,7 +56,7 @@ describe("getSession", () => {
         expect(session).toMatchObject({
             session: null,
             headers: {},
-            authenticated: false,
+            success: false,
         })
     })
 
@@ -71,7 +71,7 @@ describe("getSession", () => {
         expect(session).toMatchObject({
             session: null,
             headers: {},
-            authenticated: false,
+            success: false,
         })
     })
 

--- a/packages/core/test/api/signIn.test.ts
+++ b/packages/core/test/api/signIn.test.ts
@@ -22,7 +22,8 @@ describe("signIn API", () => {
     test("signIn with BASE_URL", async () => {
         vi.stubEnv("BASE_URL", "https://example.com")
 
-        const response = await api.signIn("oauth-provider")
+        const signIn = await api.signIn("oauth-provider")
+        const response = signIn.toResponse()
         expect(response.status).toBe(302)
         const searchParams = new URL(response.headers.get("Location")!).searchParams
         expect(searchParams.get("redirect_uri")).toBe("https://example.com/auth/callback/oauth-provider")
@@ -33,7 +34,8 @@ describe("signIn API", () => {
             oauth: [oauthCustomService],
             baseURL: "https://example.com",
         }).api
-        const response = await api.signIn("oauth-provider")
+        const signIn = await api.signIn("oauth-provider")
+        const response = signIn.toResponse()
         expect(response.status).toBe(302)
         const searchParams = new URL(response.headers.get("Location")!).searchParams
         expect(searchParams.get("redirect_uri")).toBe("https://example.com/auth/callback/oauth-provider")
@@ -44,21 +46,23 @@ describe("signIn API", () => {
             oauth: [oauthCustomService],
             trustedProxyHeaders: true,
         }).api
-        const response = await api.signIn("oauth-provider", {
+        const signIn = await api.signIn("oauth-provider", {
             headers: {
                 "X-Forwarded-Proto": "https",
                 "X-Forwarded-Host": "example.com",
             },
         })
+        const response = signIn.toResponse()
         expect(response.status).toBe(302)
         const searchParams = new URL(response.headers.get("Location")!).searchParams
         expect(searchParams.get("redirect_uri")).toBe("https://example.com/auth/callback/oauth-provider")
     })
 
     test("signIn with Request object", async () => {
-        const response = await api.signIn("oauth-provider", {
+        const signIn = await api.signIn("oauth-provider", {
             request: new Request("https://example.com/auth/signIn/oauth-provider"),
         })
+        const response = signIn.toResponse()
         expect(response.status).toBe(302)
         const searchParams = new URL(response.headers.get("Location")!).searchParams
         expect(searchParams.get("redirect_uri")).toBe("https://example.com/auth/callback/oauth-provider")
@@ -77,23 +81,26 @@ describe("signIn API", () => {
         const response = await api.signIn("oauth-provider", {
             redirect: false,
         })
-        expect(response).toEqual({
+        expect(response).toMatchObject({
+            success: true,
             redirect: false,
             signInURL: expect.any(String),
+            toResponse: expect.any(Function),
         })
     })
 
     test("signIn with asResponse", async () => {
         vi.stubEnv("BASE_URL", "https://example.com")
-
-        const response = await api.signIn("oauth-provider", {
+        const signIn = await api.signIn("oauth-provider", {
             redirect: true,
         })
+        const response = signIn.toResponse()
         expect(response).toBeInstanceOf(Response)
         expect(response.status).toBe(302)
         expect(await response.json()).toEqual({
+            success: true,
             redirect: true,
-            signInURL: expect.any(String),
+            signInURL: null,
         })
         expect(getSetCookie(response, "aura-auth.state")).toBeDefined()
     })
@@ -101,7 +108,8 @@ describe("signIn API", () => {
     test("signIn with valid redirectTo", async () => {
         vi.stubEnv("BASE_URL", "https://example.com")
 
-        const response = await api.signIn("oauth-provider", { redirectTo: "/dashboard" })
+        const signIn = await api.signIn("oauth-provider", { redirectTo: "/dashboard" })
+        const response = signIn.toResponse()
         expect(response.status).toBe(302)
         expect(getSetCookie(response, "aura-auth.redirect_to")).toBe("/dashboard")
     })
@@ -109,7 +117,8 @@ describe("signIn API", () => {
     test("signIn with invalid redirectTo", async () => {
         vi.stubEnv("BASE_URL", "https://example.com")
 
-        const response = await api.signIn("oauth-provider", { redirectTo: "https://malicious.com" })
+        const signIn = await api.signIn("oauth-provider", { redirectTo: "https://malicious.com" })
+        const response = signIn.toResponse()
         expect(response.status).toBe(302)
         expect(getSetCookie(response, "aura-auth.redirect_to")).toBe("/")
     })

--- a/packages/core/test/api/signIn.test.ts
+++ b/packages/core/test/api/signIn.test.ts
@@ -100,7 +100,7 @@ describe("signIn API", () => {
         expect(await response.json()).toEqual({
             success: true,
             redirect: true,
-            signInURL: null,
+            signInURL: expect.any(String),
         })
         expect(getSetCookie(response, "aura-auth.state")).toBeDefined()
     })

--- a/packages/core/test/api/updateSession.test.ts
+++ b/packages/core/test/api/updateSession.test.ts
@@ -14,7 +14,8 @@ describe("updateSession API", () => {
         expect(updated).toEqual({
             session: null,
             headers: expect.any(Headers),
-            updated: false,
+            success: false,
+            toResponse: expect.any(Function),
         })
     })
 
@@ -51,7 +52,8 @@ describe("updateSession API", () => {
                 expires: expect.any(String),
             },
             headers: expect.any(Headers),
-            updated: true,
+            success: true,
+            toResponse: expect.any(Function),
         })
     })
 
@@ -89,7 +91,8 @@ describe("updateSession API", () => {
                 expires: expect.any(String),
             },
             headers: expect.any(Headers),
-            updated: true,
+            success: true,
+            toResponse: expect.any(Function),
         })
     })
 
@@ -135,8 +138,9 @@ describe("updateSession API", () => {
                 },
                 expires: expect.any(String),
             },
+            success: true,
             headers: expect.any(Headers),
-            updated: true,
+            toResponse: expect.any(Function),
         })
     })
 
@@ -173,7 +177,8 @@ describe("updateSession API", () => {
                 expires: expect.any(String),
             },
             headers: expect.any(Headers),
-            updated: true,
+            success: true,
+            toResponse: expect.any(Function),
         })
     })
 
@@ -203,8 +208,9 @@ describe("updateSession API", () => {
                 },
                 expires: expiresAt,
             },
+            success: true,
             headers: expect.any(Headers),
-            updated: true,
+            toResponse: expect.any(Function),
         })
     })
 })

--- a/packages/core/test/client/client.test.ts
+++ b/packages/core/test/client/client.test.ts
@@ -57,7 +57,7 @@ describe("createAuthClient", () => {
     test("getSession returns valid session", async () => {
         const get = vi.fn().mockResolvedValue(
             createJSONResponse({
-                authenticated: true,
+                success: true,
                 session: { user: { id: "user_1" } },
             })
         )
@@ -161,7 +161,7 @@ describe("createAuthClient", () => {
         })
 
         const client = createAuthClient({ baseURL: "https://example.com" })
-        await expect(client.signOut()).rejects.toThrow()
+        expect(await client.signOut()).toMatchObject({ success: false, redirect: false, redirectURL: "/" })
         expect(post).not.toHaveBeenCalled()
     })
 })

--- a/packages/core/test/session/stateless.test.ts
+++ b/packages/core/test/session/stateless.test.ts
@@ -35,7 +35,7 @@ describe("Stateless Strategy (Integration)", () => {
             const body = await res.json()
 
             expect(res.status).toBe(200)
-            expect(body.authenticated).toBe(true)
+            expect(body.success).toBe(true)
 
             const expectedExp = new Date(new Date("2026-03-24T00:00:00Z").getTime() + 15 * 24 * 60 * 60 * 1000).toISOString()
             expect(body.session.expires).toBe(expectedExp)
@@ -155,7 +155,7 @@ describe("Stateless Strategy (Integration)", () => {
             let body = await res.json()
 
             expect(res.status).toBe(401)
-            expect(body.authenticated).toBe(false)
+            expect(body.success).toBe(false)
             expect(body.session).toBeNull()
         })
     })

--- a/packages/core/test/types.test-d.ts
+++ b/packages/core/test/types.test-d.ts
@@ -8,7 +8,7 @@ import type {
     GetSessionAPIOptions,
     SessionReturn,
     UpdateSessionAPIOptions,
-    UpdateSessionReturn,
+    UpdateSessionAPIReturn,
     UserShape,
 } from "@/@types/session.ts"
 import type { AuthConfig, AuthInstance, User } from "@/index.ts"
@@ -23,7 +23,7 @@ describe("createAuth", () => {
         (options: GetSessionAPIOptions) => Promise<SessionReturn<ShapeToObject<UserShape>>>
     >()
     expectTypeOf(createAuth({ oauth: [] }).api.updateSession).toEqualTypeOf<
-        (options: UpdateSessionAPIOptions<User>) => Promise<UpdateSessionReturn<ShapeToObject<UserShape>>>
+        (options: UpdateSessionAPIOptions<User>) => Promise<UpdateSessionAPIReturn<ShapeToObject<UserShape>>>
     >()
 
     expectTypeOf(createAuth({ oauth: [] }).jose.signJWS).toEqualTypeOf<
@@ -70,7 +70,7 @@ describe("createAuth", () => {
     ).toEqualTypeOf<
         (
             options: UpdateSessionAPIOptions<ShapeToObject<UserShape & { role: ZodString }>>
-        ) => Promise<UpdateSessionReturn<ShapeToObject<UserShape & { role: ZodString }>>>
+        ) => Promise<UpdateSessionAPIReturn<ShapeToObject<UserShape & { role: ZodString }>>>
     >()
 })
 

--- a/packages/core/test/types.test-d.ts
+++ b/packages/core/test/types.test-d.ts
@@ -6,7 +6,7 @@ import { github, type GitHubProfile } from "@/oauth/github.ts"
 import { JWTHeaderParameters, JWTVerifyOptions, TypedJWTPayload } from "@aura-stack/jose"
 import type {
     GetSessionAPIOptions,
-    SessionResponse,
+    SessionReturn,
     UpdateSessionAPIOptions,
     UpdateSessionReturn,
     UserShape,
@@ -20,7 +20,7 @@ describe("createAuth", () => {
         <Identity extends EditableShape<UserShape>>(config: AuthConfig<Identity>) => AuthInstance<ShapeToObject<Identity>>
     >()
     expectTypeOf(createAuth({ oauth: [] }).api.getSession).toEqualTypeOf<
-        (options: GetSessionAPIOptions) => Promise<SessionResponse<ShapeToObject<UserShape>>>
+        (options: GetSessionAPIOptions) => Promise<SessionReturn<ShapeToObject<UserShape>>>
     >()
     expectTypeOf(createAuth({ oauth: [] }).api.updateSession).toEqualTypeOf<
         (options: UpdateSessionAPIOptions<User>) => Promise<UpdateSessionReturn<ShapeToObject<UserShape>>>
@@ -64,7 +64,7 @@ describe("createAuth", () => {
 
     expectTypeOf(
         createAuth({ oauth: [], identity: { schema: UserIdentity.extend({ role: z.string() }) } }).api.getSession
-    ).toEqualTypeOf<(options: GetSessionAPIOptions) => Promise<SessionResponse<ShapeToObject<UserShape & { role: ZodString }>>>>()
+    ).toEqualTypeOf<(options: GetSessionAPIOptions) => Promise<SessionReturn<ShapeToObject<UserShape & { role: ZodString }>>>>()
     expectTypeOf(
         createAuth({ oauth: [], identity: { schema: UserIdentity.extend({ role: z.string() }) } }).api.updateSession
     ).toEqualTypeOf<

--- a/packages/core/test/types.test-d.ts
+++ b/packages/core/test/types.test-d.ts
@@ -3,10 +3,9 @@ import { z, ZodString } from "zod/v4"
 import { createAuth } from "@/createAuth.ts"
 import { UserIdentity } from "@/shared/identity.ts"
 import { github, type GitHubProfile } from "@/oauth/github.ts"
-import { JWTHeaderParameters, JWTVerifyOptions, TypedJWTPayload } from "@aura-stack/jose"
 import type {
     GetSessionAPIOptions,
-    SessionReturn,
+    GetSessionAPIReturn,
     UpdateSessionAPIOptions,
     UpdateSessionAPIReturn,
     UserShape,
@@ -14,13 +13,14 @@ import type {
 import type { AuthConfig, AuthInstance, User } from "@/index.ts"
 import type { OAuthProviderCredentials } from "@/@types/oauth.ts"
 import type { EditableShape, ShapeToObject } from "@/@types/utility.ts"
+import type { JWTHeaderParameters, JWTVerifyOptions, TypedJWTPayload } from "@aura-stack/jose"
 
 describe("createAuth", () => {
     expectTypeOf(createAuth).toEqualTypeOf<
         <Identity extends EditableShape<UserShape>>(config: AuthConfig<Identity>) => AuthInstance<ShapeToObject<Identity>>
     >()
     expectTypeOf(createAuth({ oauth: [] }).api.getSession).toEqualTypeOf<
-        (options: GetSessionAPIOptions) => Promise<SessionReturn<ShapeToObject<UserShape>>>
+        (options: GetSessionAPIOptions) => Promise<GetSessionAPIReturn<ShapeToObject<UserShape>>>
     >()
     expectTypeOf(createAuth({ oauth: [] }).api.updateSession).toEqualTypeOf<
         (options: UpdateSessionAPIOptions<User>) => Promise<UpdateSessionAPIReturn<ShapeToObject<UserShape>>>
@@ -64,7 +64,9 @@ describe("createAuth", () => {
 
     expectTypeOf(
         createAuth({ oauth: [], identity: { schema: UserIdentity.extend({ role: z.string() }) } }).api.getSession
-    ).toEqualTypeOf<(options: GetSessionAPIOptions) => Promise<SessionReturn<ShapeToObject<UserShape & { role: ZodString }>>>>()
+    ).toEqualTypeOf<
+        (options: GetSessionAPIOptions) => Promise<GetSessionAPIReturn<ShapeToObject<UserShape & { role: ZodString }>>>
+    >()
     expectTypeOf(
         createAuth({ oauth: [], identity: { schema: UserIdentity.extend({ role: z.string() }) } }).api.updateSession
     ).toEqualTypeOf<

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -2,14 +2,12 @@ import crypto from "crypto"
 import path from "path"
 import { defineConfig } from "vitest/config"
 
-const SECRET_KEY = crypto.randomBytes(32).toString("base64url")
-const SALT_KEY = crypto.randomBytes(32).toString("base64url")
+const SECRET_KEY = crypto.randomBytes(34).toString("base64url")
+const SALT_KEY = crypto.randomBytes(34).toString("base64url")
 
 export default defineConfig({
     test: {
         include: ["test/**/*.test.ts"],
-        // @todo: TODO(`#119`): Temporary exclusion - re-enable after fixing Zod v4 compatibility
-        exclude: ["test/actions/signIn/signIn.test.ts"],
         coverage: {
             provider: "v8",
             enabled: true,

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -72,7 +72,8 @@
   "devDependencies": {
     "@aura-stack/tsconfig": "workspace:*",
     "@aura-stack/tsup-config": "workspace:*",
-    "elysia": "^1.2.22"
+    "elysia": "^1.2.22",
+    "vitest": "catalog:vitest"
   },
   "peerDependencies": {
     "elysia": ">=1.0.0"

--- a/packages/elysia/src/lib/with-auth.ts
+++ b/packages/elysia/src/lib/with-auth.ts
@@ -14,10 +14,10 @@ export type WithAuthContext<DefaultUser extends User = User> = {
 export const withAuth = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
     return async ({ request }: { request: Request }): Promise<WithAuthContext<DefaultUser>> => {
         try {
-            const { session, authenticated } = await api.getSession({
+            const { session, success } = await api.getSession({
                 headers: request.headers,
             })
-            return { session: authenticated ? session : null }
+            return { session: success ? session : null }
         } catch {
             return { session: null }
         }

--- a/packages/elysia/test/index.test.ts
+++ b/packages/elysia/test/index.test.ts
@@ -15,7 +15,7 @@ describe("GET /api/auth/session", () => {
         expect(res.status).toBe(401)
         const body = await res.json()
         expect(body).toMatchObject({
-            authenticated: false,
+            success: false,
             session: null,
         })
     })

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -70,7 +70,8 @@
     "@types/supertest": "^6.0.3",
     "supertest": "^7.2.2",
     "express": "catalog:express",
-    "@types/express": "catalog:express"
+    "@types/express": "catalog:express",
+    "vitest": "catalog:vitest"
   },
   "peerDependencies": {
     "express": ">=4.0.0"

--- a/packages/express/test/index.test.ts
+++ b/packages/express/test/index.test.ts
@@ -16,7 +16,7 @@ describe("GET /api/auth/session", () => {
         const response = await supertest(app).get("/api/auth/session")
         expect(response.status).toBe(401)
         expect(response.body).toMatchObject({
-            authenticated: false,
+            success: false,
             session: null,
         })
     })
@@ -115,8 +115,7 @@ describe("PATCH /api/auth/session", () => {
         expect(response.status).toBe(401)
         expect(response.body).toMatchObject({
             session: null,
-            headers: {},
-            updated: false,
+            success: false,
         })
     })
 })

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -68,7 +68,8 @@
     "@aura-stack/tsconfig": "workspace:*",
     "@aura-stack/tsup-config": "workspace:*",
     "hono": "catalog:hono",
-    "@types/bun": "catalog:bun"
+    "@types/bun": "catalog:bun",
+    "vitest": "catalog:vitest"
   },
   "peerDependencies": {
     "hono": ">=4.0.0"

--- a/packages/hono/test/index.test.ts
+++ b/packages/hono/test/index.test.ts
@@ -15,7 +15,7 @@ describe("GET /api/auth/session", () => {
         expect(res.status).toBe(401)
         const body = await res.json()
         expect(body).toMatchObject({
-            authenticated: false,
+            success: false,
             session: null,
         })
     })

--- a/packages/jose/package.json
+++ b/packages/jose/package.json
@@ -79,6 +79,7 @@
   "devDependencies": {
     "@aura-stack/tsconfig": "workspace:*",
     "@aura-stack/tsup-config": "workspace:*",
-    "typescript": "catalog:typescript"
+    "typescript": "catalog:typescript",
+    "vitest": "catalog:vitest"
   }
 }

--- a/packages/next/src/@types/api.ts
+++ b/packages/next/src/@types/api.ts
@@ -1,0 +1,34 @@
+/**
+ * Next.js App Router integration types for the helpers returned by `createAuth` from `@aura-stack/next`.
+ *
+ * These conditional types describe return values when `redirect()` is used (which never returns in Next.js).
+ */
+import type {
+    SignInAPIOptions,
+    SignInAPIReturn,
+    SignInCredentialsAPIReturn,
+    SignOutAPIOptions,
+    SignOutAPIReturn,
+} from "@aura-stack/react/types"
+
+/**
+ * Return type for the Next.js server `api.signIn` helper (see `packages/next/src/lib/api.ts`).
+ * When `Options` includes `redirect: true`, the helper calls `redirect()` and the type is `never` because execution does not continue.
+ */
+export type NextSignInReturn<Options extends SignInAPIOptions> = Options extends { redirect: true } ? never : SignInAPIReturn
+
+/**
+ * Return type for the Next.js server `api.signInCredentials` helper.
+ * Same `never` rule as {@link NextSignInReturn} when a server redirect is triggered via options.
+ */
+export type NextSignInCredentials<Options extends SignInAPIOptions> = Options extends { redirect: true }
+    ? never
+    : SignInCredentialsAPIReturn
+
+/**
+ * Return type for the Next.js server `api.signOut` helper.
+ * When `Options` includes a `redirectTo` string and the core API performs a redirect response, Next’s `redirect()` is invoked and the type is `never`.
+ */
+export type NextSignOutReturn<Options extends SignOutAPIOptions> = Options extends { redirectTo: string }
+    ? never
+    : SignOutAPIReturn

--- a/packages/next/src/@types/core.ts
+++ b/packages/next/src/@types/core.ts
@@ -1,1 +1,2 @@
+/** Re-exports `@aura-stack/react/types` so consumers can import everything from `@aura-stack/next/types`. */
 export type * from "@aura-stack/react/types"

--- a/packages/next/src/@types/index.ts
+++ b/packages/next/src/@types/index.ts
@@ -1,1 +1,3 @@
+/** Public type surface for `@aura-stack/next` (re-exports React/auth types plus Next-specific helpers). */
 export type * from "@/@types/core"
+export type * from "@/@types/api"

--- a/packages/next/src/lib/api.ts
+++ b/packages/next/src/lib/api.ts
@@ -31,7 +31,8 @@ export const getSession = <DefaultUser extends User = User>({ api }: AuthInstanc
                 headers: await headers(),
                 ...options,
             })
-            if (!session.authenticated) {
+            console.log("getSession - Retrieved session:", session)
+            if (!session.success) {
                 return null
             }
             return session.session

--- a/packages/next/src/lib/api.ts
+++ b/packages/next/src/lib/api.ts
@@ -9,6 +9,7 @@ import type {
     DeepPartial,
     LiteralUnion,
     BuiltInOAuthProvider,
+    SignOutReturn,
 } from "@aura-stack/react/types"
 
 /**
@@ -60,7 +61,6 @@ export const signInCredentials = <DefaultUser extends User = User>({ api }: Auth
             payload,
             headers: await headers(),
             ...options,
-            redirect: false,
         })
         await applyCookies(result.headers)
         if (options.redirect && result.success && result.redirectURL) {
@@ -85,15 +85,19 @@ export const updateSession = <DefaultUser extends User = User>({ api }: AuthInst
 
 export const signOut = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
     return async (options?: SignOutAPIOptions) => {
-        const response = await api.signOut({
+        const {
+            headers: headersInit,
+            success,
+            redirectURL,
+        } = await api.signOut({
             headers: await headers(),
             ...options,
         })
-        await applyCookies(response.headers)
-        if (response.status === 202) {
-            redirect(options?.redirectTo ?? "/")
+        await applyCookies(headersInit)
+        if (success && redirectURL) {
+            redirect(redirectURL)
         }
-        return response.json()
+        return { success, redirectURL }
     }
 }
 

--- a/packages/next/src/lib/api.ts
+++ b/packages/next/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation"
 import { cookies, headers } from "next/headers"
 import type { AuthInstance, Session, User } from "@aura-stack/react"
+import type { NextSignInCredentials, NextSignInReturn, NextSignOutReturn } from "@/@types/api"
 import type {
     GetSessionAPIOptions,
     SignInAPIOptions,
@@ -10,7 +11,7 @@ import type {
     LiteralUnion,
     BuiltInOAuthProvider,
     SignInCredentialsAPIOptions,
-    SignInAPIReturn,
+    UpdateSessionAPIReturn,
 } from "@aura-stack/react/types"
 
 /**
@@ -45,21 +46,27 @@ export const getSession = <DefaultUser extends User = User>({ api }: AuthInstanc
 }
 
 export const signIn = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async (provider: LiteralUnion<BuiltInOAuthProvider>, options?: SignInAPIOptions): Promise<SignInAPIReturn> => {
+    return async <Options extends SignInAPIOptions>(
+        provider: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Options
+    ): Promise<NextSignInReturn<Options>> => {
         const signIn = await api.signIn(provider, {
             headers: await headers(),
             ...options,
             redirect: false,
         })
         if (options?.redirect) {
-            return redirect(signIn.signInURL)
+            return redirect(signIn.signInURL) as NextSignInReturn<Options>
         }
-        return signIn as SignInAPIReturn
+        return signIn as NextSignInReturn<Options>
     }
 }
 
 export const signInCredentials = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async (payload: CredentialsPayload, options: SignInCredentialsAPIOptions) => {
+    return async <O extends SignInCredentialsAPIOptions>(
+        payload: CredentialsPayload,
+        options: SignInCredentialsAPIOptions
+    ): Promise<NextSignInCredentials<O>> => {
         const signIn = await api.signInCredentials({
             headers: await headers(),
             ...options,
@@ -69,12 +76,15 @@ export const signInCredentials = <DefaultUser extends User = User>({ api }: Auth
         if (signIn.success && options.redirectTo) {
             redirect(signIn.redirectURL)
         }
-        return signIn
+        return signIn as NextSignInCredentials<O>
     }
 }
 
 export const updateSession = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async (session: DeepPartial<Session<DefaultUser>>, options?: GetSessionAPIOptions) => {
+    return async (
+        session: DeepPartial<Session<DefaultUser>>,
+        options?: GetSessionAPIOptions
+    ): Promise<UpdateSessionAPIReturn<DefaultUser>> => {
         const updated = await api.updateSession({
             session,
             headers: await headers(),
@@ -87,20 +97,16 @@ export const updateSession = <DefaultUser extends User = User>({ api }: AuthInst
 }
 
 export const signOut = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async (options?: SignOutAPIOptions) => {
-        const {
-            headers: headersInit,
-            success,
-            redirectURL,
-        } = await api.signOut({
+    return async <Options extends SignOutAPIOptions>(options?: Options): Promise<NextSignOutReturn<Options>> => {
+        const out = await api.signOut({
             headers: await headers(),
             ...options,
         })
-        await applyCookies(headersInit)
-        if (success && redirectURL) {
-            redirect(redirectURL)
+        await applyCookies(out.headers)
+        if (out.success && out.redirectURL) {
+            redirect(out.redirectURL)
         }
-        return { success, redirectURL }
+        return out as NextSignOutReturn<Options>
     }
 }
 

--- a/packages/next/src/lib/api.ts
+++ b/packages/next/src/lib/api.ts
@@ -9,7 +9,8 @@ import type {
     DeepPartial,
     LiteralUnion,
     BuiltInOAuthProvider,
-    SignOutReturn,
+    SignInCredentialsAPIOptions,
+    SignInAPIReturn,
 } from "@aura-stack/react/types"
 
 /**
@@ -32,7 +33,6 @@ export const getSession = <DefaultUser extends User = User>({ api }: AuthInstanc
                 headers: await headers(),
                 ...options,
             })
-            console.log("getSession - Retrieved session:", session)
             if (!session.success) {
                 return null
             }
@@ -45,41 +45,44 @@ export const getSession = <DefaultUser extends User = User>({ api }: AuthInstanc
 }
 
 export const signIn = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async (provider: LiteralUnion<BuiltInOAuthProvider>, options?: SignInAPIOptions) => {
+    return async (provider: LiteralUnion<BuiltInOAuthProvider>, options?: SignInAPIOptions): Promise<SignInAPIReturn> => {
         const signIn = await api.signIn(provider, {
             headers: await headers(),
             ...options,
             redirect: false,
         })
-        return redirect(signIn.signInURL)
+        if (options?.redirect) {
+            return redirect(signIn.signInURL)
+        }
+        return signIn as SignInAPIReturn
     }
 }
 
 export const signInCredentials = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async (payload: CredentialsPayload, options: SignInAPIOptions) => {
-        const result = await api.signInCredentials({
-            payload,
+    return async (payload: CredentialsPayload, options: SignInCredentialsAPIOptions) => {
+        const signIn = await api.signInCredentials({
             headers: await headers(),
             ...options,
+            payload,
         })
-        await applyCookies(result.headers)
-        if (options.redirect && result.success && result.redirectURL) {
-            return redirect(result.redirectURL)
+        await applyCookies(signIn.headers)
+        if (signIn.success && options.redirectTo) {
+            redirect(signIn.redirectURL)
         }
-        return result
+        return signIn
     }
 }
 
 export const updateSession = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
     return async (session: DeepPartial<Session<DefaultUser>>, options?: GetSessionAPIOptions) => {
-        const result = await api.updateSession({
+        const updated = await api.updateSession({
             session,
             headers: await headers(),
             skipCSRFCheck: true,
             ...options,
         })
-        await applyCookies(result.headers)
-        return result
+        await applyCookies(updated.headers)
+        return updated
     }
 }
 

--- a/packages/rate-limiter/package.json
+++ b/packages/rate-limiter/package.json
@@ -54,7 +54,8 @@
   "license": "MIT",
   "devDependencies": {
     "@aura-stack/tsconfig": "workspace:*",
-    "@aura-stack/tsup-config": "workspace:*"
+    "@aura-stack/tsup-config": "workspace:*",
+    "vitest": "catalog:vitest"
   },
   "packageManager": "pnpm@10.15.0"
 }

--- a/packages/react-router/src/@types/core.ts
+++ b/packages/react-router/src/@types/core.ts
@@ -1,1 +1,2 @@
+/** Re-exports `@aura-stack/react/types` for `@aura-stack/react-router` consumers. */
 export type * from "@aura-stack/react/types"

--- a/packages/react-router/src/@types/index.ts
+++ b/packages/react-router/src/@types/index.ts
@@ -1,15 +1,47 @@
-import type { Prettify, SignInAPIOptions, SignInAPIReturn, SignInCredentialsAPIReturn, SignOutAPIOptions } from "@/@types/core"
+/**
+ * React Router (framework) integration types: options include the current `Request`, and result types
+ * distinguish JSON API results from full `Response` objects when returning from loaders/actions.
+ */
+import type {
+    Prettify,
+    SignInAPIOptions,
+    SignInAPIReturn,
+    SignInCredentialsAPIOptions,
+    SignInCredentialsAPIReturn,
+    SignOutAPIOptions,
+} from "@/@types/core"
 
 export type * from "./core"
 
+/** Core `signIn` options plus the incoming `Request` (required in React Router data APIs). */
 export type ReactRouterSignInAPIOptions = Prettify<SignInAPIOptions & { request: Request }>
 
-export type ReactRouterSignInCredentialsAPIOptions = Prettify<SignInAPIOptions & { request: Request }>
+/** Credentials sign-in options plus `request` and an optional `redirect` flag matching the server helper behavior. */
+export type ReactRouterSignInCredentialsAPIOptions = Prettify<
+    SignInCredentialsAPIOptions & {
+        request: Request
+        redirect?: boolean
+    }
+>
 
+/** Sign-out options plus the incoming `Request` for cookie and CSRF handling. */
 export type ReactRouterSignOutAPIOptions = Prettify<SignOutAPIOptions & { request: Request }>
 
-export type ReactRouterSignInAPIReturn<Redirect extends boolean = true> = Redirect extends true ? Response : SignInAPIReturn
+/**
+ * Result of the React Router `api.signIn` helper: the JSON API object when `redirect: false`,
+ * otherwise the `Response` from `toResponse()` (redirect / navigation response).
+ */
+export type ReactRouterSignInReturn<Options extends ReactRouterSignInAPIOptions> = Options extends {
+    redirect: false
+}
+    ? SignInAPIReturn
+    : Response
 
-export type ReactRouterSignInCredentialsAPIReturn<Redirect extends boolean = true> = Redirect extends true
-    ? Response
-    : SignInCredentialsAPIReturn
+/**
+ * Result of the React Router `api.signInCredentials` helper: same discriminant as {@link ReactRouterSignInReturn}.
+ */
+export type ReactRouterSignInCredentialsReturn<Options extends ReactRouterSignInCredentialsAPIOptions> = Options extends {
+    redirect: false
+}
+    ? SignInCredentialsAPIReturn
+    : Response

--- a/packages/react-router/src/@types/index.ts
+++ b/packages/react-router/src/@types/index.ts
@@ -1,1 +1,15 @@
+import type { Prettify, SignInAPIOptions, SignInAPIReturn, SignInCredentialsAPIReturn, SignOutAPIOptions } from "@/@types/core"
+
 export type * from "./core"
+
+export type ReactRouterSignInAPIOptions = Prettify<SignInAPIOptions & { request: Request }>
+
+export type ReactRouterSignInCredentialsAPIOptions = Prettify<SignInAPIOptions & { request: Request }>
+
+export type ReactRouterSignOutAPIOptions = Prettify<SignOutAPIOptions & { request: Request }>
+
+export type ReactRouterSignInAPIReturn<Redirect extends boolean = true> = Redirect extends true ? Response : SignInAPIReturn
+
+export type ReactRouterSignInCredentialsAPIReturn<Redirect extends boolean = true> = Redirect extends true
+    ? Response
+    : SignInCredentialsAPIReturn

--- a/packages/react-router/src/lib/api.ts
+++ b/packages/react-router/src/lib/api.ts
@@ -1,9 +1,9 @@
 import { redirect } from "react-router"
 import type {
     ReactRouterSignInAPIOptions,
-    ReactRouterSignInAPIReturn,
     ReactRouterSignInCredentialsAPIOptions,
-    ReactRouterSignInCredentialsAPIReturn,
+    ReactRouterSignInCredentialsReturn,
+    ReactRouterSignInReturn,
     ReactRouterSignOutAPIOptions,
 } from "@/@types"
 import type { AuthInstance, Session, User } from "@aura-stack/react"
@@ -33,31 +33,31 @@ export const getSession = <DefaultUser extends User = User>({ api }: AuthInstanc
 }
 
 export const signIn = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async <Redirect extends boolean = true>(
+    return async <Options extends ReactRouterSignInAPIOptions>(
         providerId: LiteralUnion<BuiltInOAuthProvider>,
-        options?: ReactRouterSignInAPIOptions
-    ): Promise<ReactRouterSignInAPIReturn<Redirect>> => {
+        options?: Options
+    ): Promise<ReactRouterSignInReturn<Options>> => {
         const signIn = await api.signIn(providerId, options)
-        if (options?.redirect ?? true) {
-            return signIn.toResponse() as ReactRouterSignInAPIReturn<Redirect>
+        if (options?.redirect === false) {
+            return signIn as ReactRouterSignInReturn<Options>
         }
-        return signIn as unknown as ReactRouterSignInAPIReturn<Redirect>
+        return signIn.toResponse() as ReactRouterSignInReturn<Options>
     }
 }
 
 export const signInCredentials = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async <Redirect extends boolean = true>(
+    return async <Options extends ReactRouterSignInCredentialsAPIOptions>(
         payload: CredentialsPayload,
-        options?: ReactRouterSignInCredentialsAPIOptions
-    ): Promise<ReactRouterSignInCredentialsAPIReturn<Redirect>> => {
-        const signIn = await api.signInCredentials({
+        options?: Options
+    ): Promise<ReactRouterSignInCredentialsReturn<Options>> => {
+        const result = await api.signInCredentials({
             payload,
             ...options,
         })
-        if (options?.redirect ?? true) {
-            return signIn.toResponse() as ReactRouterSignInCredentialsAPIReturn<Redirect>
+        if (options?.redirect === false) {
+            return result as ReactRouterSignInCredentialsReturn<Options>
         }
-        return signIn as unknown as ReactRouterSignInCredentialsAPIReturn<Redirect>
+        return result.toResponse() as ReactRouterSignInCredentialsReturn<Options>
     }
 }
 

--- a/packages/react-router/src/lib/api.ts
+++ b/packages/react-router/src/lib/api.ts
@@ -2,9 +2,13 @@ import type { AuthInstance, Session, User } from "@aura-stack/react"
 import type {
     BuiltInOAuthProvider,
     CredentialsPayload,
+    GetSessionAPIOptions,
     GetSessionOptions,
     LiteralUnion,
     Prettify,
+    SignInAPIOptions,
+    SignInAPIReturn,
+    SignInCredentialsAPIReturn,
     SignInOptions,
     SignOutOptions,
     UpdateSessionOptions,
@@ -12,7 +16,7 @@ import type {
 import { data, redirect } from "react-router"
 
 export const getSession = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async (options: GetSessionOptions): Promise<Session<DefaultUser> | null> => {
+    return async (options: GetSessionAPIOptions): Promise<Session<DefaultUser> | null> => {
         try {
             const session = await api.getSession(options)
             if (!session.success) {
@@ -27,24 +31,33 @@ export const getSession = <DefaultUser extends User = User>({ api }: AuthInstanc
 }
 
 export const signIn = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async (providerId: LiteralUnion<BuiltInOAuthProvider>, options?: Prettify<SignInOptions & { request: Request }>) => {
+    return async <Redirect extends boolean = true>(
+        providerId: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Prettify<SignInAPIOptions<Redirect> & { request: Request }>
+    ): Promise<SignInAPIReturn<Redirect>> => {
         return await api.signIn(providerId, options)
     }
 }
 
+export type SignInCredentialsReturn<Redirect extends boolean = true> = Redirect extends true
+    ? Response
+    : SignInCredentialsAPIReturn
+
 export const signInCredentials = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async (payload: CredentialsPayload, options?: Prettify<SignInOptions & { request: Request }>) => {
+    return async <Redirect extends boolean = true>(
+        payload: CredentialsPayload,
+        options?: Prettify<SignInOptions & { request: Request }>
+    ): Promise<SignInCredentialsReturn<Redirect>> => {
         const signIn = await api.signInCredentials({
             payload,
             ...options,
-            redirect: false,
         })
         if (signIn.success) {
             return redirect(signIn.redirectURL, {
                 headers: signIn.headers,
-            })
+            }) as SignInCredentialsReturn<Redirect>
         }
-        return signIn
+        return signIn as SignInCredentialsReturn<Redirect>
     }
 }
 
@@ -54,29 +67,22 @@ export const updateSession = <DefaultUser extends User = User>({ api }: AuthInst
             session,
             headers: options.headers,
         })
-        if (updated.updated) {
-            return data(updated, {
-                headers: updated.headers,
-            })
-        }
-        return updated
+
+        return data(updated, {
+            headers: updated.headers,
+        })
     }
 }
 
 export const signOut = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
     return async (options: Prettify<SignOutOptions & { headers: HeadersInit }>) => {
-        const response = await api.signOut({
+        const out = await api.signOut({
             headers: options.headers,
             redirectTo: options?.redirectTo,
         })
-        const json = await response.json()
-        if (response.ok) {
-            return data(json, {
-                headers: response.headers,
-                status: response.status,
-            })
-        }
-        return json
+        return data(out, {
+            headers: out.headers,
+        })
     }
 }
 

--- a/packages/react-router/src/lib/api.ts
+++ b/packages/react-router/src/lib/api.ts
@@ -15,7 +15,7 @@ export const getSession = <DefaultUser extends User = User>({ api }: AuthInstanc
     return async (options: GetSessionOptions): Promise<Session<DefaultUser> | null> => {
         try {
             const session = await api.getSession(options)
-            if (!session.authenticated) {
+            if (!session.success) {
                 return null
             }
             return session.session

--- a/packages/react-router/src/lib/api.ts
+++ b/packages/react-router/src/lib/api.ts
@@ -1,3 +1,11 @@
+import { redirect } from "react-router"
+import type {
+    ReactRouterSignInAPIOptions,
+    ReactRouterSignInAPIReturn,
+    ReactRouterSignInCredentialsAPIOptions,
+    ReactRouterSignInCredentialsAPIReturn,
+    ReactRouterSignOutAPIOptions,
+} from "@/@types"
 import type { AuthInstance, Session, User } from "@aura-stack/react"
 import type {
     BuiltInOAuthProvider,
@@ -5,15 +13,9 @@ import type {
     GetSessionAPIOptions,
     GetSessionOptions,
     LiteralUnion,
-    Prettify,
-    SignInAPIOptions,
-    SignInAPIReturn,
-    SignInCredentialsAPIReturn,
-    SignInOptions,
-    SignOutOptions,
+    UpdateSessionAPIReturn,
     UpdateSessionOptions,
 } from "@aura-stack/react/types"
-import { data, redirect } from "react-router"
 
 export const getSession = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
     return async (options: GetSessionAPIOptions): Promise<Session<DefaultUser> | null> => {
@@ -33,56 +35,53 @@ export const getSession = <DefaultUser extends User = User>({ api }: AuthInstanc
 export const signIn = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
     return async <Redirect extends boolean = true>(
         providerId: LiteralUnion<BuiltInOAuthProvider>,
-        options?: Prettify<SignInAPIOptions<Redirect> & { request: Request }>
-    ): Promise<SignInAPIReturn<Redirect>> => {
-        return await api.signIn(providerId, options)
+        options?: ReactRouterSignInAPIOptions
+    ): Promise<ReactRouterSignInAPIReturn<Redirect>> => {
+        const signIn = await api.signIn(providerId, options)
+        if (options?.redirect ?? true) {
+            return signIn.toResponse() as ReactRouterSignInAPIReturn<Redirect>
+        }
+        return signIn as unknown as ReactRouterSignInAPIReturn<Redirect>
     }
 }
-
-export type SignInCredentialsReturn<Redirect extends boolean = true> = Redirect extends true
-    ? Response
-    : SignInCredentialsAPIReturn
 
 export const signInCredentials = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
     return async <Redirect extends boolean = true>(
         payload: CredentialsPayload,
-        options?: Prettify<SignInOptions & { request: Request }>
-    ): Promise<SignInCredentialsReturn<Redirect>> => {
+        options?: ReactRouterSignInCredentialsAPIOptions
+    ): Promise<ReactRouterSignInCredentialsAPIReturn<Redirect>> => {
         const signIn = await api.signInCredentials({
             payload,
             ...options,
         })
-        if (signIn.success) {
-            return redirect(signIn.redirectURL, {
-                headers: signIn.headers,
-            }) as SignInCredentialsReturn<Redirect>
+        if (options?.redirect ?? true) {
+            return signIn.toResponse() as ReactRouterSignInCredentialsAPIReturn<Redirect>
         }
-        return signIn as SignInCredentialsReturn<Redirect>
+        return signIn as unknown as ReactRouterSignInCredentialsAPIReturn<Redirect>
     }
 }
 
 export const updateSession = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async (session: UpdateSessionOptions<DefaultUser>, options: GetSessionOptions) => {
-        const updated = await api.updateSession({
+    return async (
+        session: UpdateSessionOptions<DefaultUser>,
+        options: GetSessionOptions
+    ): Promise<UpdateSessionAPIReturn<DefaultUser>> => {
+        return await api.updateSession({
             session,
             headers: options.headers,
-        })
-
-        return data(updated, {
-            headers: updated.headers,
         })
     }
 }
 
 export const signOut = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async (options: Prettify<SignOutOptions & { headers: HeadersInit }>) => {
-        const out = await api.signOut({
-            headers: options.headers,
-            redirectTo: options?.redirectTo,
-        })
-        return data(out, {
-            headers: out.headers,
-        })
+    return async (options: ReactRouterSignOutAPIOptions) => {
+        const out = await api.signOut(options)
+        if (out.success && options.redirectTo && out.redirectURL) {
+            return redirect(out.redirectURL!, {
+                headers: out.headers,
+            })
+        }
+        return out.toResponse()
     }
 }
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -85,6 +85,7 @@
     "@aura-stack/tsup-config": "workspace:*",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
+    "vitest": "catalog:vitest",
     "react": "catalog:react",
     "@types/react": "catalog:react"
   },

--- a/packages/react/src/@types/core.ts
+++ b/packages/react/src/@types/core.ts
@@ -1,1 +1,2 @@
+/** Re-exports `@aura-stack/auth/types` for the React package public API. */
 export type * from "@aura-stack/auth/types"

--- a/packages/react/src/@types/index.ts
+++ b/packages/react/src/@types/index.ts
@@ -1,2 +1,3 @@
+/** Full public type export for `@aura-stack/react` (core auth types plus React context types). */
 export type * from "@/@types/core.ts"
 export type * from "@/@types/types.ts"

--- a/packages/react/src/@types/types.ts
+++ b/packages/react/src/@types/types.ts
@@ -1,3 +1,8 @@
+/**
+ * React-specific auth types: context value, provider props, and the browser client instance shape.
+ *
+ * Re-exports of core session/user types come from `@aura-stack/auth/types` via `@aura-stack/react/types`.
+ */
 import type { ReactNode } from "react"
 import type {
     CredentialsPayload,
@@ -10,10 +15,14 @@ import type {
     User,
 } from "@aura-stack/auth/types"
 
+/**
+ * The object returned by {@link createAuthClient} for a given user type, including `getSession`, `signIn`, `signOut`, etc.
+ */
 export type AuthClientInstance<DefaultUser extends User = User> = ReturnType<
     typeof import("@aura-stack/auth/client").createAuthClient<DefaultUser>
 >
 
+/** High-level UI state for whether a session is present, absent, or still being resolved. */
 export type AuthStatus = "authenticated" | "unauthenticated" | "loading"
 
 /** Options for {@link AuthReactContextValue.updateSession} (React layer; not sent to the HTTP API). */
@@ -27,11 +36,14 @@ export type UpdateSessionCallOptions = {
  * mutations share one source of truth (no duplicate session fetches per subtree).
  */
 export type AuthReactContextValue<DefaultUser extends User = User> = {
+    /** Current session, `null` if unauthenticated, or `undefined` before the first load completes. */
     session: Session<DefaultUser> | null | undefined
     status: AuthStatus
     /** True while a transition updates session state (e.g. after refresh or a non-redirect sign-in). */
     isPending: boolean
+    /** Bound auth HTTP client (same API as `createAuthClient`). */
     client: AuthClientInstance<DefaultUser>
+    /** Re-fetches session from the server and updates context state. */
     refresh: () => Promise<void>
     signIn: (
         oauth: LiteralUnion<BuiltInOAuthProvider>,
@@ -48,6 +60,7 @@ export type AuthReactContextValue<DefaultUser extends User = User> = {
     ) => ReturnType<AuthClientInstance<DefaultUser>["updateSession"]>
 }
 
+/** Props for {@link AuthProvider}: supply the client and optional SSR session to avoid a flash of loading state. */
 export type AuthProviderProps<DefaultUser extends User = User> = {
     children: ReactNode
     /** Auth API client from {@link createAuthClient}; swap this instance whenever your app needs a different client. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ catalogs:
       specifier: ^7.1.7
       version: 7.3.1
   vitest:
+    '@vitest/coverage-v8':
+      specifier: 4.1.4
+      version: 4.1.4
     vitest:
       specifier: 4.1.4
       version: 4.1.4
@@ -85,8 +88,8 @@ importers:
         specifier: catalog:node
         version: 24.12.0
       '@vitest/coverage-v8':
-        specifier: ^4.0.14
-        version: 4.1.0(vitest@4.1.4)
+        specifier: catalog:vitest
+        version: 4.1.4(vitest@4.1.4)
       eslint:
         specifier: ^9.35.0
         version: 9.39.4(jiti@2.6.1)
@@ -107,7 +110,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:vitest
-        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   apps/astro:
     dependencies:
@@ -182,7 +185,7 @@ importers:
         version: link:../../configs/tsconfig
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.12.4
-        version: 0.12.21(@vitest/runner@4.1.4)(@vitest/snapshot@4.1.4)(vitest@4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 0.12.21(@vitest/runner@4.1.4)(@vitest/snapshot@4.1.4)(vitest@4.1.4)
       '@types/node':
         specifier: catalog:node
         version: 24.12.0
@@ -675,7 +678,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:vitest
-        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/elysia:
     dependencies:
@@ -694,7 +697,7 @@ importers:
         version: 1.4.28(@sinclair/typebox@0.34.48)(@types/bun@1.3.10)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.3)(openapi-types@12.1.3)(typescript@5.9.3)
       vitest:
         specifier: catalog:vitest
-        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/express:
     dependencies:
@@ -722,7 +725,7 @@ importers:
         version: 7.2.2
       vitest:
         specifier: catalog:vitest
-        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/hono:
     dependencies:
@@ -744,7 +747,7 @@ importers:
         version: 4.12.8
       vitest:
         specifier: catalog:vitest
-        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/jose:
     dependencies:
@@ -763,7 +766,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:vitest
-        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/next:
     dependencies:
@@ -797,7 +800,7 @@ importers:
         version: link:../../configs/tsup-config
       vitest:
         specifier: catalog:vitest
-        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/react:
     dependencies:
@@ -825,7 +828,7 @@ importers:
         version: 19.2.4
       vitest:
         specifier: catalog:vitest
-        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/react-router:
     dependencies:
@@ -4248,11 +4251,11 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
-  '@vitest/coverage-v8@4.1.0':
-    resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
+  '@vitest/coverage-v8@4.1.4':
+    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
     peerDependencies:
-      '@vitest/browser': 4.1.0
-      vitest: 4.1.0
+      '@vitest/browser': 4.1.4
+      vitest: 4.1.4
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
@@ -4271,9 +4274,6 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.0':
-    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
-
   '@vitest/pretty-format@4.1.4':
     resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
@@ -4285,9 +4285,6 @@ packages:
 
   '@vitest/spy@4.1.4':
     resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
-
-  '@vitest/utils@4.1.0':
-    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
@@ -9691,14 +9688,14 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260317.1
 
-  '@cloudflare/vitest-pool-workers@0.12.21(@vitest/runner@4.1.4)(@vitest/snapshot@4.1.4)(vitest@4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@cloudflare/vitest-pool-workers@0.12.21(@vitest/runner@4.1.4)(@vitest/snapshot@4.1.4)(vitest@4.1.4)':
     dependencies:
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
       cjs-module-lexer: 1.4.3
       esbuild: 0.27.3
       miniflare: 4.20260310.0
-      vitest: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       wrangler: 4.72.0
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -12707,10 +12704,10 @@ snapshots:
       vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
       vue: 3.5.30(typescript@5.9.3)
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.4)':
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.0
+      '@vitest/utils': 4.1.4
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -12719,7 +12716,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -12738,10 +12735,6 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/pretty-format@4.1.0':
-    dependencies:
-      tinyrainbow: 3.1.0
-
   '@vitest/pretty-format@4.1.4':
     dependencies:
       tinyrainbow: 3.1.0
@@ -12759,12 +12752,6 @@ snapshots:
       pathe: 2.0.3
 
   '@vitest/spy@4.1.4': {}
-
-  '@vitest/utils@4.1.0':
-    dependencies:
-      '@vitest/pretty-format': 4.1.0
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -18428,7 +18415,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitest@4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -18452,7 +18439,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.0
-      '@vitest/coverage-v8': 4.1.0(vitest@4.1.4)
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
       jsdom: 27.4.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,10 @@ catalogs:
     vite:
       specifier: ^7.1.7
       version: 7.3.1
+  vitest:
+    vitest:
+      specifier: 4.1.4
+      version: 4.1.4
   zod-v4:
     zod:
       specifier: 4.3.5
@@ -82,7 +86,7 @@ importers:
         version: 24.12.0
       '@vitest/coverage-v8':
         specifier: ^4.0.14
-        version: 4.1.0(vitest@4.1.0(@types/node@24.12.0)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 4.1.0(vitest@4.1.4)
       eslint:
         specifier: ^9.35.0
         version: 9.39.4(jiti@2.6.1)
@@ -102,8 +106,8 @@ importers:
         specifier: catalog:typescript
         version: 5.9.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@types/node@24.12.0)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        specifier: catalog:vitest
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   apps/astro:
     dependencies:
@@ -178,7 +182,7 @@ importers:
         version: link:../../configs/tsconfig
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.12.4
-        version: 0.12.21(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(vitest@4.1.0(@types/node@24.12.0)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 0.12.21(@vitest/runner@4.1.4)(@vitest/snapshot@4.1.4)(vitest@4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)))
       '@types/node':
         specifier: catalog:node
         version: 24.12.0
@@ -669,6 +673,9 @@ importers:
       typescript:
         specifier: catalog:typescript
         version: 5.9.3
+      vitest:
+        specifier: catalog:vitest
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/elysia:
     dependencies:
@@ -685,6 +692,9 @@ importers:
       elysia:
         specifier: ^1.2.22
         version: 1.4.28(@sinclair/typebox@0.34.48)(@types/bun@1.3.10)(exact-mirror@0.2.7(@sinclair/typebox@0.34.48))(file-type@21.3.3)(openapi-types@12.1.3)(typescript@5.9.3)
+      vitest:
+        specifier: catalog:vitest
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/express:
     dependencies:
@@ -710,6 +720,9 @@ importers:
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
+      vitest:
+        specifier: catalog:vitest
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/hono:
     dependencies:
@@ -729,6 +742,9 @@ importers:
       hono:
         specifier: catalog:hono
         version: 4.12.8
+      vitest:
+        specifier: catalog:vitest
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/jose:
     dependencies:
@@ -745,6 +761,9 @@ importers:
       typescript:
         specifier: catalog:typescript
         version: 5.9.3
+      vitest:
+        specifier: catalog:vitest
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/next:
     dependencies:
@@ -776,6 +795,9 @@ importers:
       '@aura-stack/tsup-config':
         specifier: workspace:*
         version: link:../../configs/tsup-config
+      vitest:
+        specifier: catalog:vitest
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/react:
     dependencies:
@@ -801,6 +823,9 @@ importers:
       react:
         specifier: catalog:react
         version: 19.2.4
+      vitest:
+        specifier: catalog:vitest
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/react-router:
     dependencies:
@@ -4232,14 +4257,14 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.0':
-    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
-  '@vitest/mocker@4.1.0':
-    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -4249,17 +4274,23 @@ packages:
   '@vitest/pretty-format@4.1.0':
     resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
 
-  '@vitest/runner@4.1.0':
-    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
-  '@vitest/snapshot@4.1.0':
-    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
 
-  '@vitest/spy@4.1.0':
-    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -8837,21 +8868,23 @@ packages:
       vite:
         optional: true
 
-  vitest@4.1.0:
-    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.0
-      '@vitest/browser-preview': 4.1.0
-      '@vitest/browser-webdriverio': 4.1.0
-      '@vitest/ui': 4.1.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -8864,6 +8897,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -9654,14 +9691,14 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260317.1
 
-  '@cloudflare/vitest-pool-workers@0.12.21(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(vitest@4.1.0(@types/node@24.12.0)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@cloudflare/vitest-pool-workers@0.12.21(@vitest/runner@4.1.4)(@vitest/snapshot@4.1.4)(vitest@4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
       cjs-module-lexer: 1.4.3
       esbuild: 0.27.3
       miniflare: 4.20260310.0
-      vitest: 4.1.0(@types/node@24.12.0)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       wrangler: 4.72.0
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -12670,7 +12707,7 @@ snapshots:
       vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
       vue: 3.5.30(typescript@5.9.3)
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@24.12.0)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.4)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -12682,20 +12719,20 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@24.12.0)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
-  '@vitest/expect@4.1.0':
+  '@vitest/expect@4.1.4':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@vitest/spy': 4.1.0
+      '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -12705,23 +12742,33 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.0':
+  '@vitest/pretty-format@4.1.4':
     dependencies:
-      '@vitest/utils': 4.1.0
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.0':
+  '@vitest/snapshot@4.1.4':
     dependencies:
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.0': {}
+  '@vitest/spy@4.1.4': {}
 
   '@vitest/utils@4.1.0':
     dependencies:
       '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -18381,15 +18428,15 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitest@4.1.0(@types/node@24.12.0)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.0(vitest@4.1.4))(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -18405,6 +18452,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.0
+      '@vitest/coverage-v8': 4.1.0(vitest@4.1.4)
       jsdom: 27.4.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,3 +38,5 @@ catalogs:
     express: ^4.18.2
   react-router:
     react-router: 7.12.0
+  vitest:
+    vitest: 4.1.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,3 +40,4 @@ catalogs:
     react-router: 7.12.0
   vitest:
     vitest: 4.1.4
+    "@vitest/coverage-v8": 4.1.4


### PR DESCRIPTION
## Description

This pull request standardizes the API and client types across all packages, improving type safety and consistency when consuming authentication flows. The changes primarily target the `api` object returned by `createAuth` and the client functions from `createAuthClient`.

The update introduces dedicated types that override default core types, ensuring more precise inference and better developer experience across integrations (e.g., Next.js, React Router).

Additionally, API responses are now strongly typed and include helper utilities to simplify response handling.

---

## Key Changes

- Added `success` boolean field to all API responses to indicate operation result
- Added `toResponse` helper to transform API results into `Response` objects
- Removed `authenticated` and `updated` flags in favor of unified `success` field
- Introduced dedicated types in integration packages (e.g., `@aura-stack/next`, `@aura-stack/react-router`)
- Improved type inference for API and client responses

---

## Usage

### Server-Side Rendering (SSR)

```ts
import { createAuth } from "@aura-stack/auth"

export const auth = createAuth({
  oauth: [],
})

const { success, toResponse } = await auth.api.signIn("github")
```

### Client-Side Rendering (CSR)

```ts
import { createAuthClient } from "@aura-stack/auth/client"

export const authClient = createAuthClient({
  baseURL: "http://localhost:3000",
})

const data = await authClient.signIn("github")
```
