### PR TITLE
feat(core): extend UserFrom type inference support

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Extended `UserFrom` to support type inference from `ArkType` and `Valibot` schemas. User types are now inferred correctly for `Zod`, `ArkType`, and `Valibot` schema definitions. [#191](https://github.com/aura-stack-ts/auth/pull/191)
+
 - Added `InferSignUp`, a utility type for inferring the sign-up payload from `createAuth().signUp.schema`. This type can be reused as the second generic parameter of `createAuthClient()` to ensure consistent typing between server and client authentication configurations. [#190](https://github.com/aura-stack-ts/auth/pull/190)
 
 - Added a `signUp` client function accessible via `createAuthClient`, allowing interaction with the mounted `POST /signUp` endpoint. [#184](https://github.com/aura-stack-ts/auth/pull/184)

--- a/packages/core/src/@types/utility.ts
+++ b/packages/core/src/@types/utility.ts
@@ -3,7 +3,7 @@ import type { TProperties, TObject, TSchema } from "typebox"
 import type { AuthInstance } from "@/@types/config.ts"
 import type { Session, User } from "@/@types/session.ts"
 import type { ZodObject, ZodRawShape, ZodTypeAny, infer as Infer, ZodOptional } from "zod/v4"
-import type { Identities, IsArkType, IsZod, UserShapeTypeBox, UserShapeValibot } from "@/shared/identity.ts"
+import type { Identities, IsArkType, IsZod, SchemaTypes, UserShapeTypeBox, UserShapeValibot } from "@/shared/identity.ts"
 import type { ObjectSchema, BaseSchema, AnySchema as AnyValibotSchema, ObjectEntries, InferOutput } from "valibot"
 import type { InferSchema } from "@aura-stack/router"
 
@@ -161,7 +161,7 @@ export type InferZodShape<T extends ZodObject> = T["shape"]
  *
  * type User = UserFrom<typeof schema>
  */
-export type UserFrom<T extends ZodObject> = Prettify<ZodShapeToObject<InferZodShape<T>>>
+export type UserFrom<T extends SchemaTypes> = Prettify<RemoveIndexSignature<InferSchema<T>>>
 
 /**
  * Infers the session type from a Zod identity schema.
@@ -174,7 +174,7 @@ export type UserFrom<T extends ZodObject> = Prettify<ZodShapeToObject<InferZodSh
  *
  * type Session = SessionFrom<typeof schema>
  */
-export type SessionFrom<T extends ZodObject> = Wrap<Session<Wrap<UserFrom<T>>>>
+export type SessionFrom<T extends SchemaTypes> = Wrap<Session<Merge<UserFrom<T>, User>>>
 
 /**
  * Infers the sign-up data type from an {@link AuthInstance} config's `signUp.schema`. It supports

--- a/packages/core/test/client/client.test-d.ts
+++ b/packages/core/test/client/client.test-d.ts
@@ -17,6 +17,7 @@ import type {
     UpdateSessionReturn,
     InferUser,
     InferSignUp,
+    UserFrom,
 } from "@/@types/index.ts"
 import { createAuth } from "@/createAuth.ts"
 import { z } from "zod/v4"
@@ -46,26 +47,30 @@ describe("Client Types", () => {
     })
 
     test("with custom zod identity schema", () => {
+        const schema = UserIdentity.extend({
+            isAdmin: z.boolean(),
+            role: z.enum(["admin", "user"]),
+        })
+
         const auth = createAuth({
             oauth: [],
             identity: {
-                schema: UserIdentity.extend({
-                    isAdmin: z.boolean(),
-                    role: z.enum(["admin", "user"]),
-                }),
+                schema,
             },
         })
 
-        type User = InferUser<typeof auth>
-
-        expectTypeOf<User>().toEqualTypeOf<{
+        type Expected = {
             sub: string
             name?: string | null | undefined
             image?: string | null | undefined
             email?: string | null | undefined
             isAdmin: boolean
             role: "admin" | "user"
-        }>()
+        }
+        type User = InferUser<typeof auth>
+
+        expectTypeOf<User>().toEqualTypeOf<Expected>()
+        expectTypeOf<UserFrom<typeof schema>>().toEqualTypeOf<Expected>()
 
         const authClient = createAuthClient<User>({})
         expectTypeOf(authClient).toEqualTypeOf<{
@@ -86,27 +91,31 @@ describe("Client Types", () => {
     })
 
     test("with custom valibot identity schema", () => {
+        const schema = valibot.object({
+            ...UserIdentityValibot.entries,
+            isAdmin: valibot.boolean(),
+            role: valibot.union([valibot.literal("admin"), valibot.literal("user")]),
+        })
+
         const auth = createAuth({
             oauth: [],
             identity: {
-                schema: valibot.object({
-                    ...UserIdentityValibot.entries,
-                    isAdmin: valibot.boolean(),
-                    role: valibot.union([valibot.literal("admin"), valibot.literal("user")]),
-                }),
+                schema,
             },
         })
 
-        type User = InferUser<typeof auth>
-
-        expectTypeOf<User>().toEqualTypeOf<{
+        type Expected = {
             sub: string
             name?: string | null | undefined
             image?: string | null | undefined
             email?: string | null | undefined
             isAdmin: boolean
             role: "admin" | "user"
-        }>()
+        }
+        type User = InferUser<typeof auth>
+
+        expectTypeOf<User>().toEqualTypeOf<Expected>()
+        expectTypeOf<UserFrom<typeof schema>>().toEqualTypeOf<Expected>()
 
         const authClient = createAuthClient<User>({})
         expectTypeOf(authClient).toEqualTypeOf<{
@@ -127,26 +136,30 @@ describe("Client Types", () => {
     })
 
     test("with custom arktype identity schema", () => {
+        const schema = UserIdentityArkType.and({
+            isAdmin: "boolean",
+            role: type.enumerated("admin", "user"),
+        })
+
         const auth = createAuth({
             oauth: [],
             identity: {
-                schema: UserIdentityArkType.and({
-                    isAdmin: "boolean",
-                    role: type.enumerated("admin", "user"),
-                }),
+                schema,
             },
         })
 
-        type User = InferUser<typeof auth>
-
-        expectTypeOf<User>().toEqualTypeOf<{
+        type Expected = {
             sub: string
             name?: string | null | undefined
             image?: string | null | undefined
             email?: string | null | undefined
             isAdmin: boolean
             role: "admin" | "user"
-        }>()
+        }
+        type User = InferUser<typeof auth>
+
+        expectTypeOf<User>().toEqualTypeOf<Expected>()
+        expectTypeOf<UserFrom<typeof schema>>().toEqualTypeOf<Expected>()
 
         const authClient = createAuthClient<User>({})
         expectTypeOf(authClient).toEqualTypeOf<{

--- a/packages/core/test/identity.test.ts
+++ b/packages/core/test/identity.test.ts
@@ -6,6 +6,7 @@ import {
     UserIdentityTypeBox,
     UserIdentityValibot,
     type InferUser,
+    type UserFrom,
 } from "@/shared/identity.ts"
 import { z } from "zod/v4"
 import * as valibot from "valibot"
@@ -59,6 +60,7 @@ describe("createIdentity", () => {
         })
         type ExpectedIdentity = z.infer<typeof schema>
         expectTypeOf<ExpectedIdentity>().toEqualTypeOf<InferUser<typeof auth>>()
+        expectTypeOf<ExpectedIdentity>().toEqualTypeOf<UserFrom<typeof schema>>()
     })
 
     test("createIdentity with Valibot schema", () => {
@@ -100,6 +102,7 @@ describe("createIdentity", () => {
         })
         type ExpectedIdentity = valibot.InferOutput<typeof schema>
         expectTypeOf<ExpectedIdentity>().toEqualTypeOf<InferUser<typeof auth>>()
+        expectTypeOf<ExpectedIdentity>().toEqualTypeOf<UserFrom<typeof schema>>()
     })
 
     test("createIdentity with Arktype schema", () => {
@@ -151,6 +154,7 @@ describe("createIdentity", () => {
         })
         type ExpectedIdentity = Exclude<ReturnType<typeof Schema>, ArkErrors>
         expectTypeOf<ExpectedIdentity>().toEqualTypeOf<InferUser<typeof auth>>()
+        expectTypeOf<ExpectedIdentity>().toEqualTypeOf<UserFrom<typeof Schema>>()
     })
 
     test("createIdentity with TypeBox schema", () => {


### PR DESCRIPTION
## Description

This pull request extends the type inference capabilities of the `UserFrom` utility type to support additional schema providers.

Previously, `UserFrom` only supported inferring user types from Zod schemas. This PR expands its coverage to also support ArkType and Valibot schemas, providing a consistent type inference experience across all supported schema libraries.

> [!NOTE]
> `UserFrom` is an alternative to `InferUser`.
>
> * `UserFrom` infers the user type directly from a schema definition.
> * `InferUser` infers the user type from an authentication instance created with `createAuth()`.


### Usage

```ts id="n8v3km"
const schema = UserIdentity.extend({
  isAdmin: z.boolean(),
  role: z.enum(["admin", "user"]),
})

const auth = createAuth({
  oauth: [],
  identity: {
    schema,
  },
})

// Infer from the auth instance
type User = InferUser<typeof auth>

// Infer directly from the schema
type SchemaUser = UserFrom<typeof schema>
```

Both utilities infer the same user shape, but from different sources:

* `InferUser` derives the type from a configured authentication instance.
* `UserFrom` derives the type directly from a schema definition.

This makes `UserFrom` particularly useful when working with schemas independently of a `createAuth()` instance.
