### PR TITLE
chore(integrations): add template and setup script for integrations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -362,6 +362,17 @@
         "hono": ">=4.0.0",
       },
     },
+    "packages/integration": {
+      "name": "@aura-stack/integration",
+      "version": "0.0.0",
+      "dependencies": {
+        "@aura-stack/auth": "workspace:*",
+      },
+      "devDependencies": {
+        "@aura-stack/tsconfig": "workspace:*",
+        "@aura-stack/tsdown-config": "workspace:*",
+      },
+    },
     "packages/jose": {
       "name": "@aura-stack/jose",
       "version": "0.4.0",
@@ -437,6 +448,10 @@
       "peerDependencies": {
         "react-router": ">=7.0.0",
       },
+    },
+    "packages/shared": {
+      "name": "shared",
+      "version": "0.0.0",
     },
   },
   "overrides": {
@@ -543,6 +558,8 @@
     "@aura-stack/express": ["@aura-stack/express@workspace:packages/express"],
 
     "@aura-stack/hono": ["@aura-stack/hono@workspace:packages/hono"],
+
+    "@aura-stack/integration": ["@aura-stack/integration@workspace:packages/integration"],
 
     "@aura-stack/jose": ["@aura-stack/jose@workspace:packages/jose"],
 
@@ -3253,6 +3270,8 @@
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shared": ["shared@workspace:packages/shared"],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "1.1.0", "detect-libc": "2.1.2", "semver": "7.7.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "format:check": "oxfmt --check",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
-    "type-check": "turbo run type-check --parallel"
+    "type-check": "turbo run type-check --parallel",
+    "create:integration": "node packages/shared/scripts/integration.js --name "
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:core": "turbo run @aura-stack/auth#dev",
     "dev:docs": "turbo run docs#dev",
     "build": "turbo run build --filter=./configs/* --filter=./packages/* --filter=./apps/*",
-    "build:prod": "turbo run build --filter=./configs/* --filter=./packages/* --continue=dependencies-successful",
+    "build:prod": "turbo run build --filter=./configs/* --filter=./packages/* --filter=!./packages/integration --continue=dependencies-successful",
     "test": "turbo run test --parallel",
     "format": "turbo run format format:root --parallel",
     "format:root": "oxfmt \"!packages\" \"!apps\" \"!configs\"",
@@ -17,7 +17,7 @@
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "type-check": "turbo run type-check --parallel",
-    "create:integration": "node packages/shared/scripts/integration.js --name "
+    "create:integration": "node packages/shared/scripts/integration.js"
   },
   "repository": {
     "type": "git",

--- a/packages/integration/CHANGELOG.md
+++ b/packages/integration/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog - `@aura-stack/integration`
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+### Added
+
+### Changed

--- a/packages/integration/README.md
+++ b/packages/integration/README.md
@@ -1,0 +1,35 @@
+<div align="center">
+
+<h1><b>@aura-stack/integration</b></h1>
+
+**Integration authentication library for the Aura Stack ecosystem**
+
+[![npm version](https://img.shields.io/npm/v/@aura-stack/integration.svg)](https://www.npmjs.com/package/@aura-stack/auth)
+[![JSR version](https://jsr.io/badges/@aura-stack/integration)](https://jsr.io/@aura-stack/auth)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
+[Official Docs](https://aura-stack-auth.vercel.app/docs) · [Core Package Docs](https://aura-stack-auth.vercel.app/docs/packages/core)
+
+</div>
+
+## Features
+
+## Installation
+
+```bash
+pnpm add @aura-stack/integration
+```
+
+## Documentation
+
+Visit the [**official documentation website**](https://aura-stack-auth.vercel.app).
+
+## License
+
+Licensed under the [MIT License](../../LICENSE). © [Aura Stack](https://github.com/aura-stack-ts)
+
+---
+
+<p align="center">
+  Made with ❤️ by <a href="https://github.com/aura-stack-ts">Aura Stack team</a>
+</p>

--- a/packages/integration/README.md
+++ b/packages/integration/README.md
@@ -4,8 +4,8 @@
 
 **Integration authentication library for the Aura Stack ecosystem**
 
-[![npm version](https://img.shields.io/npm/v/@aura-stack/integration.svg)](https://www.npmjs.com/package/@aura-stack/auth)
-[![JSR version](https://jsr.io/badges/@aura-stack/integration)](https://jsr.io/@aura-stack/auth)
+[![npm version](https://img.shields.io/npm/v/@aura-stack/integration.svg)](https://www.npmjs.com/package/@aura-stack/integration)
+[![JSR version](https://jsr.io/badges/@aura-stack/integration)](https://jsr.io/@aura-stack/integration)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 [Official Docs](https://aura-stack-auth.vercel.app/docs) · [Core Package Docs](https://aura-stack-auth.vercel.app/docs/packages/core)

--- a/packages/integration/deno.json
+++ b/packages/integration/deno.json
@@ -3,10 +3,14 @@
   "version": "0.0.0",
   "license": "MIT",
   "tasks": {
-    "dev": "deno run --watch src/index.tsx"
+    "dev": "deno run --watch src/index.ts"
   },
   "imports": {
-    "@/": "./src/"
+    "@/": "./src/",
+    "./oauth": "./src/oauth/index.ts",
+    "./identity": "./src/_core/identity.ts",
+    "./crypto": "./src/_core/crypto.ts",
+    "./shared": "./src/_core/shared.ts"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/**/*.tsx", "README.md", "CHANGELOG.md"]

--- a/packages/integration/deno.json
+++ b/packages/integration/deno.json
@@ -1,0 +1,15 @@
+{
+  "name": "@aura-stack/integration",
+  "version": "0.0.0",
+  "license": "MIT",
+  "tasks": {
+    "dev": "deno run --watch src/index.tsx"
+  },
+  "imports": {
+    "@/": "./src/"
+  },
+  "publish": {
+    "include": ["src/**/*.ts", "src/**/*.tsx", "README.md", "CHANGELOG.md"]
+  },
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@aura-stack/integration",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "description": "Integration for Aura Stack authentication library",
   "scripts": {
     "dev": "tsdown --watch",
-    "build": "tsdown",
+    "build": "pnpm sync:modules && tsdown",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "test": "vitest --run",

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "@aura-stack/integration",
+  "version": "0.0.0",
+  "private": false,
+  "type": "module",
+  "description": "Integration for Aura Stack authentication library",
+  "scripts": {
+    "dev": "tsdown --watch",
+    "build": "tsdown",
+    "lint": "oxlint",
+    "lint:fix": "oxlint --fix",
+    "test": "vitest --run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest --run --coverage",
+    "format": "oxfmt",
+    "format:check": "oxfmt --check",
+    "type-check": "tsc --noEmit",
+    "clean": "rm -rf dist src/_core src/oauth",
+    "clean:cts": "if [ -d dist ]; then find dist -type f -name \"*.cts\" -delete; fi",
+    "prepublishOnly": "pnpm clean:cts && pnpm build && pnpm clean:cts",
+    "sync:modules": "node ../shared/scripts/modules.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aura-stack-ts/auth"
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./oauth": {
+      "types": "./dist/oauth/index.d.ts",
+      "import": "./dist/oauth/index.js",
+      "require": "./dist/oauth/index.cjs"
+    },
+    "./oauth/*": {
+      "types": "./dist/oauth/*.d.ts",
+      "import": "./dist/oauth/*.js",
+      "require": "./dist/oauth/*.cjs"
+    },
+    "./identity": {
+      "types": "./dist/_core/identity.d.ts",
+      "import": "./dist/_core/identity.js",
+      "require": "./dist/_core/identity.cjs"
+    },
+    "./crypto": {
+      "types": "./dist/_core/crypto.d.ts",
+      "import": "./dist/_core/crypto.js",
+      "require": "./dist/_core/crypto.cjs"
+    },
+    "./shared": {
+      "types": "./dist/_core/shared.d.ts",
+      "import": "./dist/_core/shared.js",
+      "require": "./dist/_core/shared.cjs"
+    }
+  },
+  "keywords": [],
+  "author": "Aura Stack <aurastackjs@gmail.com> | Hernan Alvarado <halvaradop.dev@gmail.com>",
+  "homepage": "https://aura-stack-auth.vercel.app",
+  "bugs": {
+    "url": "https://github.com/aura-stack-ts/auth/issues"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@aura-stack/auth": "workspace:*"
+  },
+  "devDependencies": {
+    "@aura-stack/tsconfig": "workspace:*",
+    "@aura-stack/tsdown-config": "workspace:*"
+  },
+  "peerDependencies": {},
+  "packageManager": "pnpm@10.15.0"
+}

--- a/packages/integration/src/createAuth.ts
+++ b/packages/integration/src/createAuth.ts
@@ -1,4 +1,5 @@
-import { AuthConfig, createAuth as createAuthInstance, EditableShape, UserShape } from "@aura-stack/auth"
+import { AuthConfig, createAuth as createAuthInstance } from "@aura-stack/auth"
+import type { EditableShape, UserShape } from "@aura-stack/auth/identity"
 
 export const createAuth = <Identity extends EditableShape<UserShape>>(config: AuthConfig<Identity>) => {
     const auth = createAuthInstance<Identity>(config)

--- a/packages/integration/src/createAuth.ts
+++ b/packages/integration/src/createAuth.ts
@@ -1,0 +1,6 @@
+import { AuthConfig, createAuth as createAuthInstance, EditableShape, UserShape } from "@aura-stack/auth"
+
+export const createAuth = <Identity extends EditableShape<UserShape>>(config: AuthConfig<Identity>) => {
+    const auth = createAuthInstance<Identity>(config)
+    return auth
+}

--- a/packages/integration/src/index.ts
+++ b/packages/integration/src/index.ts
@@ -1,0 +1,1 @@
+export { createAuth } from "@/createAuth.ts"

--- a/packages/integration/tsconfig.json
+++ b/packages/integration/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@aura-stack/tsconfig/tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/integration/tsdown.config.ts
+++ b/packages/integration/tsdown.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsdown"
+import { tsdownConfig } from "@aura-stack/tsdown-config"
+
+export default defineConfig({
+    ...tsdownConfig,
+    entry: [
+        "src/index.ts",
+        "src/oauth/index.ts",
+        "src/oauth/*.ts",
+        "src/_core/identity.ts",
+        "src/_core/crypto.ts",
+        "src/_core/shared.ts",
+    ],
+})

--- a/packages/shared/scripts/integration.js
+++ b/packages/shared/scripts/integration.js
@@ -19,6 +19,10 @@ if (!name) {
     console.error("\x1b[31m[error]: Integration name is required\x1b[0m")
     process.exit(1)
 }
+if (!/^[a-z0-9][a-z0-9-]*$/.test(name)) {
+    console.error("\x1b[31m[error]: Integration name must be lowercase alphanumeric with dashes\x1b[0m")
+    process.exit(1)
+}
 
 if (existsSync(resolve(process.cwd(), "packages", name))) {
     console.error("\x1b[31m[error]: Integration with the same name already exists\x1b[0m")

--- a/packages/shared/scripts/integration.js
+++ b/packages/shared/scripts/integration.js
@@ -1,0 +1,50 @@
+import { existsSync } from "node:fs"
+import { parseArgs } from "node:util"
+import { cp } from "node:fs/promises"
+import { basename, resolve } from "node:path"
+
+const args = parseArgs({
+    args: process.argv.slice(2),
+    strict: true,
+    options: {
+        name: {
+            type: "string",
+        },
+    },
+})
+
+const { name } = args.values
+
+if (!name) {
+    console.error("\x1b[31m[error]: Integration name is required\x1b[0m")
+    process.exit(1)
+}
+
+if (existsSync(resolve(process.cwd(), "packages", name))) {
+    console.error("\x1b[31m[error]: Integration with the same name already exists\x1b[0m")
+    process.exit(1)
+}
+
+try {
+    const outDir = resolve(process.cwd(), "packages", name)
+    const templateDir = resolve(process.cwd(), "packages", "integration")
+
+    if (!existsSync(templateDir)) {
+        console.error("\x1b[31m[error]: Integration template folder not found at packages/integration\x1b[0m")
+        process.exit(1)
+    }
+
+    console.log(`\x1b[34m[info]: Creating integration "${name}"...\x1b[0m`)
+    await cp(templateDir, outDir, {
+        recursive: true,
+        filter: (src) => {
+            const name = basename(src)
+            return name !== "node_modules" && name !== "dist"
+        },
+    })
+
+    console.log("\x1b[32m[success]: Integration created successfully\x1b[0m")
+} catch (error) {
+    console.error("\x1b[31m[error]: Failed to create integration:\x1b[0m", error)
+    process.exit(1)
+}

--- a/packages/shared/scripts/modules.js
+++ b/packages/shared/scripts/modules.js
@@ -1,6 +1,6 @@
-import { glob, mkdir, readFile, writeFile } from "node:fs/promises"
-import { join, parse, resolve } from "node:path"
 import { parseArgs } from "node:util"
+import { join, parse, resolve } from "node:path"
+import { glob, mkdir, readFile, writeFile } from "node:fs/promises"
 
 const coreModules = ["crypto", "identity", "shared"]
 const jsonExports = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -749,6 +749,19 @@ importers:
         specifier: catalog:vitest
         version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
+  packages/integration:
+    dependencies:
+      '@aura-stack/auth':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@aura-stack/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      '@aura-stack/tsdown-config':
+        specifier: workspace:*
+        version: link:../../configs/tsdown-config
+
   packages/jose:
     dependencies:
       jose:
@@ -845,6 +858,8 @@ importers:
       react-router:
         specifier: catalog:react-router
         version: 7.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
+  packages/shared: {}
 
 packages:
 


### PR DESCRIPTION
## Description
Introduces a standardized template and scaffolding workflow for creating new integration packages in the monorepo.

This reduces setup time and enforces a consistent structure across integrations such as `next`, `react-router`, `elysia`, and `express`.

---

## Changes

- Add integration template under `packages/integration`
- Introduce `shared/scripts/integration.js` scaffolding script
- Add `create:integration` script in the root `package.json`
- Define a default structure for all new integration packages

### Scaffolding Script

The `shared/scripts/integration.js` script automates the creation of new integration packages by copying the template into a new package and applying the required setup.

It can be executed directly or via the root script alias.



### Usage
```
Usage: node shared/scripts/integration.js [OPTIONS]

Options:
--name      Required name of the integration to copy

Examples:
node packages/shared/scripts/integration.js --name tanstack-react-start
node packages/shared/scripts/integration.js --name solid
node packages/shared/scripts/integration.js --name fastify
```

**Using the root script:**
```
pnpm create:integraton shared/scripts/integration.js --name tanstack-react-start
pnpm create:integraton shared/scripts/integration.js --name solid
pnpm create:integraton  shared/scripts/integration.js --name fastify
```