### PR TITLE
feat(oauth): add `Dribble` OAuth provider

### DIFF
--- a/docs/src/content/docs/oauth/dribble.mdx
+++ b/docs/src/content/docs/oauth/dribble.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dribbble Authorization Provider
-description: description: Add the Dribbble authorization provider to Aura Auth to authenticate and authorize users.
+description: Add the Dribbble authorization provider to Aura Auth to authenticate and authorize users.
 ---
 
 ## Dribbble

--- a/docs/src/content/docs/oauth/dribble.mdx
+++ b/docs/src/content/docs/oauth/dribble.mdx
@@ -1,11 +1,11 @@
 ---
-title: Dribble Authorization Provider
-description: Add Dribble authorization provider to Aura Auth to authentication and authorize
+title: Dribbble Authorization Provider
+description: description: Add the Dribbble authorization provider to Aura Auth to authenticate and authorize users.
 ---
 
-## Dribble
+## Dribbble
 
-Set up the `Dribble` authorization provider in your Aura Auth instance.
+Set up the `Dribbble` authorization provider in your Aura Auth instance.
 
 ---
 
@@ -13,12 +13,12 @@ Set up the `Dribble` authorization provider in your Aura Auth instance.
 
 Through this quick start guide you are going to learn and understand the basics and how to set up the `Dribble` provider for Aura Auth.
 
-- [Dribble OAuth App](#dribble-oauth-app)
+- [Dribbble OAuth App](#dribbble-oauth-app)
 - [Installation](#installation)
 - [Environment setup](#environment-setup)
 - [Configure the Auth Instance](#configure-the-auth-instance)
 - [Customizing the OAuth Provider](#customizing-the-oauth-provider)
-- [Sign In to Dribble (Client & Server)](#sign-in-to-dribble-client--server)
+- [Sign In to Dribbble (Client & Server)](#sign-in-to-dribbble-client--server)
 - [Resources](#resources)
 
 ---
@@ -27,16 +27,16 @@ Through this quick start guide you are going to learn and understand the basics 
 
 <Step>
 
-## Dribble OAuth App
+## Dribbble OAuth App
 
 ### Register the Application
 
-The first step is to create and register an OAuth App on the Dribble Applications page to obtain access to the user's resources.
+The first step is to create and register an OAuth App on the Dribbble Applications page to obtain access to the user's resources.
 
-1. Navigate to your Dribble profile and go to **Settings > Applications**.
+1. Navigate to your Dribbble profile and go to **Settings > Applications**.
 2. Click **Register a new application**.
 3. Fill in the "Application name", "Description", and "Website URL".
-4. Set the **Callback URL** to `http://localhost:3000/auth/callback/dribble`.
+4. Set the **Callback URL** to `http://localhost:3000/auth/callback/dribbble`.
    - _(Make sure to replace `localhost:3000` with your production domain when deploying)_
 5. Click **Register application**.
 6. Ensure you copy the **Client ID** and click **Generate a new client secret**.
@@ -59,16 +59,16 @@ npm install @aura-stack/auth
 
 ## Environment setup
 
-Now, you must configure the environment variables required by Aura Auth, including the Dribble credentials and the encryption secrets.
+Now, you must configure the environment variables required by Aura Auth, including the Dribbble credentials and the encryption secrets.
 
 ```bash title=".env" lineNumbers
 # Aura Secrets
 AURA_AUTH_SECRET="your-32-byte-secret"
 AURA_AUTH_SALT="your-32-byte-salt"
 
-# Dribble Credentials
-AURA_AUTH_DRIBBLE_CLIENT_ID="your_dribble_client_id"
-AURA_AUTH_DRIBBLE_CLIENT_SECRET="your_dribble_client_secret"
+# Dribbble Credentials
+AURA_AUTH_DRIBBBLE_CLIENT_ID="your_dribbble_client_id"
+AURA_AUTH_DRIBBBLE_CLIENT_SECRET="your_dribbble_client_secret"
 ```
 
 <Callout type="warn">
@@ -90,7 +90,7 @@ Configure the `createAuth` instance inside an `auth.ts` file located at the root
 import { createAuth } from "@aura-stack/auth"
 
 export const auth = createAuth({
-  oauth: ["dribble"],
+  oauth: ["dribbble"],
 })
 
 // Extract the required utilities
@@ -112,11 +112,11 @@ If you need to define custom scopes, change the response type, or map profile da
 
 ```ts title="auth.ts" lineNumbers
 import { createAuth } from "@aura-stack/auth"
-import { dribble } from "@aura-stack/auth/oauth/dribble"
+import { dribbble } from "@aura-stack/auth/oauth/dribbble"
 
 export const auth = createAuth({
   oauth: [
-    dribble({
+    dribbble({
       authorize: {
         params: {
           // Override default scopes
@@ -134,14 +134,14 @@ export const { handlers, api, jose } = auth
 
 <Step>
 
-## Sign In to Dribble (Client & Server)
+## Sign In to Dribbble (Client & Server)
 
 There are multiple ways to trigger the sign-in flow depending on your ecosystem.
 
 ### Sign-in Path (Direct Navigation)
 
 The common route to trigger the auth flow natively without needing a client library is simply navigating the browser to:
-`http://localhost:3000/auth/signIn/dribble`
+`http://localhost:3000/auth/signIn/dribbble`
 
 ---
 
@@ -162,7 +162,7 @@ export const authClient = createAuthClient({
 })
 
 const triggerSignIn = async () => {
-  await authClient.signIn("dribble", {
+  await authClient.signIn("dribbble", {
     redirectTo: "/dashboard",
   })
 }
@@ -178,7 +178,7 @@ For environments supporting server-side actions, use the programmatic `api.signI
 import { api } from "./auth"
 
 export const serverSignIn = async () => {
-  const response = await api.signIn("dribble", {
+  const response = await api.signIn("dribbble", {
     redirectTo: "http://localhost:3000/dashboard",
   })
 
@@ -197,7 +197,7 @@ After a user successfully signs in, you can retrieve their session data securely
 
 ```ts
 const session = await authClient.getSession()
-console.log(session?.user) // The authenticated Dribble user profile
+console.log(session?.user) // The authenticated Dribbble user profile
 ```
 
 **Server-Side:**

--- a/docs/src/content/docs/oauth/dribble.mdx
+++ b/docs/src/content/docs/oauth/dribble.mdx
@@ -1,0 +1,222 @@
+---
+title: Dribble Authorization Provider
+description: Add Dribble authorization provider to Aura Auth to authentication and authorize
+---
+
+## Dribble
+
+Set up the `Dribble` authorization provider in your Aura Auth instance.
+
+---
+
+## What you'll build
+
+Through this quick start guide you are going to learn and understand the basics and how to set up the `Dribble` provider for Aura Auth.
+
+- [Dribble OAuth App](#dribble-oauth-app)
+- [Installation](#installation)
+- [Environment setup](#environment-setup)
+- [Configure the Auth Instance](#configure-the-auth-instance)
+- [Customizing the OAuth Provider](#customizing-the-oauth-provider)
+- [Sign In to Dribble (Client & Server)](#sign-in-to-dribble-client--server)
+- [Resources](#resources)
+
+---
+
+<Steps>
+
+<Step>
+
+## Dribble OAuth App
+
+### Register the Application
+
+The first step is to create and register an OAuth App on the Dribble Applications page to obtain access to the user's resources.
+
+1. Navigate to your Dribble profile and go to **Settings > Applications**.
+2. Click **Register a new application**.
+3. Fill in the "Application name", "Description", and "Website URL".
+4. Set the **Callback URL** to `http://localhost:3000/auth/callback/dribble`.
+   - _(Make sure to replace `localhost:3000` with your production domain when deploying)_
+5. Click **Register application**.
+6. Ensure you copy the **Client ID** and click **Generate a new client secret**.
+
+</Step>
+
+<Step>
+
+## Installation
+
+Install the package using a package manager like `npm`, `pnpm`, or `yarn`:
+
+```npm
+npm install @aura-stack/auth
+```
+
+</Step>
+
+<Step>
+
+## Environment setup
+
+Now, you must configure the environment variables required by Aura Auth, including the Dribble credentials and the encryption secrets.
+
+```bash title=".env" lineNumbers
+# Aura Secrets
+AURA_AUTH_SECRET="your-32-byte-secret"
+AURA_AUTH_SALT="your-32-byte-salt"
+
+# Dribble Credentials
+AURA_AUTH_DRIBBLE_CLIENT_ID="your_dribble_client_id"
+AURA_AUTH_DRIBBLE_CLIENT_SECRET="your_dribble_client_secret"
+```
+
+<Callout type="warn">
+  **CRITICAL SECURITY WARNING:** The `AURA_AUTH_SECRET` and `AURA_AUTH_SALT` variables are used to encrypt and sign user sessions.
+  These MUST be securely generated, highly randomized strings consisting of at least 32 bytes to ensure adequate entropy. Never
+  hardcode these values in your repository. Use a secure generator (like `openssl rand -base64 32`) to create them, and store them
+  exclusively in your secure environment variables manager.
+</Callout>
+
+</Step>
+
+<Step>
+
+## Configure the Auth Instance
+
+Configure the `createAuth` instance inside an `auth.ts` file located at the root of your project. Ensure you explicitly export the `handlers`, `api`, and `jose` objects.
+
+```ts title="auth.ts" lineNumbers
+import { createAuth } from "@aura-stack/auth"
+
+export const auth = createAuth({
+  oauth: ["dribble"],
+})
+
+// Extract the required utilities
+export const { handlers, api, jose } = auth
+```
+
+<Callout type="info">
+  The `handlers` object contains mapping utilities for standard HTTP methods (`GET`, `POST`, `PATCH`) as well as a unified `ALL`
+  handler. This allows you to easily mount the authentication routes across any framework (Next.js, Elysia, Express, etc.).
+</Callout>
+
+</Step>
+
+<Step>
+
+## Customizing the OAuth Provider
+
+If you need to define custom scopes, change the response type, or map profile data differently, you can use the provider's factory function instead of a simple string identifier.
+
+```ts title="auth.ts" lineNumbers
+import { createAuth } from "@aura-stack/auth"
+import { dribble } from "@aura-stack/auth/oauth/dribble"
+
+export const auth = createAuth({
+  oauth: [
+    dribble({
+      authorize: {
+        params: {
+          // Override default scopes
+          scope: "upload",
+        },
+      },
+    }),
+  ],
+})
+
+export const { handlers, api, jose } = auth
+```
+
+</Step>
+
+<Step>
+
+## Sign In to Dribble (Client & Server)
+
+There are multiple ways to trigger the sign-in flow depending on your ecosystem.
+
+### Sign-in Path (Direct Navigation)
+
+The common route to trigger the auth flow natively without needing a client library is simply navigating the browser to:
+`http://localhost:3000/auth/signIn/dribble`
+
+---
+
+### Client-Side (React, Vue, etc.)
+
+You can utilize the `createAuthClient` utility to programmatically trigger sign-ins. You can also define a `redirectTo` destination.
+
+<Callout type="warn">
+  **Constraint Rule**: The `baseURL` passed into `createAuthClient` MUST exactly match the root domain and path where the HTTP
+  `handlers` expose their endpoints on the server.
+</Callout>
+
+```ts title="components/Login.tsx" lineNumbers
+import { createAuthClient } from "@aura-stack/auth/client"
+
+export const authClient = createAuthClient({
+  baseURL: "http://localhost:3000/auth",
+})
+
+const triggerSignIn = async () => {
+  await authClient.signIn("dribble", {
+    redirectTo: "/dashboard",
+  })
+}
+```
+
+---
+
+### Server-Side (Next.js Actions, Remix Loaders, etc.)
+
+For environments supporting server-side actions, use the programmatic `api.signIn` method securely.
+
+```ts title="actions.ts" lineNumbers
+import { api } from "./auth"
+
+export const serverSignIn = async () => {
+  const response = await api.signIn("dribble", {
+    redirectTo: "http://localhost:3000/dashboard",
+  })
+
+  // Example returning redirect location
+  return response.headers.get("Location")
+}
+```
+
+---
+
+### Session Retrieval
+
+After a user successfully signs in, you can retrieve their session data securely.
+
+**Client-Side:**
+
+```ts
+const session = await authClient.getSession()
+console.log(session?.user) // The authenticated Dribble user profile
+```
+
+**Server-Side:**
+
+```ts
+// Note: You must pass the native Web Request object or Headers!
+const session = await api.getSession(request)
+console.log(session?.user) // Safely retrieved backend session
+```
+
+</Step>
+
+</Steps>
+
+---
+
+## Resources
+
+- [RFC - The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749)
+- [Dribble - Register Application](https://dribbble.com/account/applications/new)
+- [Dribble - OAuth](https://developer.dribbble.com/v2/oauth/)
+- [Dribble - User](https://developer.dribbble.com/v2/user/)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the `Dribbble` OAuth provider to the supported integrations in Aura Auth. [#153](https://github.com/aura-stack-ts/auth/pull/153)
+
 - Added the `ClickUp` OAuth provider to the supported integrations in Aura Auth. [#151](https://github.com/aura-stack-ts/auth/pull/151)
 
 - Added `InferSession` and `SessionFrom` types to infer the session type from either an auth instance or a Zod schema. [#150](https://github.com/aura-stack-ts/auth/pull/150)

--- a/packages/core/src/oauth/dribble.ts
+++ b/packages/core/src/oauth/dribble.ts
@@ -3,7 +3,7 @@ import type { OAuthProviderCredentials, User } from "@/@types/index.ts"
 /**
  * @see [Dribble - User](https://developer.dribbble.com/v2/user/)
  */
-export interface DribbleDefault {
+export interface DribbbleDefault {
     id: number
     name: string
     login: string
@@ -18,34 +18,34 @@ export interface DribbleDefault {
     created_at: string
 }
 
-export interface DribbleTeams extends DribbleDefault {
+export interface DribbbleTeams extends DribbbleDefault {
     type: "Team"
     updated_at: string
 }
 
-export interface DribbleProfile extends DribbleDefault {
+export interface DribbbleProfile extends DribbbleDefault {
     type: "User"
     /** Not documented but available in the API response */
     email: string | null
     can_upload_shot: boolean
     pro: boolean
     followers_count: number
-    teams: DribbleTeams[]
+    teams: DribbbleTeams[]
 }
 
 /**
- * Dribble OAuth provider
+ * Dribbble OAuth provider
  *
- * @see [Dribble - Register Application](https://dribbble.com/account/applications/new)
- * @see [Dribble - OAuth](https://developer.dribbble.com/v2/oauth/)
- * @see [Dribble - User](https://developer.dribbble.com/v2/user/)
+ * @see [Dribbble - Register Application](https://dribbble.com/account/applications/new)
+ * @see [Dribbble - OAuth](https://developer.dribbble.com/v2/oauth/)
+ * @see [Dribbble - User](https://developer.dribbble.com/v2/user/)
  */
-export const dribble = <DefaultUser extends User = User>(
-    options?: Partial<OAuthProviderCredentials<DribbleProfile, DefaultUser>>
-): OAuthProviderCredentials<DribbleProfile, DefaultUser> => {
+export const dribbble = <DefaultUser extends User = User>(
+    options?: Partial<OAuthProviderCredentials<DribbbleProfile, DefaultUser>>
+): OAuthProviderCredentials<DribbbleProfile, DefaultUser> => {
     return {
-        id: "dribble",
-        name: "Dribble",
+        id: "dribbble",
+        name: "Dribbble",
         authorize: {
             url: "https://dribbble.com/oauth/authorize",
             params: {
@@ -55,7 +55,6 @@ export const dribble = <DefaultUser extends User = User>(
         accessToken: "https://dribbble.com/oauth/token",
         userInfo: "https://api.dribbble.com/v2/user",
         profile: (profile) => {
-            console.log("Dribble profile", profile)
             return {
                 sub: String(profile.id),
                 name: profile.name,

--- a/packages/core/src/oauth/dribble.ts
+++ b/packages/core/src/oauth/dribble.ts
@@ -1,0 +1,68 @@
+import type { OAuthProviderCredentials, User } from "@/@types/index.ts"
+
+/**
+ * @see [Dribble - User](https://developer.dribbble.com/v2/user/)
+ */
+export interface DribbleDefault {
+    id: number
+    name: string
+    login: string
+    html_url: string
+    avatar_url: string
+    bio: string
+    location: string
+    links?: {
+        web?: string
+        twitter?: string
+    }
+    created_at: string
+}
+
+export interface DribbleTeams extends DribbleDefault {
+    type: "Team"
+    updated_at: string
+}
+
+export interface DribbleProfile extends DribbleDefault {
+    type: "User"
+    /** Not documented but available in the API response */
+    email: string | null
+    can_upload_shot: boolean
+    pro: boolean
+    followers_count: number
+    teams: DribbleTeams[]
+}
+
+/**
+ * Dribble OAuth provider
+ *
+ * @see [Dribble - Register Application](https://dribbble.com/account/applications/new)
+ * @see [Dribble - OAuth](https://developer.dribbble.com/v2/oauth/)
+ * @see [Dribble - User](https://developer.dribbble.com/v2/user/)
+ */
+export const dribble = <DefaultUser extends User = User>(
+    options?: Partial<OAuthProviderCredentials<DribbleProfile, DefaultUser>>
+): OAuthProviderCredentials<DribbleProfile, DefaultUser> => {
+    return {
+        id: "dribble",
+        name: "Dribble",
+        authorize: {
+            url: "https://dribbble.com/oauth/authorize",
+            params: {
+                scope: "public",
+            },
+        },
+        accessToken: "https://dribbble.com/oauth/token",
+        userInfo: "https://api.dribbble.com/v2/user",
+        profile: (profile) => {
+            console.log("Dribble profile", profile)
+            return {
+                sub: String(profile.id),
+                name: profile.name,
+                image: profile.avatar_url,
+                email: profile.email,
+            } as DefaultUser
+        },
+        ...options,
+    }
+}

--- a/packages/core/src/oauth/index.ts
+++ b/packages/core/src/oauth/index.ts
@@ -20,6 +20,7 @@ import { notion } from "./notion.ts"
 import { dropbox } from "./dropbox.ts"
 import { atlassian } from "./atlassian.ts"
 import { clickUp } from "./click-up.ts"
+import { dribble } from "./dribble.ts"
 import { formatZodError } from "@/shared/utils.ts"
 import { AuthInternalError } from "@/shared/errors.ts"
 import { OAuthEnvSchema, OAuthProviderCredentialsSchema } from "@/schemas.ts"
@@ -39,6 +40,7 @@ export * from "./notion.ts"
 export * from "./dropbox.ts"
 export * from "./atlassian.ts"
 export * from "./click-up.ts"
+export * from "./dribble.ts"
 
 export const builtInOAuthProviders = {
     github,
@@ -56,6 +58,7 @@ export const builtInOAuthProviders = {
     dropbox,
     atlassian,
     clickUp,
+    dribble,
 } as const
 
 /**


### PR DESCRIPTION
## Description

This pull request adds the `Atlassian` OAuth provider to the list of supported OAuth integrations in the Aura Auth library.  
With this addition, Aura Auth now supports seven OAuth providers: `GitHub`, `Bitbucket`, `Figma`, `Discord`, `GitLab`, `Spotify`, `X`, `Strava` and  `Atlassian`

### Usage

```ts
import { createAuth } from "@aura-stack/auth"

export const auth = createAuth({
  oauth: ["dribble"],
})

export const { handlers } = auth
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dribble as an OAuth authentication provider, enabling users to sign in with their Dribble accounts.

* **Documentation**
  * Added setup guide for Dribble authentication, covering configuration, environment variables, sign-in methods, and session retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->