### PR TITLE
fix(core): fix type inference across auth actions

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -16,6 +16,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Added support for a custom `userInfo` function in OAuth provider configuration, enabling callers to perform the user info request themselves. The `userInfo` option continues to accept either a URL string or an object with a `url` and optional request options (for example, custom headers). [#182](https://github.com/aura-stack-ts/auth/pull/182)
 
+### Fixed
+
+- Fixed type inference for authentication actions created with `createAuth()` and `createAuthClient()`. The `signUp.schema` configuration is now inferred correctly, improving type safety and reducing the need for manual type annotations. [#189](https://github.com/aura-stack-ts/auth/pull/189)
+
+### Changed
+
+- Refactored and standardized error handling across authentication flows. All authentication errors now extend the `AuraAuthError` base class, providing a consistent error model throughout the library. Error objects now expose structured metadata, including `type`, `code`, `message`, and `userMessage`. [#189](https://github.com/aura-stack-ts/auth/pull/189)
+
 ---
 
 ## [0.7.2] - 2026-06-05

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added `InferSignUp`, a utility type for inferring the sign-up payload from `createAuth().signUp.schema`. This type can be reused as the second generic parameter of `createAuthClient()` to ensure consistent typing between server and client authentication configurations. [#190](https://github.com/aura-stack-ts/auth/pull/190)
+
 - Added a `signUp` client function accessible via `createAuthClient`, allowing interaction with the mounted `POST /signUp` endpoint. [#184](https://github.com/aura-stack-ts/auth/pull/184)
 
 - Introduced an experimental `signUp` flow for both the API and endpoint definitions. The new action enables user account creation within the authentication system and provides customizable payload validation through the supported schema. To enable this feature, developers must configure the `signUp` option when calling `createAuth`. [#183](https://github.com/aura-stack-ts/auth/pull/183)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -18,11 +18,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- Fixed type inference for authentication actions created with `createAuth()` and `createAuthClient()`. The `signUp.schema` configuration is now inferred correctly, improving type safety and reducing the need for manual type annotations. [#189](https://github.com/aura-stack-ts/auth/pull/189)
+- Fixed type inference for authentication actions created with `createAuth()` and `createAuthClient()`. The `signUp.schema` configuration is now inferred correctly, improving type safety and reducing the need for manual type annotations. [#190](https://github.com/aura-stack-ts/auth/pull/190)
 
 ### Changed
 
-- Refactored and standardized error handling across authentication flows. All authentication errors now extend the `AuraAuthError` base class, providing a consistent error model throughout the library. Error objects now expose structured metadata, including `type`, `code`, `message`, and `userMessage`. [#189](https://github.com/aura-stack-ts/auth/pull/189)
+- Refactored and standardized error handling across authentication flows. All authentication errors now extend the `AuraAuthError` base class, providing a consistent error model throughout the library. Error objects now expose structured metadata, including `type`, `code`, `message`, and `userMessage`. [#190](https://github.com/aura-stack-ts/auth/pull/190)
 
 ---
 

--- a/packages/core/src/@types/utility.ts
+++ b/packages/core/src/@types/utility.ts
@@ -2,9 +2,10 @@ import { Type } from "arktype"
 import type { TProperties, TObject, TSchema } from "typebox"
 import type { AuthInstance } from "@/@types/config.ts"
 import type { Session, User } from "@/@types/session.ts"
-import type { ZodObject, ZodRawShape, ZodTypeAny, infer as Infer } from "zod/v4"
+import type { ZodObject, ZodRawShape, ZodTypeAny, infer as Infer, ZodString, ZodOptional } from "zod/v4"
 import type { Identities, IsArkType, IsZod, UserShapeTypeBox, UserShapeValibot } from "@/shared/identity.ts"
 import type { ObjectSchema, BaseSchema, AnySchema as AnyValibotSchema, ObjectEntries, InferOutput } from "valibot"
+import type { InferSchema } from "@aura-stack/router"
 
 /** Expands intersection types into a single flat object type for readable editor hints. */
 export type Prettify<T> = { [K in keyof T]: T[K] }
@@ -80,6 +81,28 @@ export type FromShapeToObject<S> = S extends ZodRawShape
             ? S
             : never
 
+export type EditableToSchema<T> =
+    T extends EditableShape<infer S>
+        ? ZodObject<S>
+        : T extends EditableShapeValibot<infer S>
+          ? ObjectSchema<S, undefined>
+          : T extends EditableShapeTypebox<infer S>
+            ? TObject<S>
+            : T extends EditableShapeArkType<any>
+              ? T
+              : never
+
+export type ReturnUpdateSessionShape<T> =
+    T extends EditableShape<infer S>
+        ? ZodObject<{ user?: ZodObject<S>; expires?: ZodOptional<ZodString> }>
+        : T extends EditableShapeValibot<infer S>
+          ? ObjectSchema<{ user?: ObjectSchema<S, undefined>; expires?: BaseSchema<any, any, any> }, undefined>
+          : T extends EditableShapeArkType<any>
+            ? Type<{ user?: T; expires?: Type<string> }>
+            : T extends EditableShapeTypebox<infer S>
+              ? TObject<{ user?: TObject<S>; expires?: TSchema }>
+              : never
+
 /** Recursively makes every property required. */
 export type DeepRequired<T> = {
     [K in keyof T]-?: T[K] extends object ? DeepRequired<T[K]> : T[K]
@@ -152,6 +175,35 @@ export type UserFrom<T extends ZodObject> = Prettify<ZodShapeToObject<InferZodSh
  * type Session = SessionFrom<typeof schema>
  */
 export type SessionFrom<T extends ZodObject> = Wrap<Session<Wrap<UserFrom<T>>>>
+
+/**
+ * Infers the sign-up data type from an {@link AuthInstance} config's `signUp.schema`. It supports
+ * Zod, Valibot and ArkType schemas.
+ *
+ * > For TypeBox its recommended to use the `Static` utility type directly to infer the schema.
+ *
+ * @example
+ * const auth = createAuth({
+ *   oauth: [],
+ *   signUp: {
+ *     schema: z.object({
+ *       username: z.string(),
+ *       nickname: z.string(),
+ *       password: z.string(),
+ *     })
+ *   }
+ * })
+ *
+ * type SignUp = InferSignUp<typeof auth>
+ */
+export type InferSignUp<Config extends AuthInstance> =
+    Config extends AuthInstance<infer _, infer SignUpSchema>
+        ? Wrap<RemoveIndexSignature<InferSchema<SignUpSchema>>>
+        : Record<string, any>
+
+export type RemoveIndexSignature<T> = {
+    [K in keyof T as string extends K ? never : number extends K ? never : symbol extends K ? never : K]: T[K]
+}
 
 /**
  * HTTP `Response` with `json()` typed to resolve to `Body` (defaults to `unknown`).

--- a/packages/core/src/@types/utility.ts
+++ b/packages/core/src/@types/utility.ts
@@ -2,7 +2,7 @@ import { Type } from "arktype"
 import type { TProperties, TObject, TSchema } from "typebox"
 import type { AuthInstance } from "@/@types/config.ts"
 import type { Session, User } from "@/@types/session.ts"
-import type { ZodObject, ZodRawShape, ZodTypeAny, infer as Infer, ZodString, ZodOptional } from "zod/v4"
+import type { ZodObject, ZodRawShape, ZodTypeAny, infer as Infer, ZodOptional } from "zod/v4"
 import type { Identities, IsArkType, IsZod, UserShapeTypeBox, UserShapeValibot } from "@/shared/identity.ts"
 import type { ObjectSchema, BaseSchema, AnySchema as AnyValibotSchema, ObjectEntries, InferOutput } from "valibot"
 import type { InferSchema } from "@aura-stack/router"
@@ -94,7 +94,7 @@ export type EditableToSchema<T> =
 
 export type ReturnUpdateSessionShape<T> =
     T extends EditableShape<infer S>
-        ? ZodObject<{ user?: ZodObject<S>; expires?: ZodOptional<ZodString> }>
+        ? ZodObject<{ user?: ZodObject<S>; expires?: ZodOptional<ZodTypeAny> }>
         : T extends EditableShapeValibot<infer S>
           ? ObjectSchema<{ user?: ObjectSchema<S, undefined>; expires?: BaseSchema<any, any, any> }, undefined>
           : T extends EditableShapeArkType<any>

--- a/packages/core/src/actions/signUp/signUp.ts
+++ b/packages/core/src/actions/signUp/signUp.ts
@@ -2,8 +2,11 @@ import { signUp } from "@/api/signUp.ts"
 import { createEndpoint, createEndpointConfig } from "@aura-stack/router"
 import { RedirectOptionsSchema } from "@/schemas.ts"
 import type { SignUpConfig } from "@/@types/config.ts"
+import type { Identities, SchemaTypes } from "@/shared/identity.ts"
 
-const signUpConfig = (config: SignUpConfig<any, any>) => {
+const signUpConfig = <Identity extends Identities, SignUpSchema extends SchemaTypes>(
+    config: SignUpConfig<Identity, SignUpSchema>
+) => {
     return createEndpointConfig({
         schemas: {
             body: config?.schema,
@@ -18,15 +21,18 @@ const signUpConfig = (config: SignUpConfig<any, any>) => {
  *
  * @returns The signed-up user's session
  */
-export const signUpAction = (config: SignUpConfig<any, any>) => {
+export const signUpAction = <Identity extends Identities, SignUpSchema extends SchemaTypes>(
+    config: SignUpConfig<Identity, SignUpSchema>
+) => {
     return createEndpoint(
         "POST",
         "/signUp",
         async (ctx) => {
-            const payload = ctx.body
+            // @ts-ignore - Type excessively expensive to compute.
+            const payload = ctx.body as any
             const { toResponse } = await signUp({
                 ctx: ctx.context,
-                payload,
+                payload: payload,
                 request: ctx.request,
                 headers: ctx.request.headers,
                 redirect: ctx.searchParams.redirect,

--- a/packages/core/src/actions/signUp/signUp.ts
+++ b/packages/core/src/actions/signUp/signUp.ts
@@ -28,7 +28,7 @@ export const signUpAction = <Identity extends Identities, SignUpSchema extends S
         "POST",
         "/signUp",
         async (ctx) => {
-            // @ts-ignore - Type excessively expensive to compute.
+            // @ts-ignore - Deep generic inference with router body type is currently too expensive.
             const payload = ctx.body as any
             const { toResponse } = await signUp({
                 ctx: ctx.context,

--- a/packages/core/src/actions/updateSession/updateSession.ts
+++ b/packages/core/src/actions/updateSession/updateSession.ts
@@ -2,13 +2,13 @@ import { createEndpoint, createEndpointConfig } from "@aura-stack/router"
 import { RedirectOptionsSchema } from "@/schemas.ts"
 import { updateSession } from "@/api/updateSession.ts"
 import { getFullSchema } from "@/validator/registry.ts"
-import type { User } from "@/@types/session.ts"
 import type { SchemaRegistryContext } from "@/@types/config.ts"
+import type { Identities } from "@/shared/identity.ts"
 
-export const config = (identity: SchemaRegistryContext) => {
+export const config = <Identity extends Identities>(identity: SchemaRegistryContext) => {
     return createEndpointConfig({
         schemas: {
-            body: getFullSchema(identity.schemaRegistry.schemaAsPartial),
+            body: getFullSchema<Identity>(identity.schemaRegistry.schemaAsPartial),
             searchParams: RedirectOptionsSchema,
         },
     })
@@ -19,16 +19,14 @@ export const updateSessionAction = (identity: SchemaRegistryContext) => {
         "PATCH",
         "/session",
         async (ctx) => {
+            const session = ctx.body
             const { toResponse } = await updateSession({
                 ctx: ctx.context,
                 request: ctx.request,
                 headers: ctx.request.headers,
                 redirect: ctx.searchParams.redirect,
                 redirectTo: ctx.searchParams.redirectTo,
-                session: {
-                    user: ctx.body?.user as User,
-                    expires: ctx.body?.expires?.toISOString(),
-                },
+                session: session as any,
             })
             return toResponse()
         },

--- a/packages/core/src/api/createApi.ts
+++ b/packages/core/src/api/createApi.ts
@@ -17,15 +17,12 @@ import type {
     SignUpAPIOptions,
     SignUpAPIReturn,
     Wrap,
+    RemoveIndexSignature,
 } from "@/@types/index.ts"
 import type { ZodObject } from "zod"
 import type { SchemaTypes } from "@/shared/identity.ts"
 
 type InferSignUp<T> = Wrap<RemoveIndexSignature<InferSchema<T>>>
-
-type RemoveIndexSignature<T> = {
-    [K in keyof T as string extends K ? never : number extends K ? never : symbol extends K ? never : K]: T[K]
-}
 
 export const createAuthAPI = <DefaultUser extends User = User, SignUpSchema extends SchemaTypes = ZodObject<any>>(
     ctx: GlobalContext

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -136,7 +136,6 @@ export const createAuthClient = <
             const { redirectTo } = options ?? {}
             const response = await client.post("/signIn/credentials", {
                 body: options.payload,
-                // @ts-ignore - Fix type here - go to @aura-stack/router.
                 searchParams: {
                     redirectTo,
                     redirect: false,
@@ -174,7 +173,6 @@ export const createAuthClient = <
             const { redirectTo } = options ?? {}
             // @ts-ignore
             const response = await client.post("/signUp", {
-                // @ts-ignore - Fix type here - go to @aura-stack/router.
                 body: options.payload,
                 searchParams: {
                     redirectTo,
@@ -226,6 +224,7 @@ export const createAuthClient = <
                 body: {
                     // @ts-ignore - Fix type here - go to @aura-stack/router.
                     user,
+                    // @ts-ignore - Fix type here - go to @aura-stack/router.
                     expires: session.expires ? new Date(session.expires) : undefined,
                 },
                 searchParams: {
@@ -267,7 +266,6 @@ export const createAuthClient = <
                 throw new AuraAuthError({ code: "CSRF_TOKEN_MISSING" })
             }
 
-            // @ts-ignore - Fix type here - go to @aura-stack/router.
             const response = await client.post("/signOut", {
                 searchParams: {
                     redirectTo: options?.redirectTo,

--- a/packages/core/src/createAuth.ts
+++ b/packages/core/src/createAuth.ts
@@ -48,7 +48,7 @@ export const createAuthInstance = <Identity extends Identities, SignUpSchema ext
             signOutAction,
             csrfTokenAction,
             updateSessionAction(config.context.identity as SchemaRegistryContext),
-            signUpAction(config.context.signUp as SignUpConfig<Identity, SignUpSchema>),
+            signUpAction<Identity, SignUpSchema>(config.context.signUp as SignUpConfig<Identity, SignUpSchema>),
         ],
         config
     )

--- a/packages/core/src/validator/registry.ts
+++ b/packages/core/src/validator/registry.ts
@@ -2,11 +2,12 @@ import { z } from "zod/v4"
 import * as valibot from "valibot"
 import { type } from "arktype"
 import { IsObject, Type as Typebox } from "typebox"
-import { UserIdentity, type SchemaTypes } from "@/shared/identity.ts"
+import { UserIdentity, type Identities, type SchemaTypes } from "@/shared/identity.ts"
 import { isArkType, isValibotSchema, isZodSchema } from "@/shared/assert.ts"
 import { AuraAuthError } from "@/shared/errors.ts"
 import { createValidator } from "@aura-stack/router/validator"
 import type { IdentityConfig } from "@/@types/config.ts"
+import type { EditableToSchema, ReturnUpdateSessionShape } from "@/@types/utility.ts"
 
 export const deriveSchema = <Schema extends SchemaTypes>(
     schema: Schema,
@@ -116,7 +117,9 @@ export const deriveSchemaWithJWT = <Schema extends SchemaTypes>(schema: Schema):
     throw new AuraAuthError({ code: "SCHEMA_UNSUPPORTED" })
 }
 
-export const getFullSchema = <Schema extends SchemaTypes>(schema: Schema): any => {
+export const getFullSchema = <Identity extends Identities, Schema = EditableToSchema<Identity>>(
+    schema: Schema
+): ReturnUpdateSessionShape<Schema> => {
     if (isValibotSchema(schema)) {
         // @ts-ignore Deep type instantiation with external schemas
         return valibot.object({
@@ -145,13 +148,13 @@ export const getFullSchema = <Schema extends SchemaTypes>(schema: Schema): any =
         return Typebox.Object({
             user: schema,
             expires: Typebox.Optional(Typebox.String()),
-        })
+        }) as unknown as ReturnUpdateSessionShape<Schema>
     }
     if (isZodSchema(schema)) {
         return z.object({
             user: schema,
             expires: z.coerce.date().optional(),
-        })
+        }) as unknown as ReturnUpdateSessionShape<Schema>
     }
     throw new AuraAuthError({ code: "SCHEMA_UNSUPPORTED" })
 }

--- a/packages/core/test/client/client.test-d.ts
+++ b/packages/core/test/client/client.test-d.ts
@@ -1,0 +1,366 @@
+import { describe, expectTypeOf, test } from "vitest"
+import { createAuthClient } from "@/client/client.ts"
+import type {
+    Session,
+    User,
+    LiteralUnion,
+    BuiltInOAuthProvider,
+    SignInCredentialsOptions,
+    SignInCredentialsReturn,
+    SignInOptions,
+    SignInReturn,
+    SignOutOptions,
+    SignOutReturn,
+    SignUpOptions,
+    SignUpReturn,
+    UpdateSessionOptions,
+    UpdateSessionReturn,
+    InferUser,
+    InferSignUp,
+} from "@/@types/index.ts"
+import { createAuth } from "@/createAuth.ts"
+import { z } from "zod/v4"
+import { type } from "arktype"
+import * as valibot from "valibot"
+import * as typebox from "typebox"
+import { UserIdentity, UserIdentityArkType, UserIdentityTypeBox, UserIdentityValibot } from "@/shared/identity.ts"
+
+describe("Client Types", () => {
+    test("createAuthClient returns the correct type", () => {
+        const authClient = createAuthClient({})
+        expectTypeOf(authClient).toEqualTypeOf<{
+            getSession: () => Promise<Session<User> | null>
+            signIn: <Options extends SignInOptions>(
+                oauth: LiteralUnion<BuiltInOAuthProvider>,
+                options?: Options | undefined
+            ) => Promise<SignInReturn<Options>>
+            signInCredentials: <Options extends SignInCredentialsOptions>(
+                options: Options
+            ) => Promise<SignInCredentialsReturn<Options>>
+            signUp: <Options extends SignUpOptions<Record<string, any>>>(options: Options) => Promise<SignUpReturn<Options>>
+            updateSession: <Options extends UpdateSessionOptions<User>>(
+                options: Options
+            ) => Promise<UpdateSessionReturn<Options, User>>
+            signOut: <Options extends SignOutOptions>(options?: Options) => Promise<SignOutReturn<Options>>
+        }>()
+    })
+
+    test("with custom zod identity schema", () => {
+        const auth = createAuth({
+            oauth: [],
+            identity: {
+                schema: UserIdentity.extend({
+                    isAdmin: z.boolean(),
+                    role: z.enum(["admin", "user"]),
+                }),
+            },
+        })
+
+        type User = InferUser<typeof auth>
+
+        expectTypeOf<User>().toEqualTypeOf<{
+            sub: string
+            name?: string | null | undefined
+            image?: string | null | undefined
+            email?: string | null | undefined
+            isAdmin: boolean
+            role: "admin" | "user"
+        }>()
+
+        const authClient = createAuthClient<User>({})
+        expectTypeOf(authClient).toEqualTypeOf<{
+            getSession: () => Promise<Session<User> | null>
+            signIn: <Options extends SignInOptions>(
+                oauth: LiteralUnion<BuiltInOAuthProvider>,
+                options?: Options | undefined
+            ) => Promise<SignInReturn<Options>>
+            signInCredentials: <Options extends SignInCredentialsOptions>(
+                options: Options
+            ) => Promise<SignInCredentialsReturn<Options>>
+            signUp: <Options extends SignUpOptions<Record<string, any>>>(options: Options) => Promise<SignUpReturn<Options>>
+            updateSession: <Options extends UpdateSessionOptions<User>>(
+                options: Options
+            ) => Promise<UpdateSessionReturn<Options, User>>
+            signOut: <Options extends SignOutOptions>(options?: Options) => Promise<SignOutReturn<Options>>
+        }>()
+    })
+
+    test("with custom valibot identity schema", () => {
+        const auth = createAuth({
+            oauth: [],
+            identity: {
+                schema: valibot.object({
+                    ...UserIdentityValibot.entries,
+                    isAdmin: valibot.boolean(),
+                    role: valibot.union([valibot.literal("admin"), valibot.literal("user")]),
+                }),
+            },
+        })
+
+        type User = InferUser<typeof auth>
+
+        expectTypeOf<User>().toEqualTypeOf<{
+            sub: string
+            name?: string | null | undefined
+            image?: string | null | undefined
+            email?: string | null | undefined
+            isAdmin: boolean
+            role: "admin" | "user"
+        }>()
+
+        const authClient = createAuthClient<User>({})
+        expectTypeOf(authClient).toEqualTypeOf<{
+            getSession: () => Promise<Session<User> | null>
+            signIn: <Options extends SignInOptions>(
+                oauth: LiteralUnion<BuiltInOAuthProvider>,
+                options?: Options | undefined
+            ) => Promise<SignInReturn<Options>>
+            signInCredentials: <Options extends SignInCredentialsOptions>(
+                options: Options
+            ) => Promise<SignInCredentialsReturn<Options>>
+            signUp: <Options extends SignUpOptions<Record<string, any>>>(options: Options) => Promise<SignUpReturn<Options>>
+            updateSession: <Options extends UpdateSessionOptions<User>>(
+                options: Options
+            ) => Promise<UpdateSessionReturn<Options, User>>
+            signOut: <Options extends SignOutOptions>(options?: Options) => Promise<SignOutReturn<Options>>
+        }>()
+    })
+
+    test("with custom arktype identity schema", () => {
+        const auth = createAuth({
+            oauth: [],
+            identity: {
+                schema: UserIdentityArkType.and({
+                    isAdmin: "boolean",
+                    role: type.enumerated("admin", "user"),
+                }),
+            },
+        })
+
+        type User = InferUser<typeof auth>
+
+        expectTypeOf<User>().toEqualTypeOf<{
+            sub: string
+            name?: string | null | undefined
+            image?: string | null | undefined
+            email?: string | null | undefined
+            isAdmin: boolean
+            role: "admin" | "user"
+        }>()
+
+        const authClient = createAuthClient<User>({})
+        expectTypeOf(authClient).toEqualTypeOf<{
+            getSession: () => Promise<Session<User> | null>
+            signIn: <Options extends SignInOptions>(
+                oauth: LiteralUnion<BuiltInOAuthProvider>,
+                options?: Options | undefined
+            ) => Promise<SignInReturn<Options>>
+            signInCredentials: <Options extends SignInCredentialsOptions>(
+                options: Options
+            ) => Promise<SignInCredentialsReturn<Options>>
+            signUp: <Options extends SignUpOptions<Record<string, any>>>(options: Options) => Promise<SignUpReturn<Options>>
+            updateSession: <Options extends UpdateSessionOptions<User>>(
+                options: Options
+            ) => Promise<UpdateSessionReturn<Options, User>>
+            signOut: <Options extends SignOutOptions>(options?: Options) => Promise<SignOutReturn<Options>>
+        }>()
+    })
+
+    test("with custom typebox identity schema", () => {
+        /**
+         * NOTE: Currently, the TypeBox schema is not correctly inferred due to the expensive nature
+         * of the Static type from "typebox". This is a known issue and we're looking into ways to optimize
+         * the type inference for TypeBox schemas in the future.
+         */
+        const schema = typebox.Type.Object({
+            ...UserIdentityTypeBox.properties,
+            isAdmin: typebox.Type.Boolean(),
+            role: typebox.Type.Union([typebox.Type.Literal("admin"), typebox.Type.Literal("user")]),
+        })
+
+        createAuth({
+            oauth: [],
+            identity: {
+                schema,
+            },
+        })
+
+        type User = typebox.Static<typeof schema>
+
+        expectTypeOf<User>().toEqualTypeOf<{
+            sub: string
+            name?: string | null | undefined
+            image?: string | null | undefined
+            email?: string | null | undefined
+            isAdmin: boolean
+            role: "admin" | "user"
+        }>()
+
+        const authClient = createAuthClient<User>({})
+        expectTypeOf(authClient).toEqualTypeOf<{
+            getSession: () => Promise<Session<User> | null>
+            signIn: <Options extends SignInOptions>(
+                oauth: LiteralUnion<BuiltInOAuthProvider>,
+                options?: Options | undefined
+            ) => Promise<SignInReturn<Options>>
+            signInCredentials: <Options extends SignInCredentialsOptions>(
+                options: Options
+            ) => Promise<SignInCredentialsReturn<Options>>
+            signUp: <Options extends SignUpOptions<Record<string, any>>>(options: Options) => Promise<SignUpReturn<Options>>
+            updateSession: <Options extends UpdateSessionOptions<User>>(
+                options: Options
+            ) => Promise<UpdateSessionReturn<Options, User>>
+            signOut: <Options extends SignOutOptions>(options?: Options) => Promise<SignOutReturn<Options>>
+        }>()
+    })
+
+    test("with custom zod signUp schema", () => {
+        const auth = createAuth({
+            oauth: [],
+            signUp: {
+                schema: z.object({
+                    username: z.string(),
+                    nickname: z.string(),
+                    password: z.string(),
+                }),
+                onCreateUser: () => null,
+            },
+        })
+        type SignUp = InferSignUp<typeof auth>
+        expectTypeOf<SignUp>().toEqualTypeOf<{
+            username: string
+            nickname: string
+            password: string
+        }>()
+
+        const authClient = createAuthClient<User, SignUp>({})
+        expectTypeOf(authClient).toEqualTypeOf<{
+            getSession: () => Promise<Session<User> | null>
+            signIn: <Options extends SignInOptions>(
+                oauth: LiteralUnion<BuiltInOAuthProvider>,
+                options?: Options | undefined
+            ) => Promise<SignInReturn<Options>>
+            signInCredentials: <Options extends SignInCredentialsOptions>(
+                options: Options
+            ) => Promise<SignInCredentialsReturn<Options>>
+            signUp: <Options extends SignUpOptions<SignUp>>(options: Options) => Promise<SignUpReturn<Options>>
+            updateSession: <Options extends UpdateSessionOptions<User>>(
+                options: Options
+            ) => Promise<UpdateSessionReturn<Options, User>>
+            signOut: <Options extends SignOutOptions>(options?: Options) => Promise<SignOutReturn<Options>>
+        }>()
+    })
+
+    test("with custom valibot signUp schema", () => {
+        const auth = createAuth({
+            oauth: [],
+            signUp: {
+                schema: valibot.object({
+                    username: valibot.string(),
+                    nickname: valibot.string(),
+                    password: valibot.string(),
+                }),
+                onCreateUser: () => null,
+            },
+        })
+        type SignUp = InferSignUp<typeof auth>
+        expectTypeOf<SignUp>().toEqualTypeOf<{
+            username: string
+            nickname: string
+            password: string
+        }>()
+
+        const authClient = createAuthClient<User, SignUp>({})
+        expectTypeOf(authClient).toEqualTypeOf<{
+            getSession: () => Promise<Session<User> | null>
+            signIn: <Options extends SignInOptions>(
+                oauth: LiteralUnion<BuiltInOAuthProvider>,
+                options?: Options | undefined
+            ) => Promise<SignInReturn<Options>>
+            signInCredentials: <Options extends SignInCredentialsOptions>(
+                options: Options
+            ) => Promise<SignInCredentialsReturn<Options>>
+            signUp: <Options extends SignUpOptions<SignUp>>(options: Options) => Promise<SignUpReturn<Options>>
+            updateSession: <Options extends UpdateSessionOptions<User>>(
+                options: Options
+            ) => Promise<UpdateSessionReturn<Options, User>>
+            signOut: <Options extends SignOutOptions>(options?: Options) => Promise<SignOutReturn<Options>>
+        }>()
+    })
+
+    test("with custom arktype signUp schema", () => {
+        const auth = createAuth({
+            oauth: [],
+            signUp: {
+                schema: type({
+                    username: "string",
+                    nickname: "string",
+                    password: "string",
+                }),
+                onCreateUser: () => null,
+            },
+        })
+        type SignUp = InferSignUp<typeof auth>
+        expectTypeOf<SignUp>().toEqualTypeOf<{
+            username: string
+            nickname: string
+            password: string
+        }>()
+
+        const authClient = createAuthClient<User, SignUp>({})
+        expectTypeOf(authClient).toEqualTypeOf<{
+            getSession: () => Promise<Session<User> | null>
+            signIn: <Options extends SignInOptions>(
+                oauth: LiteralUnion<BuiltInOAuthProvider>,
+                options?: Options | undefined
+            ) => Promise<SignInReturn<Options>>
+            signInCredentials: <Options extends SignInCredentialsOptions>(
+                options: Options
+            ) => Promise<SignInCredentialsReturn<Options>>
+            signUp: <Options extends SignUpOptions<SignUp>>(options: Options) => Promise<SignUpReturn<Options>>
+            updateSession: <Options extends UpdateSessionOptions<User>>(
+                options: Options
+            ) => Promise<UpdateSessionReturn<Options, User>>
+            signOut: <Options extends SignOutOptions>(options?: Options) => Promise<SignOutReturn<Options>>
+        }>()
+    })
+
+    test("with custom arktype signUp schema", () => {
+        const schema = typebox.Type.Object({
+            username: typebox.Type.String(),
+            nickname: typebox.Type.String(),
+            password: typebox.Type.String(),
+        })
+
+        createAuth({
+            oauth: [],
+            signUp: {
+                schema,
+                onCreateUser: () => null,
+            },
+        })
+        type SignUp = typebox.Static<typeof schema>
+        expectTypeOf<SignUp>().toEqualTypeOf<{
+            username: string
+            nickname: string
+            password: string
+        }>()
+
+        const authClient = createAuthClient<User, SignUp>({})
+        expectTypeOf(authClient).toEqualTypeOf<{
+            getSession: () => Promise<Session<User> | null>
+            signIn: <Options extends SignInOptions>(
+                oauth: LiteralUnion<BuiltInOAuthProvider>,
+                options?: Options | undefined
+            ) => Promise<SignInReturn<Options>>
+            signInCredentials: <Options extends SignInCredentialsOptions>(
+                options: Options
+            ) => Promise<SignInCredentialsReturn<Options>>
+            signUp: <Options extends SignUpOptions<SignUp>>(options: Options) => Promise<SignUpReturn<Options>>
+            updateSession: <Options extends UpdateSessionOptions<User>>(
+                options: Options
+            ) => Promise<UpdateSessionReturn<Options, User>>
+            signOut: <Options extends SignOutOptions>(options?: Options) => Promise<SignOutReturn<Options>>
+        }>()
+    })
+})

--- a/packages/core/test/client/client.test-d.ts
+++ b/packages/core/test/client/client.test-d.ts
@@ -325,7 +325,7 @@ describe("Client Types", () => {
         }>()
     })
 
-    test("with custom arktype signUp schema", () => {
+    test("with custom typebox signUp schema", () => {
         const schema = typebox.Type.Object({
             username: typebox.Type.String(),
             nickname: typebox.Type.String(),


### PR DESCRIPTION
## Description

This pull request fixes type inference issues affecting authentication actions such as `updateSession` and `signUp`.

The issue caused incorrect type inference in both `createAuth()` and `createAuthClient()`, resulting in improperly typed payloads and action parameters in certain configurations.

The root cause was incorrect type inference from the `identity.schema` and `signUp.schema` configuration options. These schemas are used to validate incoming payloads and should also drive the inferred types exposed by the authentication APIs. However, the inferred types were not being propagated correctly, leading to inconsistencies between the configured schemas and the generated API types.

