### PR TITLE
feat(oauth): add  `Reddit` OAuth provider

### DIFF
--- a/docs/src/content/docs/oauth/reddit.mdx
+++ b/docs/src/content/docs/oauth/reddit.mdx
@@ -1,0 +1,221 @@
+---
+title: Reddit Authorization Provider
+description: Add Reddit authorization provider to Aura Auth to authentication and authorize
+---
+
+## Reddit
+
+Set up the `Reddit` authorization provider in your Aura Auth instance.
+
+---
+
+## What you'll build
+
+Through this quick start guide you are going to learn and understand the basics and how to set up the `Reddit` provider for Aura Auth.
+
+- [Reddit OAuth App](#reddit-oauth-app)
+- [Installation](#installation)
+- [Environment setup](#environment-setup)
+- [Configure the Auth Instance](#configure-the-auth-instance)
+- [Customizing the OAuth Provider](#customizing-the-oauth-provider)
+- [Sign In to Reddit (Client & Server)](#sign-in-to-reddit-client--server)
+- [Resources](#resources)
+
+---
+
+<Steps>
+
+<Step>
+
+## Reddit OAuth App
+
+### Register the Application
+
+The first step is to create and register an OAuth App on the [Reddit Developer Portal](https://www.reddit.com/prefs/apps/) to obtain access to the user's resources.
+
+1. Navigate to your Reddit profile and go to **Apps**.
+2. Click **are you a developer? create an app**.
+3. Fill in the "Name" and "Description".
+4. Set the **Redirect URI** to `http://localhost:3000/auth/callback/reddit`.
+   - _(Make sure to replace `localhost:3000` with your production domain when deploying)_
+5. Click **Create app**.
+6. Ensure you copy the **Client ID** and click **Generate a new client secret**.
+
+</Step>
+
+<Step>
+
+## Installation
+
+Install the package using a package manager like `npm`, `pnpm`, or `yarn`:
+
+```npm
+npm install @aura-stack/auth
+```
+
+</Step>
+
+<Step>
+
+## Environment setup
+
+Now, you must configure the environment variables required by Aura Auth, including the Reddit credentials and the encryption secrets.
+
+```bash title=".env" lineNumbers
+# Aura Secrets
+AURA_AUTH_SECRET="your-32-byte-secret"
+AURA_AUTH_SALT="your-32-byte-salt"
+
+# Reddit Credentials
+AURA_AUTH_REDDIT_CLIENT_ID="your_reddit_client_id"
+AURA_AUTH_REDDIT_CLIENT_SECRET="your_reddit_client_secret"
+```
+
+<Callout type="warn">
+  **CRITICAL SECURITY WARNING:** The `AURA_AUTH_SECRET` and `AURA_AUTH_SALT` variables are used to encrypt and sign user sessions.
+  These MUST be securely generated, highly randomized strings consisting of at least 32 bytes to ensure adequate entropy. Never
+  hardcode these values in your repository. Use a secure generator (like `openssl rand -base64 32`) to create them, and store them
+  exclusively in your secure environment variables manager.
+</Callout>
+
+</Step>
+
+<Step>
+
+## Configure the Auth Instance
+
+Configure the `createAuth` instance inside an `auth.ts` file located at the root of your project. Ensure you explicitly export the `handlers`, `api`, and `jose` objects.
+
+```ts title="auth.ts" lineNumbers
+import { createAuth } from "@aura-stack/auth"
+
+export const auth = createAuth({
+  oauth: ["reddit"],
+})
+
+// Extract the required utilities
+export const { handlers, api, jose } = auth
+```
+
+<Callout type="info">
+  The `handlers` object contains mapping utilities for standard HTTP methods (`GET`, `POST`, `PATCH`) as well as a unified `ALL`
+  handler. This allows you to easily mount the authentication routes across any framework (Next.js, Elysia, Express, etc.).
+</Callout>
+
+</Step>
+
+<Step>
+
+## Customizing the OAuth Provider
+
+If you need to define custom scopes, change the response type, or map profile data differently, you can use the provider's factory function instead of a simple string identifier.
+
+```ts title="auth.ts" lineNumbers
+import { createAuth } from "@aura-stack/auth"
+import { reddit } from "@aura-stack/auth/oauth/reddit"
+
+export const auth = createAuth({
+  oauth: [
+    reddit({
+      authorize: {
+        params: {
+          // Override default scopes
+          scope: "identity",
+        },
+      },
+    }),
+  ],
+})
+
+export const { handlers, api, jose } = auth
+```
+
+</Step>
+
+<Step>
+
+## Sign In to Reddit (Client & Server)
+
+There are multiple ways to trigger the sign-in flow depending on your ecosystem.
+
+### Sign-in Path (Direct Navigation)
+
+The common route to trigger the auth flow natively without needing a client library is simply navigating the browser to:
+`http://localhost:3000/auth/signIn/reddit`
+
+---
+
+### Client-Side (React, Vue, etc.)
+
+You can utilize the `createAuthClient` utility to programmatically trigger sign-ins. You can also define a `redirectTo` destination.
+
+<Callout type="warn">
+  **Constraint Rule**: The `baseURL` passed into `createAuthClient` MUST exactly match the root domain and path where the HTTP
+  `handlers` expose their endpoints on the server.
+</Callout>
+
+```ts title="components/Login.tsx" lineNumbers
+import { createAuthClient } from "@aura-stack/auth/client"
+
+export const authClient = createAuthClient({
+  baseURL: "http://localhost:3000/auth",
+})
+
+const triggerSignIn = async () => {
+  await authClient.signIn("reddit", {
+    redirectTo: "/dashboard",
+  })
+}
+```
+
+---
+
+### Server-Side (Next.js Actions, Remix Loaders, etc.)
+
+For environments supporting server-side actions, use the programmatic `api.signIn` method securely.
+
+```ts title="actions.ts" lineNumbers
+import { api } from "./auth"
+
+export const serverSignIn = async () => {
+  const response = await api.signIn("reddit", {
+    redirectTo: "http://localhost:3000/dashboard",
+  })
+
+  // Example returning redirect location
+  return response.headers.get("Location")
+}
+```
+
+---
+
+### Session Retrieval
+
+After a user successfully signs in, you can retrieve their session data securely.
+
+**Client-Side:**
+
+```ts
+const session = await authClient.getSession()
+console.log(session?.user) // The authenticated Reddit user profile
+```
+
+**Server-Side:**
+
+```ts
+// Note: You must pass the native Web Request object or Headers!
+const session = await api.getSession(request)
+console.log(session?.user) // Safely retrieved backend session
+```
+
+</Step>
+
+</Steps>
+
+---
+
+## Resources
+
+- [RFC - The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749)
+- [Reddit - Apps Portal](https://www.reddit.com/prefs/apps/)
+- [Reddit - API Documentation](https://www.reddit.com/dev/api/oauth/)

--- a/packages/core/src/oauth/index.ts
+++ b/packages/core/src/oauth/index.ts
@@ -20,7 +20,8 @@ import { notion } from "./notion.ts"
 import { dropbox } from "./dropbox.ts"
 import { atlassian } from "./atlassian.ts"
 import { clickUp } from "./click-up.ts"
-import { dribble } from "./dribble.ts"
+import { dribbble } from "./dribble.ts"
+import { reddit } from "./reddit.ts"
 import { formatZodError } from "@/shared/utils.ts"
 import { AuthInternalError } from "@/shared/errors.ts"
 import { OAuthEnvSchema, OAuthProviderCredentialsSchema } from "@/schemas.ts"
@@ -41,6 +42,7 @@ export * from "./dropbox.ts"
 export * from "./atlassian.ts"
 export * from "./click-up.ts"
 export * from "./dribble.ts"
+export * from "./reddit.ts"
 
 export const builtInOAuthProviders = {
     github,
@@ -58,7 +60,8 @@ export const builtInOAuthProviders = {
     dropbox,
     atlassian,
     clickUp,
-    dribble,
+    dribbble,
+    reddit,
 } as const
 
 /**

--- a/packages/core/src/oauth/reddit.ts
+++ b/packages/core/src/oauth/reddit.ts
@@ -1,0 +1,28 @@
+import type { OAuthProviderCredentials, User } from "@/@types/index.ts"
+
+export interface RedditProfile {}
+
+/**
+ * Reddit OAuth provider.
+ *
+ * @see [Reddit - Apps Portal](https://www.reddit.com/prefs/apps/)
+ * @see [Reddit - API Documentation](https://www.reddit.com/dev/api/oauth/)
+ *
+ */
+export const reddit = <DefaultUser extends User = User>(
+    options?: Partial<OAuthProviderCredentials<RedditProfile, DefaultUser>>
+): OAuthProviderCredentials<RedditProfile, DefaultUser> => {
+    return {
+        id: "reddit",
+        name: "Reddit",
+        authorize: {
+            url: "https://www.reddit.com/api/v1/authorize",
+            params: {
+                scope: "identity",
+            },
+        },
+        accessToken: "https://www.reddit.com/api/v1/access_token",
+        userInfo: "https://www.reddit.com/api/v1/user/me",
+        ...options,
+    }
+}


### PR DESCRIPTION
## Description

This pull request adds the `Atlassian` OAuth provider to the list of supported OAuth integrations in the Aura Auth library.  
With this addition, Aura Auth now supports seven OAuth providers: `GitHub`, `Bitbucket`, `Figma`, `Discord`, `GitLab`, `Spotify`, `X`, `Strava` and  `Atlassian`

### Usage

```ts
import { createAuth } from "@aura-stack/auth"

export const auth = createAuth({
  oauth: ["reddit"],
})

export const { handlers } = auth
```



> [!NOTE]
> This Reddit OAuth provider was developed based on the [Officials Docs for Reddit OAuth 2.0](https://github.com/reddit-archive/reddit/wiki/OAuth2), However, the provider could not be fully verified as OAuth apps could not be created correctly, and the `RedditProfile` cannot yet be defined. Consequently, this PR will be marked as a draft until complete coverage is achieved.
