### PR TITLE
feat(oauth): add `Coinbase` OAuth provider

### DIFF
--- a/docs/src/content/docs/oauth/coinbase.mdx
+++ b/docs/src/content/docs/oauth/coinbase.mdx
@@ -62,7 +62,7 @@ npm install @aura-stack/auth
 
 ## Environment setup
 
-Now, you must configure the environment variables required by Aura Auth, including the GitHub credentials and the encryption secrets.
+Now, you must configure the environment variables required by Aura Auth, including the Coinbase credentials and the encryption secrets.
 
 ```bash title=".env" lineNumbers
 # Aura Secrets
@@ -123,7 +123,7 @@ export const auth = createAuth({
       authorize: {
         params: {
           // Override default scopes
-          scope: "read:user user:email",
+          scope: "wallet:user:read wallet:user:email",
         },
       },
     }),
@@ -181,7 +181,7 @@ For environments supporting server-side actions, use the programmatic `api.signI
 import { api } from "./auth"
 
 export const serverSignIn = async () => {
-  const response = await api.signIn("github", {
+  const response = await api.signIn("coinbase", {
     redirectTo: "http://localhost:3000/dashboard",
   })
 
@@ -200,7 +200,7 @@ After a user successfully signs in, you can retrieve their session data securely
 
 ```ts
 const session = await authClient.getSession()
-console.log(session?.user) // The authenticated GitHub user profile
+console.log(session?.user) // The authenticated Coinbase user profile
 ```
 
 **Server-Side:**

--- a/docs/src/content/docs/oauth/coinbase.mdx
+++ b/docs/src/content/docs/oauth/coinbase.mdx
@@ -1,0 +1,224 @@
+---
+title: Coinbase Authorization Provider
+description: Add Coinbase authorization provider to Aura Auth to authentication and authorize
+---
+
+## Coinbase
+
+Set up the `Coinbase` authorization provider in your Aura Auth instance.
+
+---
+
+## What you'll build
+
+Through this quick start guide you are going to learn and understand the basics and how to set up the `Coinbase` provider for Aura Auth.
+
+- [Coinbase OAuth App](#coinbase-oauth-app)
+- [Installation](#installation)
+- [Environment setup](#environment-setup)
+- [Configure the Auth Instance](#configure-the-auth-instance)
+- [Customizing the OAuth Provider](#customizing-the-oauth-provider)
+- [Sign In to Coinbase (Client & Server)](#sign-in-to-coinbase-client--server)
+- [Resources](#resources)
+
+---
+
+<Steps>
+
+<Step>
+
+## Coinbase OAuth App
+
+### Register the Application
+
+The first step is to create and register an OAuth App on the Coinbase CDP Portal to obtain access to the user's resources.
+
+1. Navigate to your Coinbase profile and go to **API Keys > Secret API Keys**.
+2. Click **Create API Key**.
+3. Fill in the "API Key nickname".
+4. Register the API restrictions:
+   - IP allowlist: `localhost:3000` (or your production domain when deploying)
+
+5. Set the **Authorization callback URL** to `http://localhost:3000/auth/callback/coinbase`.
+   - _(Make sure to replace `localhost:3000` with your production domain when deploying)_
+6. Click **Register application**.
+7. Ensure you copy the **Client ID** and click **Generate a new client secret**.
+
+</Step>
+
+<Step>
+
+## Installation
+
+Install the package using a package manager like `npm`, `pnpm`, or `yarn`:
+
+```npm
+npm install @aura-stack/auth
+```
+
+</Step>
+
+<Step>
+
+## Environment setup
+
+Now, you must configure the environment variables required by Aura Auth, including the GitHub credentials and the encryption secrets.
+
+```bash title=".env" lineNumbers
+# Aura Secrets
+AURA_AUTH_SECRET="your-32-byte-secret"
+AURA_AUTH_SALT="your-32-byte-salt"
+
+# Coinbase Credentials
+AURA_AUTH_COINBASE_CLIENT_ID="your_coinbase_client_id"
+AURA_AUTH_COINBASE_CLIENT_SECRET="your_coinbase_client_secret"
+```
+
+<Callout type="warn">
+  **CRITICAL SECURITY WARNING:** The `AURA_AUTH_SECRET` and `AURA_AUTH_SALT` variables are used to encrypt and sign user sessions.
+  These MUST be securely generated, highly randomized strings consisting of at least 32 bytes to ensure adequate entropy. Never
+  hardcode these values in your repository. Use a secure generator (like `openssl rand -base64 32`) to create them, and store them
+  exclusively in your secure environment variables manager.
+</Callout>
+
+</Step>
+
+<Step>
+
+## Configure the Auth Instance
+
+Configure the `createAuth` instance inside an `auth.ts` file located at the root of your project. Ensure you explicitly export the `handlers`, `api`, and `jose` objects.
+
+```ts title="auth.ts" lineNumbers
+import { createAuth } from "@aura-stack/auth"
+
+export const auth = createAuth({
+  oauth: ["coinbase"],
+})
+
+// Extract the required utilities
+export const { handlers, api, jose } = auth
+```
+
+<Callout type="info">
+  The `handlers` object contains mapping utilities for standard HTTP methods (`GET`, `POST`, `PATCH`) as well as a unified `ALL`
+  handler. This allows you to easily mount the authentication routes across any framework (Next.js, Elysia, Express, etc.).
+</Callout>
+
+</Step>
+
+<Step>
+
+## Customizing the OAuth Provider
+
+If you need to define custom scopes, change the response type, or map profile data differently, you can use the provider's factory function instead of a simple string identifier.
+
+```ts title="auth.ts" lineNumbers
+import { createAuth } from "@aura-stack/auth"
+import { coinbase } from "@aura-stack/auth/oauth/coinbase"
+
+export const auth = createAuth({
+  oauth: [
+    coinbase({
+      authorize: {
+        params: {
+          // Override default scopes
+          scope: "read:user user:email",
+        },
+      },
+    }),
+  ],
+})
+
+export const { handlers, api, jose } = auth
+```
+
+</Step>
+
+<Step>
+
+## Sign In to Coinbase (Client & Server)
+
+There are multiple ways to trigger the sign-in flow depending on your ecosystem.
+
+### Sign-in Path (Direct Navigation)
+
+The common route to trigger the auth flow natively without needing a client library is simply navigating the browser to:
+`http://localhost:3000/auth/signIn/coinbase`
+
+---
+
+### Client-Side (React, Vue, etc.)
+
+You can utilize the `createAuthClient` utility to programmatically trigger sign-ins. You can also define a `redirectTo` destination.
+
+<Callout type="warn">
+  **Constraint Rule**: The `baseURL` passed into `createAuthClient` MUST exactly match the root domain and path where the HTTP
+  `handlers` expose their endpoints on the server.
+</Callout>
+
+```ts title="components/Login.tsx" lineNumbers
+import { createAuthClient } from "@aura-stack/auth/client"
+
+export const authClient = createAuthClient({
+  baseURL: "http://localhost:3000/auth",
+})
+
+const triggerSignIn = async () => {
+  await authClient.signIn("coinbase", {
+    redirectTo: "/dashboard",
+  })
+}
+```
+
+---
+
+### Server-Side (Next.js Actions, Remix Loaders, etc.)
+
+For environments supporting server-side actions, use the programmatic `api.signIn` method securely.
+
+```ts title="actions.ts" lineNumbers
+import { api } from "./auth"
+
+export const serverSignIn = async () => {
+  const response = await api.signIn("github", {
+    redirectTo: "http://localhost:3000/dashboard",
+  })
+
+  // Example returning redirect location
+  return response.headers.get("Location")
+}
+```
+
+---
+
+### Session Retrieval
+
+After a user successfully signs in, you can retrieve their session data securely.
+
+**Client-Side:**
+
+```ts
+const session = await authClient.getSession()
+console.log(session?.user) // The authenticated GitHub user profile
+```
+
+**Server-Side:**
+
+```ts
+// Note: You must pass the native Web Request object or Headers!
+const session = await api.getSession(request)
+console.log(session?.user) // Safely retrieved backend session
+```
+
+</Step>
+
+</Steps>
+
+---
+
+## Resources
+
+- [RFC - The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749)
+- [Coinbase - App OAuth2 Integration](https://docs.cdp.coinbase.com/coinbase-app/oauth2-integration/integrations)
+- [Coinbase - Scopes](https://docs.cdp.coinbase.com/coinbase-app/oauth2-integration/scopes)

--- a/packages/core/src/oauth/coinbase.ts
+++ b/packages/core/src/oauth/coinbase.ts
@@ -36,7 +36,6 @@ export const coinbase = <DefaultUser extends User = User>(
         accessToken: "https://login.coinbase.com/oauth2/token",
         userInfo: "https://api.coinbase.com/v2/user",
         profile: (profile) => {
-            console.log("Coinbase profile", profile)
             return {
                 sub: String(profile.data.id),
                 name: profile.data.name,

--- a/packages/core/src/oauth/coinbase.ts
+++ b/packages/core/src/oauth/coinbase.ts
@@ -1,0 +1,49 @@
+import type { OAuthProviderCredentials, User } from "@/@types/index.ts"
+
+export interface CoinbaseProfile {
+    data: {
+        id: string
+        name: string
+        username: string
+        profile_bio: string | null
+        profile_location: string | null
+        profile_url: string
+        avatar_url: string
+        resource: string
+        resource_path: string
+    }
+}
+
+/**
+ * Coinbase OAuth Provider
+ *
+ * @see [Coinbase - App OAuth2 Integration](https://docs.cdp.coinbase.com/coinbase-app/oauth2-integration/integrations)
+ * @see [Coinbase - Scopes](https://docs.cdp.coinbase.com/coinbase-app/oauth2-integration/scopes)
+ */
+export const coinbase = <DefaultUser extends User = User>(
+    options?: Partial<OAuthProviderCredentials<CoinbaseProfile, DefaultUser>>
+): OAuthProviderCredentials<CoinbaseProfile, DefaultUser> => {
+    return {
+        id: "coinbase",
+        name: "Coinbase",
+        authorize: {
+            url: "https://login.coinbase.com/oauth2/auth",
+            params: {
+                scope: "wallet:user:read+wallet:user:email",
+                responseType: "code",
+            },
+        },
+        accessToken: "https://login.coinbase.com/oauth2/token",
+        userInfo: "https://api.coinbase.com/v2/user",
+        profile: (profile) => {
+            console.log("Coinbase profile", profile)
+            return {
+                sub: String(profile.data.id),
+                name: profile.data.name,
+                image: profile.data.avatar_url,
+                email: null,
+            } as DefaultUser
+        },
+        ...options,
+    }
+}

--- a/packages/core/src/oauth/index.ts
+++ b/packages/core/src/oauth/index.ts
@@ -20,6 +20,7 @@ import { notion } from "./notion.ts"
 import { dropbox } from "./dropbox.ts"
 import { atlassian } from "./atlassian.ts"
 import { clickUp } from "./click-up.ts"
+import { coinbase } from "./coinbase.ts"
 import { formatZodError } from "@/shared/utils.ts"
 import { AuthInternalError } from "@/shared/errors.ts"
 import { OAuthEnvSchema, OAuthProviderCredentialsSchema } from "@/schemas.ts"
@@ -39,6 +40,7 @@ export * from "./notion.ts"
 export * from "./dropbox.ts"
 export * from "./atlassian.ts"
 export * from "./click-up.ts"
+export * from "./coinbase.ts"
 
 export const builtInOAuthProviders = {
     github,
@@ -56,6 +58,7 @@ export const builtInOAuthProviders = {
     dropbox,
     atlassian,
     clickUp,
+    coinbase,
 } as const
 
 /**


### PR DESCRIPTION
## Description

This pull request adds the `Atlassian` OAuth provider to the list of supported OAuth integrations in the Aura Auth library.  
With this addition, Aura Auth now supports seven OAuth providers: `GitHub`, `Bitbucket`, `Figma`, `Discord`, `GitLab`, `Spotify`, `X`, `Strava` and  `Atlassian`

### Usage

```ts
import { createAuth } from "@aura-stack/auth"

export const auth = createAuth({
  oauth: ["coinbase"],
})

export const { handlers } = auth
```

> [!NOTE]
> This Coinbase OAuth provider was developed based on the [Officials Docs for App OAuth 2.0 Integration](https://docs.cdp.coinbase.com/coinbase-app/oauth2-integration/integrations), covering the authorization URL, access token exchange, and profile retrieval. However, the provider cannot currently be verified because the documentation lacks clear instructions on how to obtain a Client ID and Client Secret. Consequently, this PR will remain a draft until these credentials can be acquired to verify the end-to-end OAuth 2.0 flow.
