### PR TITLE
fix(security): harden proxy URL handling

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Fixed URL construction when proxy headers are enabled. The `trustedOrigins` option is now required to complete the configuration, allowing URLs to be constructed and validated against a list of trusted origins. [#193](https://github.com/aura-stack-ts/auth/pull/193)
+
 - Fixed type inference for authentication actions created with `createAuth()` and `createAuthClient()`. The `signUp.schema` configuration is now inferred correctly, improving type safety and reducing the need for manual type annotations. [#190](https://github.com/aura-stack-ts/auth/pull/190)
 
 ### Changed

--- a/packages/core/src/actions/signIn/authorization.ts
+++ b/packages/core/src/actions/signIn/authorization.ts
@@ -48,9 +48,10 @@ export const getBaseURL = async ({
 }
 
 export const getOriginURL = async (request: Request, context?: GlobalContext) => {
-    const trustedOrigins = await getTrustedOrigins(request, context?.trustedOrigins)
+    const trustedOrigins = [...(await getTrustedOrigins(request, context?.trustedOrigins))]
     if (!context?.trustedProxyHeaders) {
-        trustedOrigins.push(new URL(request.url).origin)
+        const requestOrigin = new URL(request.url).origin
+        if (!trustedOrigins.includes(requestOrigin)) trustedOrigins.push(requestOrigin)
     }
     const origin = await getBaseURL({ request, ctx: context })
     if (!isTrustedOrigin(origin, trustedOrigins)) {

--- a/packages/core/src/actions/signIn/authorization.ts
+++ b/packages/core/src/actions/signIn/authorization.ts
@@ -49,7 +49,9 @@ export const getBaseURL = async ({
 
 export const getOriginURL = async (request: Request, context?: GlobalContext) => {
     const trustedOrigins = await getTrustedOrigins(request, context?.trustedOrigins)
-    trustedOrigins.push(new URL(request.url).origin)
+    if (!context?.trustedProxyHeaders) {
+        trustedOrigins.push(new URL(request.url).origin)
+    }
     const origin = await getBaseURL({ request, ctx: context })
     if (!isTrustedOrigin(origin, trustedOrigins)) {
         context?.logger?.log("UNTRUSTED_ORIGIN", { structuredData: { origin: origin } })

--- a/packages/core/src/router/context.ts
+++ b/packages/core/src/router/context.ts
@@ -1,13 +1,14 @@
 import { createJoseInstance } from "@/jose.ts"
 import { createCookieStore } from "@/cookie.ts"
+import { AuraAuthError } from "@/shared/errors.ts"
 import { createProxyLogger } from "@/shared/logger.ts"
 import { createSessionStrategy } from "@/session/strategy.ts"
+import { createJoseManager } from "@/session/jose-manager.ts"
 import { createSchemaRegistry } from "@/validator/registry.ts"
 import { createBuiltInOAuthProviders } from "@/oauth/index.ts"
 import { getEnv, getEnvArray, getEnvBoolean } from "@/shared/env.ts"
 import type { Identities, SchemaTypes } from "@/shared/identity.ts"
 import type { AuthConfig, InternalContext, FromShapeToObject } from "@/@types/index.ts"
-import { createJoseManager } from "@/session/jose-manager.ts"
 
 export const createContext = <Identity extends Identities, SignUpSchema extends SchemaTypes>(
     config?: AuthConfig<Identity, SignUpSchema>
@@ -30,6 +31,13 @@ export const createContext = <Identity extends Identities, SignUpSchema extends 
         unknownKeys,
         skipValidation,
     })
+
+    if (
+        useProxyHeaders &&
+        (!config?.trustedOrigins || (Array.isArray(config.trustedOrigins) && config.trustedOrigins.length === 0))
+    ) {
+        throw new AuraAuthError({ code: "AUTH_INVALID_PROXY_HEADERS_CONFIG" })
+    }
 
     const ctx = {
         oauth: createBuiltInOAuthProviders(config?.oauth),

--- a/packages/core/src/router/context.ts
+++ b/packages/core/src/router/context.ts
@@ -16,6 +16,8 @@ export const createContext = <Identity extends Identities, SignUpSchema extends 
     const trustedProxyHeadersEnv = getEnv("TRUSTED_PROXY_HEADERS")
     const useProxyHeaders =
         trustedProxyHeadersEnv === undefined ? (config?.trustedProxyHeaders ?? false) : getEnvBoolean("TRUSTED_PROXY_HEADERS")
+    const envTrustedOrigins = getEnvArray("TRUSTED_ORIGINS")
+    const resolvedTrustedOrigins = envTrustedOrigins.length > 0 ? envTrustedOrigins : config?.trustedOrigins
     const logger = createProxyLogger(config)
     const cookiePrefix = config?.cookies?.prefix
     const cookieOverrides = config?.cookies?.overrides ?? {}
@@ -34,7 +36,7 @@ export const createContext = <Identity extends Identities, SignUpSchema extends 
 
     if (
         useProxyHeaders &&
-        (!config?.trustedOrigins || (Array.isArray(config.trustedOrigins) && config.trustedOrigins.length === 0))
+        (!resolvedTrustedOrigins || (Array.isArray(resolvedTrustedOrigins) && resolvedTrustedOrigins.length === 0))
     ) {
         throw new AuraAuthError({ code: "AUTH_INVALID_PROXY_HEADERS_CONFIG" })
     }
@@ -47,7 +49,7 @@ export const createContext = <Identity extends Identities, SignUpSchema extends 
         secret: config?.secret,
         basePath: config?.basePath ?? "/auth",
         trustedProxyHeaders: useProxyHeaders,
-        trustedOrigins: getEnvArray("TRUSTED_ORIGINS").length > 0 ? getEnvArray("TRUSTED_ORIGINS") : config?.trustedOrigins,
+        trustedOrigins: resolvedTrustedOrigins,
         logger,
         cookieConfig: { secure: secureCookieStore, standard: standardCookieStore },
         baseURL: config?.baseURL,

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -60,6 +60,7 @@ export const AuraErrorCode = {
     INVALID_SALT_SECRET_VALUE: "INVALID_SALT_SECRET_VALUE",
     INVALID_PEM_KEY_PAIR_MODE_MISMATCH: "INVALID_PEM_KEY_PAIR_MODE_MISMATCH",
     INVALID_PEM_KEY_PAIR_SINGLE_MISMATCH: "INVALID_PEM_KEY_PAIR_SINGLE_MISMATCH",
+    AUTH_INVALID_PROXY_HEADERS_CONFIG: "AUTH_INVALID_PROXY_HEADERS_CONFIG",
     /**
      * OAuth Errors
      */
@@ -634,6 +635,15 @@ export const ERROR_CATALOG: Record<AuraErrorCode, CatalogEntry> = {
         message:
             "The generated or passed PKCE 'code_verifier' configuration string structure does not fulfill security specification layout rules (must be between 43 and 128 characters long).",
         userMessage: "The cryptographic dynamic code verifier does not fit structural specification constraints (43-128 chars).",
+    },
+    AUTH_INVALID_PROXY_HEADERS_CONFIG: {
+        type: "VALIDATION",
+        statusCode: 500,
+        name: "ConfigError",
+        message:
+            "Security assertion failed during instantiation: 'trustedProxyHeaders' was enabled, but 'trustedOrigins' is completely empty or undefined. Real proxy networks require explicit origin mapping rules to mitigate host-header hijacking and cache-poisoning vectors.",
+        userMessage:
+            "Internal configuration failure. Enabling trusted proxy headers requires an explicit trusted origins array setup.",
     },
     /**
      * Schema Errors

--- a/packages/core/test/actions/signIn/signIn.test.ts
+++ b/packages/core/test/actions/signIn/signIn.test.ts
@@ -153,7 +153,7 @@ describe("signIn action", () => {
         } = createAuth({
             oauth: [oauthCustomService],
             trustedProxyHeaders: true,
-            trustedOrigins: [],
+            trustedOrigins: ["https://example.com"],
         })
         const request = await GET(
             new Request("http://example.com/auth/signIn/oauth-provider", {
@@ -234,7 +234,7 @@ describe("signIn action", () => {
         } = createAuth({
             oauth: [oauthCustomService],
             trustedProxyHeaders: true,
-            trustedOrigins: [],
+            trustedOrigins: ["https://example.com"],
         })
         const request = await GET(
             new Request("http://example.com/auth/signIn/oauth-provider", {
@@ -328,7 +328,7 @@ describe("signIn action", () => {
         } = createAuth({
             oauth: [oauthCustomService],
             trustedProxyHeaders: true,
-            trustedOrigins: [],
+            trustedOrigins: ["https://example.com"],
         })
 
         const request = await GET(
@@ -358,7 +358,7 @@ describe("signIn action", () => {
         } = createAuth({
             oauth: [oauthCustomService],
             trustedProxyHeaders: true,
-            trustedOrigins: [],
+            trustedOrigins: ["https://example.com"],
         })
 
         const request = await GET(

--- a/packages/core/test/api/signIn.test.ts
+++ b/packages/core/test/api/signIn.test.ts
@@ -51,7 +51,7 @@ describe("signIn API", () => {
         const api = createAuth({
             oauth: [oauthCustomService],
             trustedProxyHeaders: true,
-            trustedOrigins: [],
+            trustedOrigins: ["https://example.com"],
         }).api
         const signIn = await api.signIn("oauth-provider", {
             headers: {

--- a/packages/core/test/instance.test.ts
+++ b/packages/core/test/instance.test.ts
@@ -84,5 +84,41 @@ describe("createAuth", () => {
                 })
             ).not.toThrow()
         })
+
+        test("throws error if trustedProxyHeaders is enabled but trustedOrigins is not set via env", () => {
+            vi.stubEnv("TRUSTED_PROXY_HEADERS", "true")
+
+            expect(() =>
+                createAuth({
+                    oauth: [],
+                })
+            ).toThrow(
+                "Security assertion failed during instantiation: 'trustedProxyHeaders' was enabled, but 'trustedOrigins' is completely empty or undefined. Real proxy networks require explicit origin mapping rules to mitigate host-header hijacking and cache-poisoning vectors."
+            )
+        })
+
+        test("throws error if trustedProxyHeaders is enabled but trustedOrigins is empty set via env", () => {
+            vi.stubEnv("TRUSTED_PROXY_HEADERS", "true")
+            vi.stubEnv("TRUSTED_ORIGINS", "")
+
+            expect(() =>
+                createAuth({
+                    oauth: [],
+                })
+            ).toThrow(
+                "Security assertion failed during instantiation: 'trustedProxyHeaders' was enabled, but 'trustedOrigins' is completely empty or undefined. Real proxy networks require explicit origin mapping rules to mitigate host-header hijacking and cache-poisoning vectors."
+            )
+        })
+
+        test("does not throw error if trustedProxyHeaders is enabled and trustedOrigins is set via env", () => {
+            vi.stubEnv("TRUSTED_PROXY_HEADERS", "true")
+            vi.stubEnv("TRUSTED_ORIGINS", "https://example.com")
+
+            expect(() =>
+                createAuth({
+                    oauth: [],
+                })
+            ).not.toThrow()
+        })
     })
 })

--- a/packages/core/test/instance.test.ts
+++ b/packages/core/test/instance.test.ts
@@ -61,4 +61,28 @@ describe("createAuth", () => {
             expect(response.status).toBe(404)
         })
     })
+
+    describe("trustedProxyHeader", () => {
+        test("throws error if trustedProxyHeaders is enabled but trustedOrigins is not set", () => {
+            expect(() =>
+                createAuth({
+                    oauth: [],
+                    trustedProxyHeaders: true,
+                    trustedOrigins: [],
+                })
+            ).toThrow(
+                "Security assertion failed during instantiation: 'trustedProxyHeaders' was enabled, but 'trustedOrigins' is completely empty or undefined. Real proxy networks require explicit origin mapping rules to mitigate host-header hijacking and cache-poisoning vectors."
+            )
+        })
+
+        test("does not throw error if trustedProxyHeaders is enabled and trustedOrigins is set", () => {
+            expect(() =>
+                createAuth({
+                    oauth: [],
+                    trustedProxyHeaders: true,
+                    trustedOrigins: ["https://example.com"],
+                })
+            ).not.toThrow()
+        })
+    })
 })


### PR DESCRIPTION
## Description

This pull request hardens automatic URL construction when the `trustedProxyHeaders` option is enabled.

With this change, configuring `trustedOrigins` is now required when `trustedProxyHeaders` is enabled. If no trusted origins are provided, the authentication instance will throw a configuration error during initialization.

This additional validation improves security by ensuring that URLs reconstructed from proxy headers are verified against an explicit allowlist of trusted origins before being considered valid.

Previously, when `trustedProxyHeaders` was enabled, the URL was automatically reconstructed from the incoming proxy headers and assumed to be valid. While this behavior worked correctly in many deployments, it relied solely on the forwarded header values and did not verify the resulting URL against a trusted origin list.

With this hardening, the reconstructed URL is now compared against the configured `trustedOrigins`, providing an additional layer of validation and increasing confidence in deployments that rely on reverse proxies, load balancers, and other proxy infrastructure.

### Key Changes

* Require `trustedOrigins` when `trustedProxyHeaders` is enabled.
* Throw a configuration error when `trustedProxyHeaders` is enabled without any trusted origins configured.
* Validate URLs reconstructed from proxy headers against the configured trusted origin list.
* Strengthen URL verification for proxy-based deployments.
* Improve security around automatic URL detection and construction.

@coderabbitai ignore