### PR TITLE
feat(core): add experimental Arktype support for schema validation

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -87,6 +87,7 @@
   "dependencies": {
     "@aura-stack/jose": "workspace:*",
     "@aura-stack/router": "^0.6.0",
+    "arktype": "^2.2.0",
     "valibot": "^1.3.1",
     "zod": "catalog:zod-v4"
   },

--- a/packages/core/src/@types/config.ts
+++ b/packages/core/src/@types/config.ts
@@ -9,6 +9,7 @@ import type { ConfigSchema, FromShapeToObject, Prettify } from "@/@types/utility
 import type { OAuthProviderCredentials, OAuthProviderRecord } from "@/@types/oauth.ts"
 import type { JWTKey, SessionConfig, SessionStrategy, User } from "@/@types/session.ts"
 import { ObjectSchema } from "valibot"
+import { Type } from "arktype"
 
 /**
  * Main configuration interface for Aura Auth.
@@ -284,7 +285,7 @@ export interface InternalLogger {
  * Identity validation settings used when building session strategy and OAuth profile mapping.
  * Controls the Zod schema and how unknown keys are handled on user objects.
  */
-export interface IdentityConfig<Schema extends ZodObject<any> | ObjectSchema<any, undefined> = typeof UserIdentity> {
+export interface IdentityConfig<Schema extends ZodObject<any> | ObjectSchema<any, undefined | Type<any>> = typeof UserIdentity> {
     schema?: Schema
     skipValidation?: boolean
     unknownKeys?: "passthrough" | "strict" | "strip"

--- a/packages/core/src/@types/utility.ts
+++ b/packages/core/src/@types/utility.ts
@@ -1,8 +1,9 @@
+import type { Type } from "arktype"
 import type { AuthInstance } from "@/@types/config.ts"
-import type { Session, User, UserShape } from "@/@types/session.ts"
+import type { Session, User } from "@/@types/session.ts"
 import type { ZodObject, ZodRawShape, ZodTypeAny, infer as Infer } from "zod/v4"
+import type { Identities, IsArkType, IsZod, UserShapeValibot } from "@/shared/identity.ts"
 import type { ObjectSchema, BaseSchema, AnySchema as AnyValibotSchema, ObjectEntries, InferOutput } from "valibot"
-import { UserShapeValibot } from "@/shared/identity.ts"
 
 /** Expands intersection types into a single flat object type for readable editor hints. */
 export type Prettify<T> = { [K in keyof T]: T[K] }
@@ -30,14 +31,20 @@ export type EditableShapeValibot<T extends ObjectEntries> = {
         : BaseSchema<any, any, any>
 }
 
-export type ConfigSchema<T extends EditableShape<UserShape> | EditableShapeValibot<UserShapeValibot>> =
-    T extends EditableShape<UserShape>
+export type ConfigSchema<T extends Identities> =
+    IsZod<T> extends true
         ? ZodObject<T & ZodRawShape>
         : T extends EditableShapeValibot<UserShapeValibot>
           ? ObjectSchema<T & ObjectEntries, undefined>
-          : never
+          : IsArkType<T> extends true
+            ? T
+            : never
 
 export type ValibotShapeToObject<S extends ObjectEntries> = Merge<InferOutput<ObjectSchema<S, undefined>>, User>
+
+export type ArktypeShapeToObject<S extends Type> = S extends Type<infer Shape> ? Wrap<Merge<Shape, User>> : never
+
+export type EditableShapeArkType<T extends Type> = T extends Type<infer Shape> ? Type<{ [K in keyof Shape]: any }> : never
 
 /** Merges type `B` over `A`, replacing overlapping keys with `B`. */
 export type Merge<A, B> = Omit<A, keyof B> & B
@@ -52,7 +59,9 @@ export type FromShapeToObject<S> = S extends ZodRawShape
     ? ZodShapeToObject<S>
     : S extends ObjectEntries
       ? ValibotShapeToObject<S>
-      : never
+      : S extends Type
+        ? ArktypeShapeToObject<S>
+        : never
 
 /** Recursively makes every property required. */
 export type DeepRequired<T> = {

--- a/packages/core/src/actions/signIn/authorization.ts
+++ b/packages/core/src/actions/signIn/authorization.ts
@@ -9,7 +9,10 @@ import { Identities } from "@/shared/identity.ts"
 /**
  * Resolves trusted origins from config (array or function).
  */
-export const getTrustedOrigins = async (request: Request, trustedOrigins: AuthConfig<Identities>["trustedOrigins"]): Promise<string[]> => {
+export const getTrustedOrigins = async (
+    request: Request,
+    trustedOrigins: AuthConfig<Identities>["trustedOrigins"]
+): Promise<string[]> => {
     if (!trustedOrigins) return []
     const raw = typeof trustedOrigins === "function" ? await trustedOrigins(request) : trustedOrigins
     return Array.isArray(raw) ? raw : typeof raw === "string" ? [raw] : []

--- a/packages/core/src/createAuth.ts
+++ b/packages/core/src/createAuth.ts
@@ -12,8 +12,8 @@ import {
     csrfTokenAction,
     updateSessionAction,
 } from "@/actions/index.ts"
-import { Identities } from "@/shared/identity.ts"
-import type { AuthConfig, AuthInstance, EditableShape, FromShapeToObject, UserShape } from "@/@types/index.ts"
+import type { EditableShape, Identities, UserShape } from "@/shared/identity.ts"
+import type { AuthConfig, AuthInstance, FromShapeToObject } from "@/@types/index.ts"
 
 const createInternalConfig = <Identity extends Identities>(config?: AuthConfig<Identity>): RouterConfig => {
     const context = createContext<Identity>(config)

--- a/packages/core/src/schema-registry.ts
+++ b/packages/core/src/schema-registry.ts
@@ -1,12 +1,13 @@
-import { isZodSchema } from "@/shared/assert.ts"
+import { isArkType, isValibotSchema, isZodSchema } from "@/shared/assert.ts"
 import { formatZodError } from "@/shared/utils.ts"
 import { UserIdentity } from "@/shared/identity.ts"
 import { AuthValidationError } from "@/shared/errors.ts"
 import { strictObject, objectWithRest, transform, pipe, unknown, safeParseAsync, partial, type ObjectSchema } from "valibot"
+import type { Type } from "arktype"
 import type { ZodObject } from "zod/v4"
 import type { IdentityConfig } from "@/@types/config.ts"
 
-export const stripUnknownKeys = <T extends ZodObject<any> | ObjectSchema<any, undefined>>(
+export const stripUnknownKeys = <T extends ZodObject<any> | ObjectSchema<any, undefined> | Type>(
     schema: T,
     unknownKeys: "strip" | "passthrough" | "strict"
 ): any => {
@@ -14,22 +15,36 @@ export const stripUnknownKeys = <T extends ZodObject<any> | ObjectSchema<any, un
         case "strip":
             return isZodSchema(schema)
                 ? schema.strip()
-                : pipe(
-                      objectWithRest((schema as ObjectSchema<any, undefined>).entries, unknown()),
-                      transform((input) => {
-                          const result: any = {}
-                          for (const key in (schema as ObjectSchema<any, undefined>).entries) {
-                              if (key in input) result[key] = input[key]
-                          }
-                          return result
-                      })
-                  )
+                : isValibotSchema(schema)
+                  ? pipe(
+                        objectWithRest((schema as ObjectSchema<any, undefined>).entries, unknown()),
+                        transform((input) => {
+                            const result: any = {}
+                            for (const key in (schema as ObjectSchema<any, undefined>).entries) {
+                                if (key in input) result[key] = input[key]
+                            }
+                            return result
+                        })
+                    )
+                  : isArkType(schema)
+                    ? schema.onUndeclaredKey("delete")
+                    : undefined
         case "passthrough":
             return isZodSchema(schema)
                 ? schema.loose()
-                : objectWithRest((schema as ObjectSchema<any, undefined>).entries, unknown())
+                : isValibotSchema(schema)
+                  ? objectWithRest((schema as ObjectSchema<any, undefined>).entries, unknown())
+                  : isArkType(schema)
+                    ? schema.onUndeclaredKey("ignore")
+                    : undefined
         case "strict":
-            return isZodSchema(schema) ? schema.strict() : strictObject((schema as ObjectSchema<any, undefined>).entries)
+            return isZodSchema(schema)
+                ? schema.strict()
+                : isValibotSchema(schema)
+                  ? strictObject((schema as ObjectSchema<any, undefined>).entries)
+                  : isArkType(schema)
+                    ? schema.onUndeclaredKey("reject")
+                    : undefined
         default:
             throw new AuthValidationError(
                 "INVALID_IDENTITY_VALIDATION_FAILED",
@@ -38,22 +53,34 @@ export const stripUnknownKeys = <T extends ZodObject<any> | ObjectSchema<any, un
     }
 }
 
-export const createSchemaRegistry = <Identity extends ZodObject<any> | ObjectSchema<any, any>>(
-    config: IdentityConfig<Identity>
+export const createSchemaRegistry = <Identity extends ZodObject<any> | ObjectSchema<any, any> | Type>(
+    config: IdentityConfig<Identity & any>
 ) => {
     const schema = stripUnknownKeys(config.schema ?? UserIdentity, config.unknownKeys ?? "strip")
-    const partialSchema = isZodSchema(schema) ? schema.partial() : partial(schema)
+    const partialSchema = isZodSchema(schema)
+        ? schema.partial()
+        : isValibotSchema(schema)
+          ? partial(schema as ObjectSchema<any, undefined>)
+          : isArkType(schema)
+            ? schema.partial()
+            : undefined
 
     const parse = async (data: unknown = {}) => {
         const isZod = isZodSchema(schema)
-        const parsed: any = isZod ? await schema.safeParseAsync(data) : await safeParseAsync(schema as any, data)
-        if (!parsed.success) {
+        const parsed: any = isZod
+            ? await schema.safeParseAsync(data)
+            : isValibotSchema(schema)
+              ? await safeParseAsync(schema as any, data)
+              : isArkType(schema)
+                ? schema(data)
+                : undefined
+        if ((!isArkType(schema) && !parsed.success) || (isArkType(schema) && !schema?.allows(data))) {
             const details = JSON.stringify(isZod ? formatZodError(parsed.error) : {}, null, 2)
             throw new AuthValidationError("INVALID_IDENTITY_VALIDATION_FAILED", details, {
-                cause: isZod ? parsed.error : undefined,
+                cause: isZod ? parsed.error : isArkType(schema) ? parsed.errors : undefined,
             })
         }
-        return isZod ? parsed.data : parsed.output
+        return isZod ? parsed.data : isValibotSchema(schema) ? parsed.output : isArkType(schema) ? parsed : undefined
     }
 
     const parseAsPartial = async (data: unknown = {}) => {

--- a/packages/core/src/session/stateless.ts
+++ b/packages/core/src/session/stateless.ts
@@ -133,15 +133,11 @@ export const createStatelessStrategy = <DefaultUser extends User = User>({
 
             const expiresAt = updateExpires({ exp })
             if (!expiresAt) {
-                const userSession = identity.skipValidation
-                    ? session.user
-                    : await schema.parse(session.user)
+                const userSession = identity.skipValidation ? session.user : await schema.parse(session.user)
                 return { session: { expires: session.expires, user: userSession }, headers }
             }
 
-            const newSessionPayload = identity.skipValidation
-                ? session.user
-                : await schema.parse(session.user)
+            const newSessionPayload = identity.skipValidation ? session.user : await schema.parse(session.user)
             const newSession = { user: newSessionPayload, expires: expiresAt.toISOString() }
 
             const issuedAt = strategy === "absolute" ? _iat : Math.floor(Date.now() / 1000)

--- a/packages/core/src/shared/assert.ts
+++ b/packages/core/src/shared/assert.ts
@@ -11,6 +11,7 @@ import type {
 import type { JWK } from "@aura-stack/jose/jose"
 import { BaseSchema } from "valibot"
 import { ZodObject, ZodTypeAny } from "zod"
+import { Type } from "arktype"
 
 export const isFalsy = (value: unknown): boolean => {
     return value === false || value === 0 || value === "" || value === null || value === undefined || Number.isNaN(value)
@@ -196,4 +197,8 @@ export const isZodSchema = (value: unknown): value is ZodObject<any> => {
 
 export const isZodEntries = (value: unknown): value is Record<string, ZodTypeAny> => {
     return typeof value === "object" && value !== null && !Array.isArray(value) && Object.values(value).every(isZodSchema)
+}
+
+export const isArkType = (value: unknown): value is Type<{}, {}> => {
+    return typeof value === "function" && value !== null && "allows" in value && "assert" in value
 }

--- a/packages/core/src/shared/identity.ts
+++ b/packages/core/src/shared/identity.ts
@@ -1,7 +1,8 @@
 import { z } from "zod/v4"
-import type { EditableShape, EditableShapeValibot } from "@/@types/utility.ts"
 import * as valibot from "valibot"
-import { isValibotEntries } from "./assert.ts"
+import { type } from "arktype"
+import { isArkType, isValibotEntries, isZodEntries } from "@/shared/assert.ts"
+import type { EditableShape, EditableShapeArkType, EditableShapeValibot } from "@/@types/utility.ts"
 
 export type {
     InferUser,
@@ -17,7 +18,7 @@ export const UserIdentity = z.object({
     sub: z.string(),
     name: z.string().nullable().optional(),
     image: z.string().nullable().optional(),
-    email: z.string().email().nullable().optional(),
+    email: z.email().nullable().optional(),
 })
 
 export const UserIdentityValibot = valibot.object({
@@ -27,23 +28,44 @@ export const UserIdentityValibot = valibot.object({
     email: valibot.optional(valibot.nullable(valibot.pipe(valibot.string(), valibot.email()))),
 })
 
-export type UserShape = (typeof UserIdentity)["shape"]
+export const UserIdentityArkType = type({
+    sub: "string",
+    name: "string | null?",
+    image: "string | null?",
+    email: "string.email | null?",
+})
+
+export type UserShape = typeof UserIdentity.shape
 export type UserShapeValibot = typeof UserIdentityValibot.entries
+export type UserShapeArkType = typeof UserIdentityArkType
 
-export type Identities = EditableShape<UserShape> | EditableShapeValibot<UserShapeValibot>
+export type IsArkType<T extends Identities> = T extends EditableShapeArkType<UserShapeArkType> ? true : false
+export type IsZod<T extends Identities> = T extends EditableShape<UserShape> ? true : false
+export type IsValibot<T extends Identities> = T extends EditableShapeValibot<UserShapeValibot> ? true : false
 
-type ReturnShapeType<S> =
-    S extends EditableShape<UserShape>
-        ? z.ZodObject<S>
-        : S extends EditableShapeValibot<UserShapeValibot>
-          ? valibot.ObjectSchema<S, undefined>
-          : never
+export type Identities =
+    | EditableShape<UserShape>
+    | EditableShapeValibot<UserShapeValibot>
+    | EditableShapeArkType<UserShapeArkType>
 
-export const createIdentity = <S extends EditableShape<UserShape> | EditableShapeValibot<UserShapeValibot>>(
-    shape: S
-): ReturnShapeType<S> => {
+type ReturnShapeType<T> =
+    T extends EditableShape<UserShape>
+        ? z.ZodObject<T>
+        : T extends EditableShapeValibot<UserShapeValibot>
+          ? valibot.ObjectSchema<T, undefined>
+          : T extends EditableShapeArkType<UserShapeArkType>
+            ? T
+            : never
+
+export const createIdentity = <S extends Identities>(shape: S): ReturnShapeType<S> => {
+    if (isArkType(shape)) {
+        return shape as unknown as ReturnShapeType<S>
+    }
     if (isValibotEntries(shape)) {
         return valibot.object(shape) as unknown as ReturnShapeType<S>
+    }
+    if (isZodEntries(shape)) {
+        return z.object(shape) as unknown as ReturnShapeType<S>
     }
     return z.object(shape) as unknown as ReturnShapeType<S>
 }

--- a/packages/core/test/identity.test.ts
+++ b/packages/core/test/identity.test.ts
@@ -1,9 +1,10 @@
 import { describe, test, expect, expectTypeOf } from "vitest"
-import { createIdentity, InferUser } from "@/shared/identity.ts"
+import { createIdentity, InferUser, UserIdentity, UserIdentityArkType, UserIdentityValibot } from "@/shared/identity.ts"
 import { z } from "zod/v4"
 import * as valibot from "valibot"
 import { createAuth } from "@/createAuth.ts"
 import { createSchemaRegistry, stripUnknownKeys } from "@/schema-registry.ts"
+import { type } from "arktype"
 
 describe("createIdentity", () => {
     test("should create a Zod schema when passed a Zod shape", () => {
@@ -69,6 +70,36 @@ describe("createIdentity", () => {
         })
     })
 
+    test("should create an Arktype schema when passed an Arktype shape", () => {
+        const Schema = createIdentity(
+            type({
+                sub: "string",
+                name: "string | null?",
+                email: "string | null?",
+                image: "string | null?",
+                role: "string",
+            })
+        )
+
+        type User = typeof Schema.infer
+
+        const out = Schema({
+            sub: "user123",
+            name: "John Doe",
+            role: "admin",
+        }) as User
+
+        expect({
+            sub: out.sub,
+            name: out.name,
+            role: out.role,
+        }).toEqual({
+            sub: "user123",
+            name: "John Doe",
+            role: "admin",
+        })
+    })
+
     test("auth instance with Valibot schema", () => {
         const schema = createIdentity({
             sub: valibot.string(),
@@ -90,20 +121,17 @@ describe("createIdentity", () => {
 })
 
 describe("stripUnknownKeys", () => {
-    const zodSchema = z.object({
-        sub: z.string(),
-        name: z.string().nullable().optional(),
-        email: z.string().nullable().optional(),
-        image: z.string().nullable().optional(),
+    const zodSchema = UserIdentity.extend({
         role: z.string(),
     })
 
     const valibotSchema = valibot.object({
-        sub: valibot.string(),
-        name: valibot.optional(valibot.nullable(valibot.string())),
-        email: valibot.optional(valibot.nullable(valibot.pipe(valibot.string(), valibot.email()))),
-        image: valibot.optional(valibot.nullable(valibot.string())),
+        ...UserIdentityValibot.entries,
         role: valibot.string(),
+    })
+
+    const arktypeSchema = UserIdentityArkType.and({
+        role: "string",
     })
 
     const payload = {
@@ -113,86 +141,111 @@ describe("stripUnknownKeys", () => {
         extraKey: "should be stripped",
     }
 
-    test("zod schema with 'strip' unknownKeys", () => {
-        const schema = stripUnknownKeys(zodSchema, "strip")
-        expect(schema.safeParse(payload)).toMatchObject({
-            success: true,
-            data: {
-                sub: "user123",
-                name: "John Doe",
-                role: "admin",
-            },
+    describe("zod schemas", () => {
+        test("zod schema with 'strip' unknownKeys", () => {
+            const schema = stripUnknownKeys(zodSchema, "strip")
+            expect(schema.safeParse(payload)).toMatchObject({
+                success: true,
+                data: {
+                    sub: "user123",
+                    name: "John Doe",
+                    role: "admin",
+                },
+            })
+        })
+
+        test("zod schema with 'passthrough' unknownKeys", () => {
+            const schema = stripUnknownKeys(zodSchema, "passthrough")
+            expect(schema.safeParse(payload)).toMatchObject({
+                success: true,
+                data: {
+                    sub: "user123",
+                    name: "John Doe",
+                    role: "admin",
+                    extraKey: "should be stripped",
+                },
+            })
+        })
+
+        test("zod schema with 'strict' unknownKeys", () => {
+            const schema = stripUnknownKeys(zodSchema, "strict")
+            expect(schema.safeParse(payload)).toMatchObject({
+                success: false,
+            })
         })
     })
 
-    test("zod schema with 'passthrough' unknownKeys", () => {
-        const schema = stripUnknownKeys(zodSchema, "passthrough")
-        expect(schema.safeParse(payload)).toMatchObject({
-            success: true,
-            data: {
+    describe("valibot schemas", () => {
+        test("valibot schema with 'strip' unknownKeys", () => {
+            const schema = stripUnknownKeys(valibotSchema, "strip")
+            expect(valibot.safeParse(schema, payload)).toMatchObject({
+                success: true,
+                output: {
+                    sub: "user123",
+                    name: "John Doe",
+                    role: "admin",
+                },
+            })
+        })
+
+        test("valibot schema with 'passthrough' unknownKeys", () => {
+            const schema = stripUnknownKeys(valibotSchema, "passthrough")
+            expect(valibot.safeParse(schema, payload)).toMatchObject({
+                success: true,
+                output: {
+                    sub: "user123",
+                    name: "John Doe",
+                    role: "admin",
+                    extraKey: "should be stripped",
+                },
+            })
+        })
+
+        test("valibot schema with 'strict' unknownKeys", () => {
+            const schema = stripUnknownKeys(valibotSchema, "strict")
+            expect(valibot.safeParse(schema, payload)).toMatchObject({
+                success: false,
+            })
+        })
+    })
+
+    describe("arktype schemas", () => {
+        test("arktype schema with 'strip' unknownKeys", () => {
+            const Schema = stripUnknownKeys(arktypeSchema, "strip")
+
+            const out = Schema(payload)
+            expect(out).toMatchObject({
+                sub: "user123",
+                name: "John Doe",
+                role: "admin",
+            })
+        })
+
+        test("arktype schema with 'passthrough' unknownKeys", () => {
+            const Schema = stripUnknownKeys(arktypeSchema, "passthrough")
+            const out = Schema(payload)
+            expect(out).toMatchObject({
                 sub: "user123",
                 name: "John Doe",
                 role: "admin",
                 extraKey: "should be stripped",
-            },
-        })
-    })
-
-    test("zod schema with 'strict' unknownKeys", () => {
-        const schema = stripUnknownKeys(zodSchema, "strict")
-        expect(schema.safeParse(payload)).toMatchObject({
-            success: false,
-        })
-    })
-
-    test("valibot schema with 'strip' unknownKeys", () => {
-        const schema = stripUnknownKeys(valibotSchema, "strip")
-        expect(valibot.safeParse(schema, payload)).toMatchObject({
-            success: true,
-            output: {
-                sub: "user123",
-                name: "John Doe",
-                role: "admin",
-            },
-        })
-    })
-
-    test("valibot schema with 'passthrough' unknownKeys", () => {
-        const schema = stripUnknownKeys(valibotSchema, "passthrough")
-        expect(valibot.safeParse(schema, payload)).toMatchObject({
-            success: true,
-            output: {
-                sub: "user123",
-                name: "John Doe",
-                role: "admin",
-                extraKey: "should be stripped",
-            },
-        })
-    })
-
-    test("valibot schema with 'strict' unknownKeys", () => {
-        const schema = stripUnknownKeys(valibotSchema, "strict")
-        expect(valibot.safeParse(schema, payload)).toMatchObject({
-            success: false,
+            })
         })
     })
 })
 
 describe("createSchemaRegistry", () => {
-    const zodSchema = z.object({
-        sub: z.string(),
-        name: z.string().nullable().optional(),
-        email: z.string().nullable().optional(),
-        image: z.string().nullable().optional(),
+    const zodSchema = UserIdentity.extend({
         role: z.string(),
     })
 
     const valibotSchema = valibot.object({
-        sub: valibot.string(),
-        name: valibot.optional(valibot.nullable(valibot.string())),
-        email: valibot.optional(valibot.nullable(valibot.pipe(valibot.string(), valibot.email()))),
-        image: valibot.optional(valibot.nullable(valibot.string())),
+        ...UserIdentityValibot.entries,
         role: valibot.string(),
+    })
+
+    const arktypeSchema = UserIdentityArkType.and({
+        role: "string",
     })
 
     const payload = {
@@ -202,73 +255,114 @@ describe("createSchemaRegistry", () => {
         extraKey: "should be stripped",
     }
 
-    test("zod schema with 'strip' unknownKeys", async () => {
-        const { parse } = createSchemaRegistry({
-            schema: zodSchema,
-            unknownKeys: "strip",
+    describe("zod schemas", () => {
+        test("zod schema with 'strip' unknownKeys", async () => {
+            const { parse } = createSchemaRegistry({
+                schema: zodSchema,
+                unknownKeys: "strip",
+            })
+            const out = await parse(payload)
+            expect(out).toEqual({
+                sub: "user123",
+                name: "John Doe",
+                role: "admin",
+            })
         })
-        const out = await parse(payload)
-        expect(out).toEqual({
-            sub: "user123",
-            name: "John Doe",
-            role: "admin",
+
+        test("zod schema with 'passthrough' unknownKeys", async () => {
+            const { parse } = createSchemaRegistry({
+                schema: zodSchema,
+                unknownKeys: "passthrough",
+            })
+            const out = await parse(payload)
+            expect(out).toEqual({
+                sub: "user123",
+                name: "John Doe",
+                role: "admin",
+                extraKey: "should be stripped",
+            })
+        })
+
+        test("zod schema with 'strict' unknownKeys", async () => {
+            const { parse } = createSchemaRegistry({
+                schema: zodSchema,
+                unknownKeys: "strict",
+            })
+            await expect(parse(payload)).rejects.toThrow()
         })
     })
 
-    test("zod schema with 'passthrough' unknownKeys", async () => {
-        const { parse } = createSchemaRegistry({
-            schema: zodSchema,
-            unknownKeys: "passthrough",
+    describe("valibot schemas", () => {
+        test("valibot schema with 'strip' unknownKeys", async () => {
+            const { parse } = createSchemaRegistry({
+                schema: valibotSchema,
+                unknownKeys: "strip",
+            })
+            const out = await parse(payload)
+            expect(out).toEqual({
+                sub: "user123",
+                name: "John Doe",
+                role: "admin",
+            })
         })
-        const out = await parse(payload)
-        expect(out).toEqual({
-            sub: "user123",
-            name: "John Doe",
-            role: "admin",
-            extraKey: "should be stripped",
+
+        test("valibot schema with 'passthrough' unknownKeys", async () => {
+            const { parse } = createSchemaRegistry({
+                schema: valibotSchema,
+                unknownKeys: "passthrough",
+            })
+            const out = await parse(payload)
+            expect(out).toEqual({
+                sub: "user123",
+                name: "John Doe",
+                role: "admin",
+                extraKey: "should be stripped",
+            })
+        })
+
+        test("valibot schema with 'strict' unknownKeys", async () => {
+            const { parse } = createSchemaRegistry({
+                schema: valibotSchema,
+                unknownKeys: "strict",
+            })
+            await expect(parse(payload)).rejects.toThrow()
         })
     })
 
-    test("zod schema with 'strict' unknownKeys", async () => {
-        const { parse } = createSchemaRegistry({
-            schema: zodSchema,
-            unknownKeys: "strict",
+    describe("arktype schemas", () => {
+        test("arktype schema with 'strip' unknownKeys", async () => {
+            const { parse } = createSchemaRegistry({
+                schema: arktypeSchema,
+                unknownKeys: "strip",
+            })
+            const out = await parse(payload)
+            expect(out).toEqual({
+                sub: "user123",
+                name: "John Doe",
+                role: "admin",
+            })
         })
-        await expect(parse(payload)).rejects.toThrow()
-    })
 
-    test("valibot schema with 'strip' unknownKeys", async () => {
-        const { parse } = createSchemaRegistry({
-            schema: valibotSchema,
-            unknownKeys: "strip",
+        test("arktype schema with 'passthrough' unknownKeys", async () => {
+            const { parse } = createSchemaRegistry({
+                schema: arktypeSchema,
+                unknownKeys: "passthrough",
+            })
+            const out = await parse(payload)
+            expect(out).toEqual({
+                sub: "user123",
+                name: "John Doe",
+                role: "admin",
+                extraKey: "should be stripped",
+            })
         })
-        const out = await parse(payload)
-        expect(out).toEqual({
-            sub: "user123",
-            name: "John Doe",
-            role: "admin",
-        })
-    })
 
-    test("valibot schema with 'passthrough' unknownKeys", async () => {
-        const { parse } = createSchemaRegistry({
-            schema: valibotSchema,
-            unknownKeys: "passthrough",
+        test("arktype schema with 'strict' unknownKeys", async () => {
+            const { parse } = createSchemaRegistry({
+                schema: arktypeSchema,
+                unknownKeys: "strict",
+            })
+            await expect(parse(payload)).rejects.toThrow()
         })
-        const out = await parse(payload)
-        expect(out).toEqual({
-            sub: "user123",
-            name: "John Doe",
-            role: "admin",
-            extraKey: "should be stripped",
-        })
-    })
-
-    test("valibot schema with 'strict' unknownKeys", async () => {
-        const { parse } = createSchemaRegistry({
-            schema: valibotSchema,
-            unknownKeys: "strict",
-        })
-        await expect(parse(payload)).rejects.toThrow()
     })
 })

--- a/packages/core/test/types.test-d.ts
+++ b/packages/core/test/types.test-d.ts
@@ -2,7 +2,7 @@ import { describe, expectTypeOf } from "vitest"
 import * as valibot from "valibot"
 import { createAuth } from "@/createAuth.ts"
 import { z, ZodOptional, ZodString } from "zod/v4"
-import { Identities, UserIdentity, UserIdentityValibot, UserShapeValibot } from "@/shared/identity.ts"
+import { Identities, UserIdentity, UserIdentityArkType, UserIdentityValibot, UserShapeValibot } from "@/shared/identity.ts"
 import { github, type GitHubProfile } from "@/oauth/github.ts"
 import type {
     GetSessionAPIOptions,
@@ -14,12 +14,21 @@ import type {
 } from "@/@types/index.ts"
 import type { AuthConfig, AuthInstance, User } from "@/index.ts"
 import type { OAuthProviderCredentials } from "@/@types/oauth.ts"
-import type { EditableShape, FromShapeToObject, InferSession, InferUser, ValibotShapeToObject, ZodShapeToObject } from "@/@types/utility.ts"
+import type {
+    EditableShape,
+    FromShapeToObject,
+    InferSession,
+    InferUser,
+    ValibotShapeToObject,
+    ZodShapeToObject,
+} from "@/@types/utility.ts"
 import type { JWTHeaderParameters, JWTVerifyOptions, Prettify, TypedJWTPayload } from "@aura-stack/jose"
 
 describe("createAuth", () => {
     expectTypeOf(createAuth).toEqualTypeOf<
-        <Identity extends Identities = EditableShape<UserShape>>(config: AuthConfig<Identity>) => AuthInstance<FromShapeToObject<Identity>>
+        <Identity extends Identities = EditableShape<UserShape>>(
+            config: AuthConfig<Identity>
+        ) => AuthInstance<FromShapeToObject<Identity>>
     >()
     expectTypeOf(createAuth({ oauth: [] }).api.getSession).toEqualTypeOf<
         (options: GetSessionAPIOptions) => Promise<GetSessionAPIReturn<ZodShapeToObject<UserShape>>>
@@ -70,6 +79,32 @@ describe("createAuth", () => {
                     {
                         sub: string
                         role: string
+                        name?: string | null | undefined
+                        image?: string | null | undefined
+                        email?: string | null | undefined
+                    } & {
+                        sub: string
+                        name?: string | null | undefined
+                        image?: string | null | undefined
+                        email?: string | null | undefined
+                    }
+                >
+            >,
+            options?: JWTHeaderParameters
+        ) => Promise<string>
+    >()
+    expectTypeOf(
+        createAuth({
+            oauth: [],
+            identity: { schema: UserIdentityArkType.and({ role: "string?" }) },
+        }).jose.signJWS
+    ).toEqualTypeOf<
+        (
+            payload: TypedJWTPayload<
+                Partial<
+                    {
+                        sub: string
+                        role?: string | undefined
                         name?: string | null | undefined
                         image?: string | null | undefined
                         email?: string | null | undefined

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,7 +495,7 @@ importers:
         version: 0.561.0(react@19.2.4)
       nitro:
         specifier: npm:nitro-nightly@latest
-        version: nitro-nightly@3.0.1-20260501-155839-674070e0(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.7)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: nitro-nightly@3.0.1-20260501-164602-aee73f19(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.7)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       react:
         specifier: catalog:react
         version: 19.2.4
@@ -663,6 +663,9 @@ importers:
       '@aura-stack/router':
         specifier: ^0.6.0
         version: 0.6.0
+      arktype:
+        specifier: ^2.2.0
+        version: 2.2.0
       valibot:
         specifier: ^1.3.1
         version: 1.3.1(typescript@5.9.3)
@@ -875,6 +878,12 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@ark/schema@0.56.0':
+    resolution: {integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==}
+
+  '@ark/util@0.56.0':
+    resolution: {integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==}
 
   '@asamuzakjp/css-color@4.1.2':
     resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
@@ -4655,6 +4664,12 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  arkregex@0.0.5:
+    resolution: {integrity: sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==}
+
+  arktype@2.2.0:
+    resolution: {integrity: sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ==}
+
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
@@ -6187,8 +6202,8 @@ packages:
       crossws:
         optional: true
 
-  h3@2.0.1-rc.20:
-    resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==}
+  h3@2.0.1-rc.21:
+    resolution: {integrity: sha512-lDeqAgCQXWT7C+5Zs3ler2phZPeX5yTk9KqQuL8taSSngIhcPR0r83TZyYwTO/cLogm6a4+9slZcngrfdyZtrQ==}
     engines: {node: '>=20.11.1'}
     hasBin: true
     peerDependencies:
@@ -7133,8 +7148,8 @@ packages:
   nf3@0.3.16:
     resolution: {integrity: sha512-Gs0xRPpUm2nDkqbi40NJ9g7qDIcjcJzgExiydnq6LAyqhI2jfno8wG3NKTL+IiJsx799UHOb1CnSd4Wg4SG4Pw==}
 
-  nitro-nightly@3.0.1-20260501-155839-674070e0:
-    resolution: {integrity: sha512-V+zm26pSCrMAaAnv3o7we3dJbnT/XNKMTBJvEaNg7c0tXtne5+0nx9l0X61l3JwDVpRxBCYEb1SuGz3XlHTinw==}
+  nitro-nightly@3.0.1-20260501-164602-aee73f19:
+    resolution: {integrity: sha512-3InRZCLH9AWbmxTEaFhqdqQfM55ynKZJYi3FMnJbBkf9trxQG1zrBgELZLdx2HSB9bn0jUnv5TcM46W1tASsGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -9467,6 +9482,12 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.4
+
+  '@ark/schema@0.56.0':
+    dependencies:
+      '@ark/util': 0.56.0
+
+  '@ark/util@0.56.0': {}
 
   '@asamuzakjp/css-color@4.1.2':
     dependencies:
@@ -13197,6 +13218,16 @@ snapshots:
 
   aria-query@5.3.2: {}
 
+  arkregex@0.0.5:
+    dependencies:
+      '@ark/util': 0.56.0
+
+  arktype@2.2.0:
+    dependencies:
+      '@ark/schema': 0.56.0
+      '@ark/util': 0.56.0
+      arkregex: 0.0.5
+
   array-flatten@1.1.1: {}
 
   array-iterate@2.0.1: {}
@@ -14898,7 +14929,7 @@ snapshots:
     optionalDependencies:
       crossws: 0.4.5(srvx@0.11.15)
 
-  h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15)):
+  h3@2.0.1-rc.21(crossws@0.4.5(srvx@0.11.15)):
     dependencies:
       rou3: 0.8.1
       srvx: 0.11.15
@@ -16157,13 +16188,13 @@ snapshots:
 
   nf3@0.3.16: {}
 
-  nitro-nightly@3.0.1-20260501-155839-674070e0(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.7)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
+  nitro-nightly@3.0.1-20260501-164602-aee73f19(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.7)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.5(srvx@0.11.15)
       db0: 0.3.4
       env-runner: 0.1.7
-      h3: 2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15))
+      h3: 2.0.1-rc.21(crossws@0.4.5(srvx@0.11.15))
       hookable: 6.1.1
       nf3: 0.3.16
       ocache: 0.1.4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ArkType as a supported schema validation library alongside Zod and Valibot.
  * Added OAuth redirect URI creation helper for improved authentication flow handling.

* **Improvements**
  * Extended identity system to support ArkType for flexible schema validation.
  * Enhanced schema registry with ArkType support and unknown key policies (strip, passthrough, strict).

* **Tests**
  * Expanded test coverage for ArkType integration with identity schemas and schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->