### PR TITLE
chore(release): bump package versions

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -13,23 +13,27 @@
     "jsr:@std/media-types@1": "1.1.0",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@supabase/functions-js@2": "2.98.0",
-    "npm:@aura-stack/router@0.6": "0.6.0",
-    "npm:@aura-stack/router@0.7": "0.7.0_arktype@2.2.0_valibot@1.4.0_zod@4.3.5",
+    "npm:@aura-stack/router@0.7": "0.7.0_arktype@2.2.0_typebox@1.1.38_valibot@1.4.0_zod@4.3.5",
     "npm:@testing-library/dom@^10.4.1": "10.4.1",
     "npm:@testing-library/react@^16.3.2": "16.3.2_@testing-library+dom@10.4.1_react@19.2.5_react-dom@19.2.5__react@19.2.5",
     "npm:@types/supertest@^6.0.3": "6.0.3",
+    "npm:arktype@2.2.0": "2.2.0",
     "npm:arktype@^2.2.0": "2.2.0",
     "npm:elysia@^1.2.22": "1.4.28_@sinclair+typebox@0.34.49_exact-mirror@0.2.7__@sinclair+typebox@0.34.49_file-type@21.3.4_openapi-types@12.1.3",
     "npm:hono@4": "4.12.14",
     "npm:jose@^6.1.2": "6.2.2",
     "npm:next@16": "16.2.3_react@19.2.5_react-dom@19.2.5__react@19.2.5",
     "npm:openai@^4.52.5": "4.104.0_zod@4.3.5",
+    "npm:oxfmt@0.51": "0.51.0",
+    "npm:oxlint@^1.66.0": "1.66.0",
     "npm:path-to-regexp@^6.3.0": "1.9.0",
     "npm:supabase@^2.76.15": "2.91.2",
     "npm:supertest@^7.2.2": "7.2.2",
     "npm:tsdown@~0.21.8": "0.21.8_rolldown@1.0.0-rc.15",
     "npm:turbo@^2.7.5": "2.9.6",
-    "npm:valibot@^1.3.1": "1.4.0",
+    "npm:typebox@1.1.38": "1.1.38",
+    "npm:typebox@^1.1.38": "1.1.38",
+    "npm:valibot@1.4.0": "1.4.0",
     "npm:zod@4.3.5": "4.3.5"
   },
   "jsr": {
@@ -103,22 +107,18 @@
     "@ark/util@0.56.0": {
       "integrity": "sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA=="
     },
-    "@aura-stack/router@0.6.0": {
-      "integrity": "sha512-mb0iXHGgKeN5myC2PrmXxGydN8Gol3MlVARRoFc7/2+G3OD9/k3LqkQKDDnKnwVvrj6kE7EIwftXDxouEDdAxA==",
-      "dependencies": [
-        "cookie"
-      ]
-    },
-    "@aura-stack/router@0.7.0_arktype@2.2.0_valibot@1.4.0_zod@4.3.5": {
+    "@aura-stack/router@0.7.0_arktype@2.2.0_typebox@1.1.38_valibot@1.4.0_zod@4.3.5": {
       "integrity": "sha512-4I0U7Ot8A6Lj0c7O2O7UO1oXDvr8w/fEAxab4n79I970LwRVukuOks1zjJ9KFw4KWEib34D1qWLu2b4nVPDIAw==",
       "dependencies": [
         "arktype",
         "cookie",
+        "typebox",
         "valibot",
         "zod"
       ],
       "optionalPeers": [
         "arktype",
+        "typebox",
         "valibot",
         "zod"
       ]
@@ -427,6 +427,196 @@
     },
     "@oxc-project/types@0.124.0": {
       "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="
+    },
+    "@oxfmt/binding-android-arm-eabi@0.51.0": {
+      "integrity": "sha512-Ni0sCqg5CIHaLIYFGj+ncbcumylvNC6FE4rfD0KfdmnWHbPJ+zev0qZCXKxy2hFVa0fYRK0yPzf5nzPbkZou7g==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@oxfmt/binding-android-arm64@0.51.0": {
+      "integrity": "sha512-eu5lAZjuo0KAkp+M24EhDqfOwA8owQ8d7wyBlOUUGRbDLHpU3IRlDHp8Dif+YqGlxs6jra7yS6WQu/NkPhAxeg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@oxfmt/binding-darwin-arm64@0.51.0": {
+      "integrity": "sha512-6LsUNIdURhhcIfIn8+xsOb61mSTa9msAHTeSGx9Jf4rsP/gN8PGCF+SKWPAQZbND2w/WBkqQ6303jqEEIXzMdQ==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@oxfmt/binding-darwin-x64@0.51.0": {
+      "integrity": "sha512-9aUMGmVxdHjYMsEAW1tNRoieTJXlVNDFkRvIR1J7LttJXWjVYCu2ekclLij2KJtxBxSQOYSHd12ME/adVGVbZg==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@oxfmt/binding-freebsd-x64@0.51.0": {
+      "integrity": "sha512-mkY1nhZTqYb+NHaAWxOCKISN6FwdrwMNsu17vTUA3wzUV2VJ+Paq15ZokRcsMU/2PUdHO73prxyeJpjXQ3MPpQ==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@oxfmt/binding-linux-arm-gnueabihf@0.51.0": {
+      "integrity": "sha512-wtFwNwE4+YCNuPaWoGDZeGsKvD6D1YSUNBJNn/rJBh7CrDBThFE+TBI5kY7vRW9rIOQRsbW2IpyyL3Du4Zqwiw==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@oxfmt/binding-linux-arm-musleabihf@0.51.0": {
+      "integrity": "sha512-rnOaNx86G7iRKM6lsCIQMux0SMGNC/TEbFR+r7lpruJ12bnrIWgxd5w1PLqOvgR9r8ZJbpK/zfRKctJnh8/Jfg==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@oxfmt/binding-linux-arm64-gnu@0.51.0": {
+      "integrity": "sha512-jOgDzSqWcICGRjsp4mc08FxKMN8vzP2Kgs4E0d2HUP99F+nJDQKklRV4Zuj+0gcBgjrzx2CbpqaIdUVPepCojA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@oxfmt/binding-linux-arm64-musl@0.51.0": {
+      "integrity": "sha512-KBUCdrH5bwVrAvI9gU/1S55oH6fzXjr++J/oVocdu7bYTks1l7DNNT+rLd/1TDdAEjObGwmfWamn7LC1m8A0DQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@oxfmt/binding-linux-ppc64-gnu@0.51.0": {
+      "integrity": "sha512-NapfjYsABFqTJ1Dn9Efq6sN5esaHconVKwVLbDGNQLrwpOx/g17mkwErHzU72PutL67nf3wNAkbq122H+zLxag==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@oxfmt/binding-linux-riscv64-gnu@0.51.0": {
+      "integrity": "sha512-5dlDt1dUZCVi6elIhiK1PWg9wpTzTcIuj0IZnSurvIoMrhOWqqTcc1dSTxcSkNaBZhfsNqRZdINI1zAgbKkJNQ==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@oxfmt/binding-linux-riscv64-musl@0.51.0": {
+      "integrity": "sha512-pgdWUJn0S5nulyiVdlFV8DzCUnGXkU99W5PSkkmbaZW+LrZBPxpezun4G0DDHbQaVYuJeCuKsXsGKGo77CkUTQ==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@oxfmt/binding-linux-s390x-gnu@0.51.0": {
+      "integrity": "sha512-2XTFUe97CbDGAI8vjwDfZ1HdakO0XIADyJ24idEg64SC4/K4in/OisXVnrW4NMK7I6TgC7EqRhC0Ln/nKhAemA==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@oxfmt/binding-linux-x64-gnu@0.51.0": {
+      "integrity": "sha512-kQ1OuCqqt/yyf0ZN9VFxW1/JnlgJgii3Dr7pWf9vNBvrX1hv6g39/+mc5oGRHRGJFZtl3zsGDWR9c5N2B/gwBw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@oxfmt/binding-linux-x64-musl@0.51.0": {
+      "integrity": "sha512-ARTYqxHF475o96Gbn41hvSWSSRygPlRDXZZgZ9I2scU1y0qiWpCQyZCoefaQa0mwv+wwtZ+luS4YOzsRzM/izg==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@oxfmt/binding-openharmony-arm64@0.51.0": {
+      "integrity": "sha512-QiC1XrCl6a6BmqMzduO8hdIRMf1m44hCkt2Q68KWkTvUB/E7fd2iomyNh6KnnRca5w6eBrRAAtLFqTh+xjsjJA==",
+      "os": ["openharmony"],
+      "cpu": ["arm64"]
+    },
+    "@oxfmt/binding-win32-arm64-msvc@0.51.0": {
+      "integrity": "sha512-NC/hJb9dtU23Zf8L7IVK95xnFjiQ7AfcLO2l5pb69TDEr958qxrtnB2CveeeNSCBFNIkgaTCfd/vHNSoG78l9g==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@oxfmt/binding-win32-ia32-msvc@0.51.0": {
+      "integrity": "sha512-2C45za4Rj36n8YIbhRL1PQbxmXJYf81WEcAgvj5I4ptRROG+A+81hREEN5bmCHADE1UfYaN312U6tkILoZZy6w==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@oxfmt/binding-win32-x64-msvc@0.51.0": {
+      "integrity": "sha512-73RqdAuVKQTkjZIDw08JaDHUM4lav5Qu+CaPwg4QbbA7k8o7LEW0p3UsfZ/F8dsO/pwVYh3RzFcanwLRTTahbQ==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@oxlint/binding-android-arm-eabi@1.66.0": {
+      "integrity": "sha512-f7kq8N51T4phpzqfBpA2qaVTI/KrkCmNwaj3t/97I/WLTDI+UhlP5GL9eER+zVxBhtlx5rKXWByJU1/zDAvyaw==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@oxlint/binding-android-arm64@1.66.0": {
+      "integrity": "sha512-xu6QO71tdDS9mjmLZ3AqhtaVHBvdmsOKkYnReNNDgh+XiwnsipeQOIxbiYOOO0iAXycJ+GK0wdMSZP/2j/AmSg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@oxlint/binding-darwin-arm64@1.66.0": {
+      "integrity": "sha512-HZ24VimSOC7mxuEA99e0H2FS0C1yO3+iW13jPRAk+e2njsUs3QeAXsafCDyaIrV/MirdOVez+etQNQsJE43zNQ==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@oxlint/binding-darwin-x64@1.66.0": {
+      "integrity": "sha512-awhj8ZvJrrRSnXj7V++rpZvTmnl99L6mi0B7gg7Cp7BN6cKpzuI481bHNLvXGA9GB1/oEgA3ponuyoAc6Md12A==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@oxlint/binding-freebsd-x64@1.66.0": {
+      "integrity": "sha512-KQF0oVV21/FjIqkRuL8Q1vh8ECsE5+ocdH5tcqTQ4ZnYuDVoYibQUNfqBjQaUsP6UIIda5Y75Wpm5p4RgQWiWw==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@oxlint/binding-linux-arm-gnueabihf@1.66.0": {
+      "integrity": "sha512-9u1rgwZSEXWb30vbFZzQ78HVXBo0WCKNwJ3a2InRUTNMRng+PUDIoSFmA+m4HdUfBaIqftShq8J8qHc+eE/Vig==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@oxlint/binding-linux-arm-musleabihf@1.66.0": {
+      "integrity": "sha512-Ynot2HR1bHxUaNWoC280MVTDfZuaWuP3XfSMRDhyuZrVjhzoaBCVFlw8h8qeZjWKVUBhPWFIxB7AQTlK8Z2WWg==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@oxlint/binding-linux-arm64-gnu@1.66.0": {
+      "integrity": "sha512-xCbgzciGgo+A4aQZEknsNrNiIwY7sU5SfRuMmRjPIvZAgdF34cIHiKvwOsS5XRLjlTVSFwitmq6YclTtHTfU+g==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@oxlint/binding-linux-arm64-musl@1.66.0": {
+      "integrity": "sha512-hmo+ZB/lHkR1HdDmnziNpzSLmulnUSu10VEqX2Yex7OwvoBAbjJQLvy4gIBRV3AAwWnCvAxKp5Nv1GE6LU1QMg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@oxlint/binding-linux-ppc64-gnu@1.66.0": {
+      "integrity": "sha512-2Invd4Uyy81mVooQC5FBtfxSNrvcX1OxbMlVQ6M2erRrNI2awFYF26YNW2yFxdVFZ4ffNOWKghtMjhnUPsXsVA==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@oxlint/binding-linux-riscv64-gnu@1.66.0": {
+      "integrity": "sha512-s0iXPDQVdgayE3RGa/N2DZF7tjgg0TwEtD1sGoDxqPDGrIXgo45H0yHknT0f9A0yteASsweYZtDyTuVlM4aSag==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@oxlint/binding-linux-riscv64-musl@1.66.0": {
+      "integrity": "sha512-OekL4XFiu7RPK0JIZi8VeHgtIXPREf42t8Cy/rKEsC+P3gcqDgNAAGiyuUOpdbG4wwbfue1q4CHcCO7spSve6w==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@oxlint/binding-linux-s390x-gnu@1.66.0": {
+      "integrity": "sha512-Ga1D0kj1SFslm34ThA/BdkUlyAYEnTsXyRC4pF0C5agZSwtGdHYWMTQWemUfBGp4RCG4QWXgdO+HmmmKqOtlBg==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@oxlint/binding-linux-x64-gnu@1.66.0": {
+      "integrity": "sha512-p5jfP1wUZe/IC3qpQO84n9DRnf9g3lKRtLBlQq23ykyrDglHcVx7sWmVTlPuU6SBw8mNnPzyOn022G3XZHnlww==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@oxlint/binding-linux-x64-musl@1.66.0": {
+      "integrity": "sha512-vUB/sYlYZorDL1ZD+o9mRv7zbsykrrFRtmgS6R8musZqLtrPRQn1gc1eGpuX+sfdccz42STl/AqldY6XRb2upQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@oxlint/binding-openharmony-arm64@1.66.0": {
+      "integrity": "sha512-yde+6p/F59xRkGR9H1HfngWRif1QRJjynZK349l+UI0H6w9hL3G8/AVaTHFyTtLVQ56qtNbX2/5Dc77n1ovnOg==",
+      "os": ["openharmony"],
+      "cpu": ["arm64"]
+    },
+    "@oxlint/binding-win32-arm64-msvc@1.66.0": {
+      "integrity": "sha512-O9GLucgoTdmOrbBX+EjzNe7o/Ze5TFOvXcib6bzUOtBOmj6cV+zw18NgB+cGKAkDw1Pdqs8vGkfHbbsLuDtXWg==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@oxlint/binding-win32-ia32-msvc@1.66.0": {
+      "integrity": "sha512-m3Pjwc2MfTcom4E4gOv7DyuGyt7OfGNCbmqDHd+N7EzXmP+ppHuudm2NjcA3AjV5TSeGxaguVF4SbTKHe1USYA==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@oxlint/binding-win32-x64-msvc@1.66.0": {
+      "integrity": "sha512-/DbBvw8UFBhja6PqudUjV4UtfsJr0Oa7jUjWVKB0g86lj/VwnPrkngn0sFql3c9RDA0O16dh7ozsXb6GjNAzBQ==",
+      "os": ["win32"],
+      "cpu": ["x64"]
     },
     "@paralleldrive/cuid2@2.3.1": {
       "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
@@ -1133,6 +1323,59 @@
     "openapi-types@12.1.3": {
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="
     },
+    "oxfmt@0.51.0": {
+      "integrity": "sha512-l/AoAnaEOV7Q5/Z9kHOMDehVJnCgYN7wRoooWCTUMBMi16BJhLZqd9cmCnwcVFfVlzkt53zK2KLPFNp8vSsoDg==",
+      "dependencies": [
+        "tinypool"
+      ],
+      "optionalDependencies": [
+        "@oxfmt/binding-android-arm-eabi",
+        "@oxfmt/binding-android-arm64",
+        "@oxfmt/binding-darwin-arm64",
+        "@oxfmt/binding-darwin-x64",
+        "@oxfmt/binding-freebsd-x64",
+        "@oxfmt/binding-linux-arm-gnueabihf",
+        "@oxfmt/binding-linux-arm-musleabihf",
+        "@oxfmt/binding-linux-arm64-gnu",
+        "@oxfmt/binding-linux-arm64-musl",
+        "@oxfmt/binding-linux-ppc64-gnu",
+        "@oxfmt/binding-linux-riscv64-gnu",
+        "@oxfmt/binding-linux-riscv64-musl",
+        "@oxfmt/binding-linux-s390x-gnu",
+        "@oxfmt/binding-linux-x64-gnu",
+        "@oxfmt/binding-linux-x64-musl",
+        "@oxfmt/binding-openharmony-arm64",
+        "@oxfmt/binding-win32-arm64-msvc",
+        "@oxfmt/binding-win32-ia32-msvc",
+        "@oxfmt/binding-win32-x64-msvc"
+      ],
+      "bin": true
+    },
+    "oxlint@1.66.0": {
+      "integrity": "sha512-N4LLxYLd94KEBqXDMDM5f+2PUpItTjDLreXe2Gn5KhjhCK4Qp2YUXaBi8Yu325ryOgKwt22m45fpD7nPOn69Yw==",
+      "optionalDependencies": [
+        "@oxlint/binding-android-arm-eabi",
+        "@oxlint/binding-android-arm64",
+        "@oxlint/binding-darwin-arm64",
+        "@oxlint/binding-darwin-x64",
+        "@oxlint/binding-freebsd-x64",
+        "@oxlint/binding-linux-arm-gnueabihf",
+        "@oxlint/binding-linux-arm-musleabihf",
+        "@oxlint/binding-linux-arm64-gnu",
+        "@oxlint/binding-linux-arm64-musl",
+        "@oxlint/binding-linux-ppc64-gnu",
+        "@oxlint/binding-linux-riscv64-gnu",
+        "@oxlint/binding-linux-riscv64-musl",
+        "@oxlint/binding-linux-s390x-gnu",
+        "@oxlint/binding-linux-x64-gnu",
+        "@oxlint/binding-linux-x64-musl",
+        "@oxlint/binding-openharmony-arm64",
+        "@oxlint/binding-win32-arm64-msvc",
+        "@oxlint/binding-win32-ia32-msvc",
+        "@oxlint/binding-win32-x64-msvc"
+      ],
+      "bin": true
+    },
     "path-to-regexp@1.9.0": {
       "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
       "dependencies": [
@@ -1386,6 +1629,9 @@
         "picomatch"
       ]
     },
+    "tinypool@2.1.0": {
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="
+    },
     "token-types@6.1.2": {
       "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
       "dependencies": [
@@ -1437,6 +1683,9 @@
         "@turbo/windows-arm64"
       ],
       "bin": true
+    },
+    "typebox@1.1.38": {
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="
     },
     "uint8array-extras@1.5.0": {
       "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="
@@ -1496,6 +1745,8 @@
   "workspace": {
     "packageJson": {
       "dependencies": [
+        "npm:oxfmt@0.51",
+        "npm:oxlint@^1.66.0",
         "npm:tsdown@~0.21.8",
         "npm:turbo@^2.7.5"
       ],
@@ -1531,14 +1782,17 @@
       },
       "packages/core": {
         "dependencies": [
-          "npm:@aura-stack/router@0.6",
+          "npm:@aura-stack/router@0.7",
+          "npm:arktype@2.2.0",
+          "npm:typebox@1.1.38",
+          "npm:valibot@1.4.0",
           "npm:zod@4.3.5"
         ],
         "packageJson": {
           "dependencies": [
             "npm:@aura-stack/router@0.7",
             "npm:arktype@^2.2.0",
-            "npm:valibot@^1.3.1"
+            "npm:typebox@^1.1.38"
           ]
         }
       },

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.7.0] - 2026-05-23
+
 ### Added
 
 - Added experimental support for `Typebox` schema validation in `createAuth`; it now supports both Zod and Typebox schemas to extend the default User fields. [#163](https://github.com/aura-stack-ts/auth/pull/163)

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/auth",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -30,8 +30,11 @@
   },
   "imports": {
     "@/": "./src/",
-    "@aura-stack/router": "npm:@aura-stack/router@^0.6.0",
-    "zod": "npm:zod@4.3.5"
+    "@aura-stack/router": "npm:@aura-stack/router@^0.7.0",
+    "zod": "npm:zod@4.3.5",
+    "arktype": "npm:arktype@2.2.0",
+    "valibot": "npm:valibot@1.4.0",
+    "typebox": "npm:typebox@1.1.38"
   },
   "publish": {
     "include": ["src/**/*.ts", "README.md", "CHANGELOG.md"]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/auth",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": false,
   "type": "module",
   "description": "Core auth for @aura-stack/auth",
@@ -16,7 +16,7 @@
     "format:check": "oxfmt --check",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist",
-    "clean:cts": "if [ -d dist ]; then find dist -type f -name \"*.cts\" -delete; fi",
+    "clean:cts": "find dist -type f -name \"*.cts\" -delete",
     "prepublishOnly": "pnpm build && pnpm clean:cts"
   },
   "repository": {

--- a/packages/core/test/actions/signIn/signIn.test.ts
+++ b/packages/core/test/actions/signIn/signIn.test.ts
@@ -152,6 +152,7 @@ describe("signIn action", () => {
         } = createAuth({
             oauth: [oauthCustomService],
             trustedProxyHeaders: true,
+            trustedOrigins: [],
         })
         const request = await GET(
             new Request("http://example.com/auth/signIn/oauth-provider", {
@@ -232,6 +233,7 @@ describe("signIn action", () => {
         } = createAuth({
             oauth: [oauthCustomService],
             trustedProxyHeaders: true,
+            trustedOrigins: [],
         })
         const request = await GET(
             new Request("http://example.com/auth/signIn/oauth-provider", {
@@ -325,6 +327,7 @@ describe("signIn action", () => {
         } = createAuth({
             oauth: [oauthCustomService],
             trustedProxyHeaders: true,
+            trustedOrigins: [],
         })
 
         const request = await GET(
@@ -354,6 +357,7 @@ describe("signIn action", () => {
         } = createAuth({
             oauth: [oauthCustomService],
             trustedProxyHeaders: true,
+            trustedOrigins: [],
         })
 
         const request = await GET(

--- a/packages/core/test/api/signIn.test.ts
+++ b/packages/core/test/api/signIn.test.ts
@@ -51,6 +51,7 @@ describe("signIn API", () => {
         const api = createAuth({
             oauth: [oauthCustomService],
             trustedProxyHeaders: true,
+            trustedOrigins: [],
         }).api
         const signIn = await api.signIn("oauth-provider", {
             headers: {

--- a/packages/core/test/identity.test.ts
+++ b/packages/core/test/identity.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, expectTypeOf } from "vitest"
+import { describe, test, expect, expectTypeOf, vi, afterEach } from "vitest"
 import {
     createIdentity,
     InferUser,
@@ -14,6 +14,10 @@ import { createSchemaRegistry, deriveSchema } from "@/validator/registry.ts"
 import { ArkErrors, type } from "arktype"
 import { Static, Type as Typebox } from "typebox"
 import { Value } from "typebox/value"
+
+afterEach(() => {
+    vi.unstubAllEnvs()
+})
 
 describe("createIdentity", () => {
     test("createIdentity with Zod schema", () => {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,9 +1,10 @@
 import path from "path"
-import crypto from "crypto"
 import { defineConfig } from "vitest/config"
+import { getRandomBytes } from "@aura-stack/jose/crypto"
+import { base64url } from "@aura-stack/jose/jose"
 
-const SECRET_KEY = crypto.randomBytes(34).toString("base64url")
-const SALT_KEY = crypto.randomBytes(34).toString("base64url")
+const SECRET_KEY = getRandomBytes(44)
+const SALT_KEY = getRandomBytes(44)
 
 export default defineConfig({
     test: {
@@ -14,10 +15,10 @@ export default defineConfig({
         },
         unstubEnvs: true,
         env: {
-            AURA_AUTH_SECRET: SECRET_KEY,
+            AURA_AUTH_SECRET: base64url.encode(SECRET_KEY),
             AURA_AUTH_GITHUB_CLIENT_ID: "github-client-id",
             AURA_AUTH_GITHUB_CLIENT_SECRET: "github-client-secret",
-            AURA_AUTH_SALT: SALT_KEY,
+            AURA_AUTH_SALT: base64url.encode(SALT_KEY),
             AURA_AUTH_OAUTH_PROVIDER_CLIENT_ID: "oauth_client_id",
             AURA_AUTH_OAUTH_PROVIDER_CLIENT_SECRET: "oauth_client_secret",
             "AURA_AUTH_OAUTH-PROVIDER_CLIENT_ID": "oauth_client_id",

--- a/packages/jose/CHANGELOG.md
+++ b/packages/jose/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- Added strict secret verification: require at least 4 bits of entropy per character and a minimum total entropy of 254 bits. [`#165`](https://github.com/aura-stack-ts/auth/pull/165)
+- Added strict secret verification: require at least 4 bits of entropy per character and a minimum total entropy of 128 bits. [`#165`](https://github.com/aura-stack-ts/auth/pull/165)
 
 - Renamed compact JWE helpers from `compactEncryptJWE` to `encryptCompactJWE` to align naming with other JWE APIs. [#165](https://github.com/aura-stack-ts/auth/pull/165)
 

--- a/packages/jose/CHANGELOG.md
+++ b/packages/jose/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.6.0] - 2026-05-23
+
 ### Added
 
 - Introduced algorithm inference: signing and encryption algorithms are now inferred from the provided asymmetric keys to reduce configuration mismatches. Defaults: `RS256` (signing) and `RSA-OAEP-256` (encryption) for asymmetric keys; `HS256` (signing) and `dir` (encryption) for symmetric keys. [#165](https://github.com/aura-stack-ts/auth/pull/165)

--- a/packages/jose/deno.json
+++ b/packages/jose/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/jose",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts",

--- a/packages/jose/package.json
+++ b/packages/jose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/jose",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": false,
   "type": "module",
   "description": "JOSE utilities for @aura-stack/auth",
@@ -16,7 +16,7 @@
     "format:check": "oxfmt --check",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist",
-    "clean:cts": "if [ -d dist ]; then find dist -type f -name \"*.cts\" -delete; fi",
+    "clean:cts": "find dist -type f -name \"*.cts\" -delete",
     "prepublishOnly": "pnpm build && pnpm clean:cts"
   },
   "repository": {
@@ -25,7 +25,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/@aura-stack/jose"
+    "registry": "https://registry.npmjs.org/"
   },
   "files": [
     "dist"

--- a/packages/jose/src/secret.ts
+++ b/packages/jose/src/secret.ts
@@ -4,7 +4,7 @@ import { encoder } from "@/crypto.ts"
 import type { DerivedKeyInput, JWTSecretInput, SecretInput } from "@/index.ts"
 
 export const MIN_SECRET_ENTROPY_PER_CHAR = 4
-export const MIN_SECRET_ENTROPY_BITS = 254
+export const MIN_SECRET_ENTROPY_BITS = 128
 
 export const assertSecretEntropy = (secret: string) => {
     const charFreq = new Map<string, number>()

--- a/packages/jose/test/secret.test.ts
+++ b/packages/jose/test/secret.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from "vitest"
 import { createSecret, MIN_SECRET_ENTROPY_BITS, MIN_SECRET_ENTROPY_PER_CHAR } from "@/secret.ts"
+import { getRandomBytes } from "@/crypto.ts"
+import { base64url } from "jose"
 
 describe("createSecret", () => {
     test("createSecret without secret", () => {
@@ -82,5 +84,18 @@ describe("createSecret", () => {
         expect(() => createSecret(secret)).toThrow(
             `Secret must have an entropy of at least ${MIN_SECRET_ENTROPY_PER_CHAR} bits per character and a total entropy of at least ${MIN_SECRET_ENTROPY_BITS} bits`
         )
+    })
+
+    test("secret from getRandomBytes", () => {
+        const secret = getRandomBytes(32)
+        const createdSecret = createSecret(secret)
+        expect(createdSecret).toBe(secret)
+    })
+
+    test("secret from getRandomBytes to string", () => {
+        const secret = getRandomBytes(32).toString()
+        const encodedSecret = base64url.encode(secret)
+        const createdSecret = createSecret(encodedSecret)
+        expect(createdSecret).toBeInstanceOf(Uint8Array)
     })
 })


### PR DESCRIPTION
## Description

This pull request publishes new releases of the packages to both npm and JSR registries:

- `@aura-stack/auth@0.7.0`
- `@aura-stack/jose@0.6.0`

### Registries

#### NPM
- https://www.npmjs.com/package/@aura-stack/auth
- https://www.npmjs.com/package/@aura-stack/jose

#### JSR
- https://jsr.io/@aura-stack/auth
- https://jsr.io/@aura-stack/jose


### Key changes

`@aura-stack/auth`

- #165 
- #163 
- #162 
- #161 
- #160 
- #159 
- #158 
- #157 
- #153 
- #151 
- #150 

`@aura-stack/jose`
- #165
- #159
- #157 

@coderabbitai pause