### PR TITLE
chore(release): bump package versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,6 +190,8 @@ worker-configuration.d.ts
 .wrangler/*
 
 # Packages
-!packages/core/src/oauth
 packages/**/_core
 packages/**/oauth
+
+!packages/core/src/oauth/
+!packages/core/src/oauth/**

--- a/bun.lock
+++ b/bun.lock
@@ -297,7 +297,7 @@
     },
     "packages/core": {
       "name": "@aura-stack/auth",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@aura-stack/jose": "workspace:*",
         "@aura-stack/router": "^0.6.0",
@@ -375,7 +375,7 @@
     },
     "packages/jose": {
       "name": "@aura-stack/jose",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "jose": "^6.1.2",
       },

--- a/deno.json
+++ b/deno.json
@@ -1,3 +1,3 @@
 {
-  "workspace": ["packages/**", "apps/oak", "apps/deno", "apps/supabase/**"]
+  "workspace": ["packages/**", "configs/**", "apps/oak", "apps/deno", "apps/supabase/**"]
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.6.0] - 2026-04-26
+
 ### Added
 
 - Removed and cleaned up the types and functions exported from the main `/` entry point to reduce import noise, and introduced `/identity`, `/shared`, and `/crypto` as direct entry points for specific utilities. Utilities and types previously exposed via `/` are now accessible through these direct entry points. Additionally, removed the `StrippedUserIdentity` Zod schema and added the `UpdateSessionOptions` type. [#141](https://github.com/aura-stack-ts/auth/pull/141)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
-## [0.6.0] - 2026-04-26
+## [0.6.0] - 2026-04-21
 
 ### Added
 

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/auth",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/auth",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": false,
   "type": "module",
   "description": "Core auth for @aura-stack/auth",

--- a/packages/jose/CHANGELOG.md
+++ b/packages/jose/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.5.0] - 2026-04-26
+
 ### Added
 
 - Added `compactEncryptJWE`, `decryptCompactJWE`, and `createCompactJWE` to handle compact JWE (JSON Web Encryption) serialization, and introduced `EncodeJWTOptions` and `DecodeJWTOptions` to configure additional payload headers and verification options for signing and encryption flows. [#123](https://github.com/aura-stack-ts/auth/pull/123)

--- a/packages/jose/CHANGELOG.md
+++ b/packages/jose/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
-## [0.5.0] - 2026-04-26
+## [0.5.0] - 2026-04-21
 
 ### Added
 

--- a/packages/jose/deno.json
+++ b/packages/jose/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/jose",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts",

--- a/packages/jose/package.json
+++ b/packages/jose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/jose",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "type": "module",
   "description": "JOSE utilities for @aura-stack/auth",


### PR DESCRIPTION
## Description

This pull request publishes new releases of the packages to both npm and JSR registries:

- `@aura-stack/auth@0.6.0`
- `@aura-stack/jose@0.5.0`

### Registries

#### NPM
- https://www.npmjs.com/package/@aura-stack/auth
- https://www.npmjs.com/package/@aura-stack/jose

#### JSR
- https://jsr.io/@aura-stack/auth
- https://jsr.io/@aura-stack/jose


### Key changes

**`@aura-stack/auth`**
- #146 
- #141 
- #136 
- #130 
- #129 
- #127 
- #126 
- #125 
- #123 

**`@aura-stack/jose`**
- #123 
