### PR TITLE
feat(oauth): add `Click Up` OAuth provider

### DIFF
--- a/docs/src/content/docs/oauth/click-up.mdx
+++ b/docs/src/content/docs/oauth/click-up.mdx
@@ -1,0 +1,222 @@
+---
+title: ClickUp Authorization Provider
+description: Add ClickUp authorization provider to Aura Auth to authentication and authorize
+---
+
+## ClickUp
+
+Set up the `ClickUp` authorization provider in your Aura Auth instance.
+
+---
+
+## What you'll build
+
+Through this quick start guide you are going to learn and understand the basics and how to set up the `ClickUp` provider for Aura Auth.
+
+- [ClickUp OAuth App](#clickup-oauth-app)
+- [Installation](#installation)
+- [Environment setup](#environment-setup)
+- [Configure the Auth Instance](#configure-the-auth-instance)
+- [Customizing the OAuth Provider](#customizing-the-oauth-provider)
+- [Sign In to ClickUp (Client & Server)](#sign-in-to-clickup-client--server)
+- [Resources](#resources)
+
+---
+
+<Steps>
+
+<Step>
+
+## ClickUp OAuth App
+
+### Register the Application
+
+The first step is to create and register an OAuth App on the ClickUp Workspace to obtain access to the user's resources.
+
+1. Navigate to your Clickup Avatar and go to **Settings > Integrations & ClickApps > ClickUp API > ClickUp API Settings**.
+2. Click **Create an App**.
+3. Fill in the "App name".
+4. Set the **Redirect URL(s)** to `localhost:3000`.
+   - _(Make sure to replace `localhost:3000` with your production domain when deploying)_
+5. Click **Create App**.
+6. Ensure you copy the **Client ID** and click **Generate a new client secret**.
+
+</Step>
+
+<Step>
+
+## Installation
+
+Install the package using a package manager like `npm`, `pnpm`, or `yarn`:
+
+```npm
+npm install @aura-stack/auth
+```
+
+</Step>
+
+<Step>
+
+## Environment setup
+
+Now, you must configure the environment variables required by Aura Auth, including the ClickUp credentials and the encryption secrets.
+
+```bash title=".env" lineNumbers
+# Aura Secrets
+AURA_AUTH_SECRET="your-32-byte-secret"
+AURA_AUTH_SALT="your-32-byte-salt"
+
+# ClickUp Credentials
+AURA_AUTH_CLICK_UP_CLIENT_ID="your_click_up_client_id"
+AURA_AUTH_CLICK_UP_CLIENT_SECRET="your_click_up_client_secret"
+```
+
+<Callout type="warn">
+  **CRITICAL SECURITY WARNING:** The `AURA_AUTH_SECRET` and `AURA_AUTH_SALT` variables are used to encrypt and sign user sessions.
+  These MUST be securely generated, highly randomized strings consisting of at least 32 bytes to ensure adequate entropy. Never
+  hardcode these values in your repository. Use a secure generator (like `openssl rand -base64 32`) to create them, and store them
+  exclusively in your secure environment variables manager.
+</Callout>
+
+</Step>
+
+<Step>
+
+## Configure the Auth Instance
+
+Configure the `createAuth` instance inside an `auth.ts` file located at the root of your project. Ensure you explicitly export the `handlers`, `api`, and `jose` objects.
+
+```ts title="auth.ts" lineNumbers
+import { createAuth } from "@aura-stack/auth"
+
+export const auth = createAuth({
+  oauth: ["click-up"],
+})
+
+// Extract the required utilities
+export const { handlers, api, jose } = auth
+```
+
+<Callout type="info">
+  The `handlers` object contains mapping utilities for standard HTTP methods (`GET`, `POST`, `PATCH`) as well as a unified `ALL`
+  handler. This allows you to easily mount the authentication routes across any framework (Next.js, Elysia, Express, etc.).
+</Callout>
+
+</Step>
+
+<Step>
+
+## Customizing the OAuth Provider
+
+If you need to define custom scopes, change the response type, or map profile data differently, you can use the provider's factory function instead of a simple string identifier.
+
+```ts title="auth.ts" lineNumbers
+import { createAuth } from "@aura-stack/auth"
+import { clickUp } from "@aura-stack/auth/oauth/click-up"
+
+export const auth = createAuth({
+  oauth: [
+    clickUp({
+      authorize: {
+        params: {
+          scope: "read:user user:email",
+        },
+      },
+    }),
+  ],
+})
+
+export const { handlers, api, jose } = auth
+```
+
+</Step>
+
+<Step>
+
+## Sign In to ClickUp (Client & Server)
+
+There are multiple ways to trigger the sign-in flow depending on your ecosystem.
+
+### Sign-in Path (Direct Navigation)
+
+The common route to trigger the auth flow natively without needing a client library is simply navigating the browser to:
+`http://localhost:3000/auth/signIn/click-up`
+
+---
+
+### Client-Side (React, Vue, etc.)
+
+You can utilize the `createAuthClient` utility to programmatically trigger sign-ins. You can also define a `redirectTo` destination.
+
+<Callout type="warn">
+  **Constraint Rule**: The `baseURL` passed into `createAuthClient` MUST exactly match the root domain and path where the HTTP
+  `handlers` expose their endpoints on the server.
+</Callout>
+
+```ts title="components/Login.tsx" lineNumbers
+import { createAuthClient } from "@aura-stack/auth/client"
+
+export const authClient = createAuthClient({
+  baseURL: "http://localhost:3000/auth",
+})
+
+const triggerSignIn = async () => {
+  await authClient.signIn("click-up", {
+    redirectTo: "/dashboard",
+  })
+}
+```
+
+---
+
+### Server-Side (Next.js Actions, Remix Loaders, etc.)
+
+For environments supporting server-side actions, use the programmatic `api.signIn` method securely.
+
+```ts title="actions.ts" lineNumbers
+import { api } from "./auth"
+
+export const serverSignIn = async () => {
+  const response = await api.signIn("click-up", {
+    redirectTo: "http://localhost:3000/dashboard",
+  })
+
+  // Example returning redirect location
+  return response.headers.get("Location")
+}
+```
+
+---
+
+### Session Retrieval
+
+After a user successfully signs in, you can retrieve their session data securely.
+
+**Client-Side:**
+
+```ts
+const session = await authClient.getSession()
+console.log(session?.user) // The authenticated ClickUp user profile
+```
+
+**Server-Side:**
+
+```ts
+// Note: You must pass the native Web Request object or Headers!
+const session = await api.getSession(request)
+console.log(session?.user) // Safely retrieved backend session
+```
+
+</Step>
+
+</Steps>
+
+---
+
+## Resources
+
+- [RFC - The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749)
+- [Click Up - Create your own app](https://help.clickup.com/hc/en-us/articles/6303422883095-Create-your-own-app-with-the-ClickUp-API)
+- [Click Up - Authentication](https://developer.clickup.com/docs/authentication)
+- [Click UP - Get Access Token](https://developer.clickup.com/reference/getaccesstoken)
+- [Click Up - Get Authorized User](https://developer.clickup.com/reference/getauthorizeduser)

--- a/docs/src/content/docs/oauth/click-up.mdx
+++ b/docs/src/content/docs/oauth/click-up.mdx
@@ -36,8 +36,8 @@ The first step is to create and register an OAuth App on the ClickUp Workspace t
 1. Navigate to your Clickup Avatar and go to **Settings > Integrations & ClickApps > ClickUp API > ClickUp API Settings**.
 2. Click **Create an App**.
 3. Fill in the "App name".
-4. Set the **Redirect URL(s)** to `localhost:3000`.
-   - _(Make sure to replace `localhost:3000` with your production domain when deploying)_
+4. Set the **Redirect URL(s)** to `http://localhost:3000/auth/callback/click-up`.
+   - _(Make sure to replace `http://localhost:3000` with your production domain when deploying)_
 5. Click **Create App**.
 6. Ensure you copy the **Client ID** and click **Generate a new client secret**.
 
@@ -119,7 +119,7 @@ export const auth = createAuth({
     clickUp({
       authorize: {
         params: {
-          scope: "read:user user:email",
+          clientId: process.env.AURA_AUTH_CLICK_UP_CLIENT_ID!,
         },
       },
     }),

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Added the `Click UP` OAuth provider to the supported integrations in Aura Auth. [#151](https://github.com/aura-stack-ts/auth/pull/151)
+- Added the `ClickUp` OAuth provider to the supported integrations in Aura Auth. [#151](https://github.com/aura-stack-ts/auth/pull/151)
 
 - Added `InferSession` and `SessionFrom` types to infer the session type from either an auth instance or a Zod schema. [#150](https://github.com/aura-stack-ts/auth/pull/150)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the `Click UP` OAuth provider to the supported integrations in Aura Auth. [#151](https://github.com/aura-stack-ts/auth/pull/151)
+
 - Added `InferSession` and `SessionFrom` types to infer the session type from either an auth instance or a Zod schema. [#150](https://github.com/aura-stack-ts/auth/pull/150)
 
 ### Changed

--- a/packages/core/src/actions/callback/access-token.ts
+++ b/packages/core/src/actions/callback/access-token.ts
@@ -63,12 +63,10 @@ export const createAccessToken = async (
                 code_verifier: codeVerifier,
             }).toString(),
         })
-
         if (!response.ok) {
             logger?.log("INVALID_OAUTH_ACCESS_TOKEN_RESPONSE")
             throw new OAuthProtocolError("invalid_request", "Invalid access token response")
         }
-
         const json = await response.json()
         const token = OAuthAccessTokenResponse.safeParse(json)
         if (!token.success) {

--- a/packages/core/src/oauth/click-up.ts
+++ b/packages/core/src/oauth/click-up.ts
@@ -5,7 +5,7 @@ import type { OAuthProviderCredentials, User } from "@/@types/index.ts"
  */
 export interface ClickUpProfile {
     user: {
-        id: string
+        id: number
         username: string
         email: string
         color: string
@@ -36,7 +36,7 @@ export const clickUp = <DefaultUser extends User = User>(
         userInfo: "https://api.clickup.com/api/v2/user",
         profile: (profile) => {
             return {
-                sub: profile.user.id,
+                sub: String(profile.user.id),
                 name: profile.user.username,
                 email: profile.user.email,
                 image: profile.user.profilePicture,

--- a/packages/core/src/oauth/click-up.ts
+++ b/packages/core/src/oauth/click-up.ts
@@ -1,0 +1,47 @@
+import type { OAuthProviderCredentials, User } from "@/@types/index.ts"
+
+/**
+ * @see [Click Up - Get Authorized User](https://developer.clickup.com/reference/getauthorizeduser)
+ */
+export interface ClickUpProfile {
+    user: {
+        id: string
+        username: string
+        email: string
+        color: string
+        profilePicture: string
+        initials: string
+        week_start_day: number
+        global_font_support: boolean
+        timezone: string
+    }
+}
+
+/**
+ * ClickUp OAuth Provider
+ *
+ * @see [Click Up - Create your own app](https://help.clickup.com/hc/en-us/articles/6303422883095-Create-your-own-app-with-the-ClickUp-API)
+ * @see [Click Up - Authentication](https://developer.clickup.com/docs/authentication)
+ * @see [Click UP - Get Access Token](https://developer.clickup.com/reference/getaccesstoken)
+ * @see [Click Up - Get Authorized User](https://developer.clickup.com/reference/getauthorizeduser)
+ */
+export const clickUp = <DefaultUser extends User = User>(
+    options?: Partial<OAuthProviderCredentials<ClickUpProfile, DefaultUser>>
+): OAuthProviderCredentials<ClickUpProfile, DefaultUser> => {
+    return {
+        id: "click-up",
+        name: "ClickUp",
+        authorize: "https://app.clickup.com/api",
+        accessToken: "https://api.clickup.com/api/v2/oauth/token",
+        userInfo: "https://api.clickup.com/api/v2/user",
+        profile: (profile) => {
+            return {
+                sub: profile.user.id,
+                name: profile.user.username,
+                email: profile.user.email,
+                image: profile.user.profilePicture,
+            } as DefaultUser
+        },
+        ...options,
+    }
+}

--- a/packages/core/src/oauth/index.ts
+++ b/packages/core/src/oauth/index.ts
@@ -19,6 +19,7 @@ import { twitch } from "./twitch.ts"
 import { notion } from "./notion.ts"
 import { dropbox } from "./dropbox.ts"
 import { atlassian } from "./atlassian.ts"
+import { clickUp } from "./click-up.ts"
 import { formatZodError } from "@/shared/utils.ts"
 import { AuthInternalError } from "@/shared/errors.ts"
 import { OAuthEnvSchema, OAuthProviderCredentialsSchema } from "@/schemas.ts"
@@ -37,6 +38,7 @@ export * from "./twitch.ts"
 export * from "./notion.ts"
 export * from "./dropbox.ts"
 export * from "./atlassian.ts"
+export * from "./click-up.ts"
 
 export const builtInOAuthProviders = {
     github,
@@ -53,6 +55,7 @@ export const builtInOAuthProviders = {
     notion,
     dropbox,
     atlassian,
+    clickUp,
 } as const
 
 /**
@@ -68,8 +71,8 @@ export const builtInOAuthProviders = {
  */
 const defineOAuthEnvironment = (oauth: string) => {
     const loadEnvs = OAuthEnvSchema.safeParse({
-        clientId: getEnv(`${oauth.toUpperCase()}_CLIENT_ID`),
-        clientSecret: getEnv(`${oauth.toUpperCase()}_CLIENT_SECRET`),
+        clientId: getEnv(`${oauth.replace("-", "_").toUpperCase()}_CLIENT_ID`),
+        clientSecret: getEnv(`${oauth.replace("-", "_").toUpperCase()}_CLIENT_SECRET`),
     })
     if (!loadEnvs.success) {
         const msg = JSON.stringify({ [oauth]: formatZodError(loadEnvs.error) }, null, 2)


### PR DESCRIPTION
## Description

This pull request adds the `Atlassian` OAuth provider to the list of supported OAuth integrations in the Aura Auth library.  
With this addition, Aura Auth now supports seven OAuth providers: `GitHub`, `Bitbucket`, `Figma`, `Discord`, `GitLab`, `Spotify`, `X`, `Strava` and  `Atlassian`

### Usage

```ts
import { createAuth } from "@aura-stack/auth"

export const auth = createAuth({
  oauth: ["click-up"],
})

export const { handlers } = auth
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ClickUp OAuth provider for authentication integration

* **Documentation**
  * Added comprehensive guide for configuring and implementing ClickUp OAuth, including setup instructions and integration examples

* **Chores**
  * Updated changelog with new provider support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->