### PR TITLE
feat(core): integrate rate limiting into auth flows

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -301,6 +301,7 @@
       "version": "0.7.2",
       "dependencies": {
         "@aura-stack/jose": "workspace:*",
+        "@aura-stack/rate-limiter": "workspace:*",
         "@aura-stack/router": "^0.9.0",
         "arktype": "^2.2.0",
         "typebox": "^1.1.38",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Integrated `@aura-stack/rate-limiter` into authentication flows. Rate limiting is now enforced for `signIn`, `signInCredentials`, `signUp`, and `updateSession` actions, providing built-in protection against abuse and excessive requests. [#194](https://github.com/aura-stack-ts/auth/pull/194)
+
 - Extended `UserFrom` to support type inference from `ArkType` and `Valibot` schemas. User types are now inferred correctly for `Zod`, `ArkType`, and `Valibot` schema definitions. [#191](https://github.com/aura-stack-ts/auth/pull/191)
 
 - Added `InferSignUp`, a utility type for inferring the sign-up payload from `createAuth().signUp.schema`. This type can be reused as the second generic parameter of `createAuthClient()` to ensure consistent typing between server and client authentication configurations. [#190](https://github.com/aura-stack-ts/auth/pull/190)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,6 +105,7 @@
   "license": "MIT",
   "dependencies": {
     "@aura-stack/jose": "workspace:*",
+    "@aura-stack/rate-limiter": "workspace:*",
     "@aura-stack/router": "^0.9.0",
     "arktype": "^2.2.0",
     "typebox": "^1.1.38",

--- a/packages/core/src/@types/config.ts
+++ b/packages/core/src/@types/config.ts
@@ -3,13 +3,15 @@ import { createAuthAPI } from "@/api/createApi.ts"
 import { createLogEntry } from "@/shared/logger.ts"
 import { createSchemaRegistry } from "@/validator/registry.ts"
 import { UserIdentity, type Identities, type SchemaTypes } from "@/shared/identity.ts"
+import type { ZodObject } from "zod"
+import type { InferSchema } from "@aura-stack/router"
 import type { BuiltInOAuthProvider } from "@/oauth/index.ts"
 import type { SerializeOptions } from "@aura-stack/router/cookie"
 import type { ConfigSchema, FromShapeToObject, Prettify } from "@/@types/utility.ts"
 import type { OAuthProviderCredentials, OAuthProviderRecord } from "@/@types/oauth.ts"
+import type { InferRules, RateLimiterRule } from "@aura-stack/rate-limiter/types"
 import type { JWTKey, JWTManager, SessionConfig, SessionStrategy, User } from "@/@types/session.ts"
-import type { InferSchema } from "@aura-stack/router"
-import type { ZodObject } from "zod"
+import type { RateLimiterConfig as RaterLimiterBaseConfig } from "@aura-stack/rate-limiter"
 
 /**
  * Main configuration interface for Aura Auth.
@@ -164,6 +166,10 @@ export type AuthConfig<Identity extends Identities, SignUpSchema extends SchemaT
      * and required callback for user creation.
      */
     signUp?: SignUpConfig<Identity, SignUpSchema>
+    /**
+     * Rate limiter configuration to protect authentication endpoints from DoS/DDoS attacks.
+     */
+    rateLimiter?: RateLimiterConfig
 } & TrustedProxyHeadersConfig
 
 // @todo Should trustedOrigins support subdomain wildcards like `https://*.example.com`?
@@ -427,6 +433,7 @@ export interface RouterGlobalContext<DefaultUser extends User = User, SignUpSche
     identity: SchemaRegistryContext
     signUp?: SignUpConfig<DefaultUser, SignUpSchema>
     jwtManager: JWTManager<DefaultUser>
+    rateLimiters: InferRules<Required<RateLimiterConfig>>
 }
 
 export interface SchemaRegistryContext {
@@ -499,3 +506,9 @@ export interface SignUpConfig<Identity extends Identities, SignUpSchema extends 
         context: OnCreateUserContext<SignUpSchema>
     ) => Promise<FromShapeToObject<Identity> | null> | FromShapeToObject<Identity> | null
 }
+
+// #region Rate Limiter
+
+export type RateLimiterConfig = Partial<
+    RaterLimiterBaseConfig<Record<"signIn" | "signInCredentials" | "updateSession" | "signUp", RateLimiterRule>>["rules"]
+>

--- a/packages/core/src/actions/callback/access-token.ts
+++ b/packages/core/src/actions/callback/access-token.ts
@@ -2,6 +2,7 @@ import { fetchAsync } from "@/shared/fetch-async.ts"
 import { AuraAuthError, isAuraAuthError } from "@/shared/errors.ts"
 import { OAuthAccessTokenErrorResponse, OAuthAccessTokenResponse } from "@/schemas.ts"
 import type { InternalLogger, OAuthProviderCredentials } from "@/@types/index.ts"
+import { assertContentTypeResponse } from "@/shared/assert.ts"
 
 /**
  * Make a request to the OAuth provider to the token endpoint to exchange the authorization code provided
@@ -67,6 +68,7 @@ export const createAccessToken = async (
             logger?.log("INVALID_OAUTH_ACCESS_TOKEN_RESPONSE")
             throw new AuraAuthError({ code: "INVALID_OAUTH_ACCESS_TOKEN_RESPONSE" })
         }
+        assertContentTypeResponse(response, logger)
         const json = await response.json()
         const token = OAuthAccessTokenResponse.safeParse(json)
         if (!token.success) {

--- a/packages/core/src/actions/callback/userinfo.ts
+++ b/packages/core/src/actions/callback/userinfo.ts
@@ -8,7 +8,7 @@ import type {
     OAuthProviderCredentials,
     User,
 } from "@/@types/index.ts"
-import { isCustomUserInfoFunction } from "@/shared/assert.ts"
+import { assertContentTypeResponse, isCustomUserInfoFunction } from "@/shared/assert.ts"
 import { AuraAuthError, isAuraAuthError } from "@/shared/errors.ts"
 
 /**
@@ -61,6 +61,7 @@ const createUserInfoRequest = async (oauthConfig: ProviderConfig, accessToken: s
             throw new AuraAuthError({ code: "INVALID_OAUTH_USER_INFO_RESPONSE" })
         }
 
+        assertContentTypeResponse(response, logger)
         const json = await response.json()
         const { success, data } = OAuthErrorResponse.safeParse(json)
         if (success) {

--- a/packages/core/src/api/signIn.ts
+++ b/packages/core/src/api/signIn.ts
@@ -1,5 +1,6 @@
 import { cacheControl, secureApiHeaders } from "@/shared/headers.ts"
 import { HeadersBuilder } from "@aura-stack/router"
+import { verifyRateLimit } from "@/router/rate-limiter.ts"
 import { AuraAuthError, isAuraAuthError } from "@/shared/errors.ts"
 import { createAuthorizationURL } from "@/actions/signIn/authorization-url.ts"
 import { createRedirectTo, createRedirectURI, createSignInURL, getBaseURL } from "@/actions/signIn/authorization.ts"
@@ -24,6 +25,15 @@ export const signIn = async (
             const origin = await getBaseURL({ ctx, headers })
             const url = `${origin}${ctx.basePath}/signIn/${oauth}`
             request = new Request(url, { headers })
+        }
+
+        const rateLimit = await verifyRateLimit(ctx, request, "signIn")
+
+        if (rateLimit) {
+            /**
+             * Rate Limiting is not returning the expected body.
+             */
+            return rateLimit as unknown as SignInAPIReturn
         }
 
         if (redirect === false) {

--- a/packages/core/src/api/signIn.ts
+++ b/packages/core/src/api/signIn.ts
@@ -30,9 +30,6 @@ export const signIn = async (
         const rateLimit = await verifyRateLimit(ctx, request, "signIn")
 
         if (rateLimit) {
-            /**
-             * Rate Limiting is not returning the expected body.
-             */
             return rateLimit as unknown as SignInAPIReturn
         }
 

--- a/packages/core/src/api/signInCredentials.ts
+++ b/packages/core/src/api/signInCredentials.ts
@@ -5,6 +5,7 @@ import { AuraAuthError, isAuraAuthError } from "@/shared/errors.ts"
 import { createCSRF, hashPassword, verifyPassword } from "@/shared/crypto.ts"
 import { createRedirectTo, getBaseURL, getOriginURL } from "@/actions/signIn/authorization.ts"
 import type { FunctionAPIContext, SignInCredentialsAPIOptions, SignInCredentialsAPIReturn } from "@/@types/api.ts"
+import { verifyRateLimit } from "@/router/rate-limiter.ts"
 
 export const signInCredentials = async ({
     ctx,
@@ -30,6 +31,12 @@ export const signInCredentials = async ({
             const url = `${origin}${ctx.basePath}/signIn/credentials`
             request = new Request(url, { headers: headerInit })
         }
+
+        const rateLimit = await verifyRateLimit(ctx, request, "signInCredentials")
+        if (rateLimit) {
+            return rateLimit as SignInCredentialsAPIReturn
+        }
+
         await getOriginURL(request, ctx)
 
         const session = await credentials?.authorize({

--- a/packages/core/src/api/signUp.ts
+++ b/packages/core/src/api/signUp.ts
@@ -2,6 +2,7 @@ import { createCSRF } from "@/shared/crypto.ts"
 import { HeadersBuilder } from "@aura-stack/router"
 import { verifyCSRFToken } from "@/shared/utils.ts"
 import { secureApiHeaders } from "@/shared/headers.ts"
+import { verifyRateLimit } from "@/router/rate-limiter.ts"
 import { AuraAuthError, isAuraAuthError } from "@/shared/errors.ts"
 import { createRedirectTo, getBaseURL, getOriginURL } from "@/actions/signIn/authorization.ts"
 import type { FunctionAPIContext, SignUpAPIOptions, SignUpAPIReturn } from "@/@types/api.ts"
@@ -31,6 +32,12 @@ export const signUp = async <Payload extends Record<string, unknown> = Record<st
             const url = `${origin}${ctx.basePath}/signUp`
             request = new Request(url, { headers: headersInit })
         }
+
+        const rateLimit = await verifyRateLimit(ctx, request, "signUp")
+        if (rateLimit) {
+            return rateLimit as SignUpAPIReturn
+        }
+
         await getOriginURL(request, ctx)
         const user = await signUp?.onCreateUser({
             payload,

--- a/packages/core/src/api/signUp.ts
+++ b/packages/core/src/api/signUp.ts
@@ -18,6 +18,19 @@ export const signUp = async <Payload extends Record<string, unknown> = Record<st
 }: FunctionAPIContext<SignUpAPIOptions<Payload>>): Promise<SignUpAPIReturn> => {
     const { signUp, cookies, sessionStrategy, logger } = ctx
     try {
+        let request = requestInit
+        if (!request) {
+            const origin = await getBaseURL({ ctx, headers: headersInit })
+            const url = `${origin}${ctx.basePath}/signUp`
+            request = new Request(url, { headers: headersInit })
+        }
+        await getOriginURL(request, ctx)
+
+        const rateLimit = await verifyRateLimit(ctx, request, "signUp")
+        if (rateLimit) {
+            return rateLimit as SignUpAPIReturn
+        }
+
         await verifyCSRFToken({
             headers: new Headers(headersInit),
             cookies,
@@ -26,19 +39,6 @@ export const signUp = async <Payload extends Record<string, unknown> = Record<st
             skipCSRFCheck,
         })
 
-        let request = requestInit
-        if (!request) {
-            const origin = await getBaseURL({ ctx, headers: headersInit })
-            const url = `${origin}${ctx.basePath}/signUp`
-            request = new Request(url, { headers: headersInit })
-        }
-
-        const rateLimit = await verifyRateLimit(ctx, request, "signUp")
-        if (rateLimit) {
-            return rateLimit as SignUpAPIReturn
-        }
-
-        await getOriginURL(request, ctx)
         const user = await signUp?.onCreateUser({
             payload,
         })

--- a/packages/core/src/api/updateSession.ts
+++ b/packages/core/src/api/updateSession.ts
@@ -34,7 +34,7 @@ export const updateSession = async <DefaultUser extends User = User>({
         }
         await getOriginURL(request, ctx)
 
-        const rateLimit = await verifyRateLimit(ctx, request, "signIn")
+        const rateLimit = await verifyRateLimit(ctx, request, "updateSession")
         if (rateLimit) {
             return rateLimit as UpdateSessionAPIReturn<DefaultUser>
         }

--- a/packages/core/src/api/updateSession.ts
+++ b/packages/core/src/api/updateSession.ts
@@ -3,6 +3,7 @@ import { secureApiHeaders } from "@/shared/headers.ts"
 import { AuraAuthError, isAuraAuthError } from "@/shared/errors.ts"
 import { createRedirectTo, getBaseURL, getOriginURL } from "@/actions/signIn/authorization.ts"
 import type { FunctionAPIContext, UpdateSessionAPIOptions, UpdateSessionAPIReturn, User } from "@/@types/index.ts"
+import { verifyRateLimit } from "@/router/rate-limiter.ts"
 
 export const updateSession = async <DefaultUser extends User = User>({
     ctx,
@@ -32,6 +33,11 @@ export const updateSession = async <DefaultUser extends User = User>({
             request = new Request(url, { headers: newHeaders })
         }
         await getOriginURL(request, ctx)
+
+        const rateLimit = await verifyRateLimit(ctx, request, "signIn")
+        if (rateLimit) {
+            return rateLimit as UpdateSessionAPIReturn<DefaultUser>
+        }
 
         let redirectURL: string | null = await createRedirectTo(request, redirectToInit, ctx)
         redirectURL = redirectToInit ? redirectURL : redirectURL === "/" ? null : redirectURL

--- a/packages/core/src/router/context.ts
+++ b/packages/core/src/router/context.ts
@@ -7,6 +7,7 @@ import { createJoseManager } from "@/session/jose-manager.ts"
 import { createSchemaRegistry } from "@/validator/registry.ts"
 import { createBuiltInOAuthProviders } from "@/oauth/index.ts"
 import { getEnv, getEnvArray, getEnvBoolean } from "@/shared/env.ts"
+import { createRateLimiterInstance } from "@/router/rate-limiter.ts"
 import type { Identities, SchemaTypes } from "@/shared/identity.ts"
 import type { AuthConfig, InternalContext, FromShapeToObject } from "@/@types/index.ts"
 
@@ -60,6 +61,7 @@ export const createContext = <Identity extends Identities, SignUpSchema extends 
         },
         signUp: config?.signUp,
         jwtManager: createJoseManager(config?.session?.jwt, jose),
+        rateLimiters: createRateLimiterInstance(config?.rateLimiter),
     } as InternalContext<Identity, SignUpSchema>
     ctx.sessionStrategy = createSessionStrategy<Identity>({
         cookies: () => ctx.cookies,

--- a/packages/core/src/router/rate-limiter.ts
+++ b/packages/core/src/router/rate-limiter.ts
@@ -1,0 +1,77 @@
+import type { RateLimiterConfig, RouterGlobalContext } from "@/@types/config.ts"
+import { secureApiHeaders } from "@/shared/headers.ts"
+import { createRateLimiter, type RateLimiterRule } from "@aura-stack/rate-limiter"
+
+export const createRateLimiterInstance = (config?: RateLimiterConfig) => {
+    const getLimitKey = (request: Request, action: string): string => {
+        const ip =
+            request.headers.get("cf-connecting-ip") ??
+            request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+            request.headers.get("x-real-ip") ??
+            "anon"
+        return `rl:${action}:${ip}`
+    }
+
+    return createRateLimiter<RateLimiterConfig>({
+        rules: {
+            signIn: {
+                algorithm: "sliding-window",
+                limit: 10,
+                windowMs: 15 * 60 * 1000,
+                keyGenerator: (request) => getLimitKey(request, "signIn"),
+                ...config?.signIn,
+            } as RateLimiterRule,
+            signInCredentials: {
+                algorithm: "sliding-window",
+                limit: 8,
+                windowMs: 15 * 60 * 1000,
+                keyGenerator: (request) => getLimitKey(request, "signInCredentials"),
+                ...config?.signInCredentials,
+            } as RateLimiterRule,
+            signUp: {
+                algorithm: "fixed-window",
+                limit: 5,
+                windowMs: 60 * 60 * 1000,
+                keyGenerator: (request) => getLimitKey(request, "signUp"),
+                ...config?.signUp,
+            } as RateLimiterRule,
+            updateSession: {
+                algorithm: "token-bucket",
+                capacity: 10,
+                refillRate: 1 / 60_000,
+                keyGenerator: (request) => getLimitKey(request, "updateSession"),
+                ...config?.updateSession,
+            } as RateLimiterRule,
+        },
+    })
+}
+
+/**
+ * Should return rateLimit.toResponse() or custom body managed along the package ?
+ */
+export const verifyRateLimit = async (ctx: RouterGlobalContext, request: Request, action: keyof RateLimiterConfig) => {
+    const rateLimit = await ctx.rateLimiters[action].check(request)
+    if (!rateLimit.ok) {
+        const response = rateLimit.toResponse()
+        const headersList = new Headers(secureApiHeaders)
+        response.headers.forEach((v: string, k: string) => headersList.set(k, v))
+        return {
+            success: false,
+            redirect: false,
+            redirectURL: null,
+            error: { code: "RATE_LIMIT_EXCEEDED", message: "Too many requests." },
+            headers: headersList,
+            toResponse: () => {
+                return Response.json(
+                    {
+                        success: false,
+                        redirect: false,
+                        redirectURL: null,
+                    },
+                    { status: 429, headers: headersList }
+                )
+            },
+        }
+    }
+    return undefined
+}

--- a/packages/core/src/router/rate-limiter.ts
+++ b/packages/core/src/router/rate-limiter.ts
@@ -51,7 +51,17 @@ export const createRateLimiterInstance = (config?: RateLimiterConfig) => {
 export const verifyRateLimit = async (ctx: RouterGlobalContext, request: Request, action: keyof RateLimiterConfig) => {
     const rateLimit = await ctx.rateLimiters[action].check(request)
     if (!rateLimit.ok) {
-        return rateLimit.toResponse()
+        const toResponse = rateLimit.toResponse()
+        let redirectField = action === "signIn" ? "signInURL" : "redirectURL"
+
+        return {
+            success: false,
+            redirect: false,
+            [redirectField]: null,
+            error: { code: "RATE_LIMIT_EXCEEDED", message: "Too many requests." },
+            headers: toResponse.headers,
+            toResponse: () => toResponse,
+        }
     }
     return undefined
 }

--- a/packages/core/src/router/rate-limiter.ts
+++ b/packages/core/src/router/rate-limiter.ts
@@ -1,6 +1,5 @@
-import type { RateLimiterConfig, RouterGlobalContext } from "@/@types/config.ts"
-import { secureApiHeaders } from "@/shared/headers.ts"
 import { createRateLimiter, type RateLimiterRule } from "@aura-stack/rate-limiter"
+import type { RateLimiterConfig, RouterGlobalContext } from "@/@types/config.ts"
 
 export const createRateLimiterInstance = (config?: RateLimiterConfig) => {
     const getLimitKey = (request: Request, action: string): string => {
@@ -52,26 +51,7 @@ export const createRateLimiterInstance = (config?: RateLimiterConfig) => {
 export const verifyRateLimit = async (ctx: RouterGlobalContext, request: Request, action: keyof RateLimiterConfig) => {
     const rateLimit = await ctx.rateLimiters[action].check(request)
     if (!rateLimit.ok) {
-        const response = rateLimit.toResponse()
-        const headersList = new Headers(secureApiHeaders)
-        response.headers.forEach((v: string, k: string) => headersList.set(k, v))
-        return {
-            success: false,
-            redirect: false,
-            redirectURL: null,
-            error: { code: "RATE_LIMIT_EXCEEDED", message: "Too many requests." },
-            headers: headersList,
-            toResponse: () => {
-                return Response.json(
-                    {
-                        success: false,
-                        redirect: false,
-                        redirectURL: null,
-                    },
-                    { status: 429, headers: headersList }
-                )
-            },
-        }
+        return rateLimit.toResponse()
     }
     return undefined
 }

--- a/packages/core/src/shared/assert.ts
+++ b/packages/core/src/shared/assert.ts
@@ -8,6 +8,7 @@ import type {
     AsymmetricKeyPair,
     AsymmetricKeyPairFromEnv,
     CryptoSecret,
+    InternalLogger,
     JWTConfig,
     JWTMode,
     JWTPayloadWithToken,
@@ -15,6 +16,7 @@ import type {
     SessionConfig,
 } from "@/@types/index.ts"
 import type { JWK } from "@aura-stack/jose/jose"
+import { AuraAuthError } from "./errors.ts"
 
 export const isFalsy = (value: unknown): boolean => {
     return value === false || value === 0 || value === "" || value === null || value === undefined || Number.isNaN(value)
@@ -225,4 +227,14 @@ export const isCustomUserInfoFunction = (value: OAuthProviderConfig["userInfo"])
         "request" in value &&
         typeof value.request === "function"
     )
+}
+
+export const assertContentTypeResponse = (response: Response, logger?: InternalLogger | undefined) => {
+    const contentType = response.headers.get("Content-Type")
+    if (!contentType?.includes("application/json")) {
+        logger?.log("OAUTH_INVALID_CONTENT_TYPE", {
+            structuredData: { content_type: contentType! },
+        })
+        throw new AuraAuthError({ code: "OAUTH_INVALID_CONTENT_TYPE" })
+    }
 }

--- a/packages/core/src/shared/assert.ts
+++ b/packages/core/src/shared/assert.ts
@@ -231,7 +231,8 @@ export const isCustomUserInfoFunction = (value: OAuthProviderConfig["userInfo"])
 
 export const assertContentTypeResponse = (response: Response, logger?: InternalLogger | undefined) => {
     const contentType = response.headers.get("Content-Type")
-    if (!contentType?.includes("application/json")) {
+    const mediaType = contentType?.split(";")[0]?.trim().toLowerCase()
+    if (mediaType !== "application/json") {
         logger?.log("OAUTH_INVALID_CONTENT_TYPE", {
             structuredData: { content_type: contentType! },
         })

--- a/packages/core/src/shared/crypto.ts
+++ b/packages/core/src/shared/crypto.ts
@@ -94,10 +94,10 @@ export const verifyCSRF = async <DefaultUser extends User = User>(
  *
  * @param password - The password to hash.
  * @param salt - Optional salt (base64url encoded). If not provided, a random salt will be generated.
- * @param iterations - The number of PBKDF2 iterations. Default is 100,000.
+ * @param iterations - The number of PBKDF2 iterations. Default is 600,000.
  * @returns The hashed password in the format `iterations:salt:hash` (all segments base64url encoded).
  */
-export const hashPassword = async (password: string, salt?: string, iterations = 100000) => {
+export const hashPassword = async (password: string, salt?: string, iterations = 600_000) => {
     const subtle = getSubtleCrypto()
     const saltBuffer = (salt ? base64url.decode(salt) : getRandomBytes(16)) as Uint8Array<ArrayBuffer>
     const baseKey = await subtle.importKey("raw", encoder.encode(password) as Uint8Array<ArrayBuffer>, "PBKDF2", false, [

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -83,6 +83,8 @@ export const AuraErrorCode = {
     DUPLICATED_OAUTH_PROVIDER_ID: "DUPLICATED_OAUTH_PROVIDER_ID",
     INVALID_ENVIRONMENT_CONFIGURATION: "INVALID_ENVIRONMENT_CONFIGURATION",
     PKCE_VERIFIER_INVALID: "PKCE_VERIFIER_INVALID",
+    OAUTH_INVALID_CONTENT_TYPE: "OAUTH_INVALID_CONTENT_TYPE",
+
     /**
      * Schema Errors
      */
@@ -644,6 +646,15 @@ export const ERROR_CATALOG: Record<AuraErrorCode, CatalogEntry> = {
             "Security assertion failed during instantiation: 'trustedProxyHeaders' was enabled, but 'trustedOrigins' is completely empty or undefined. Real proxy networks require explicit origin mapping rules to mitigate host-header hijacking and cache-poisoning vectors.",
         userMessage:
             "Internal configuration failure. Enabling trusted proxy headers requires an explicit trusted origins array setup.",
+    },
+    OAUTH_INVALID_CONTENT_TYPE: {
+        type: "PROTOCOL",
+        statusCode: 502,
+        name: "OAuthError",
+        message:
+            "The remote identity provider token exchange endpoint returned an invalid Content-Type header. Expected 'application/json' or 'application/x-www-form-urlencoded', but received a non-JSON formatted alternative (e.g., text/html). This usually indicates an upstream server error, proxy block, or provider outage.",
+        userMessage:
+            "The identity provider returned an unreadable response format. Please try again or check the provider status.",
     },
     /**
      * Schema Errors

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -652,7 +652,7 @@ export const ERROR_CATALOG: Record<AuraErrorCode, CatalogEntry> = {
         statusCode: 502,
         name: "OAuthError",
         message:
-            "The remote identity provider token exchange endpoint returned an invalid Content-Type header. Expected 'application/json' or 'application/x-www-form-urlencoded', but received a non-JSON formatted alternative (e.g., text/html). This usually indicates an upstream server error, proxy block, or provider outage.",
+            "The remote identity provider endpoint returned an invalid Content-Type header. Expected 'application/json', but received an incompatible format (e.g., text/html). This usually indicates an upstream server error, proxy block, or provider outage.",
         userMessage:
             "The identity provider returned an unreadable response format. Please try again or check the provider status.",
     },

--- a/packages/core/src/shared/logger.ts
+++ b/packages/core/src/shared/logger.ts
@@ -321,6 +321,12 @@ export const logMessages = {
         msgId: "SESSION_NOT_FOUND",
         message: "Session token was not found in the request cookies",
     },
+    OAUTH_INVALID_CONTENT_TYPE: {
+        facility: 10,
+        severity: "error",
+        msgId: "OAUTH_INVALID_CONTENT_TYPE",
+        message: "OAuth token endpoint returned an invalid Content-Type header",
+    },
 } as const
 
 export const createLogEntry = <T extends keyof typeof logMessages>(key: T, overrides?: Partial<SyslogOptions>): SyslogOptions => {

--- a/packages/core/src/shared/logger.ts
+++ b/packages/core/src/shared/logger.ts
@@ -325,7 +325,7 @@ export const logMessages = {
         facility: 10,
         severity: "error",
         msgId: "OAUTH_INVALID_CONTENT_TYPE",
-        message: "OAuth token endpoint returned an invalid Content-Type header",
+        message: "OAuth endpoint returned an invalid Content-Type header",
     },
 } as const
 

--- a/packages/core/test/actions/callback/access-token.test.ts
+++ b/packages/core/test/actions/callback/access-token.test.ts
@@ -25,6 +25,9 @@ describe("createAccessToken", async () => {
             "fetch",
             vi.fn(async () => ({
                 ok: true,
+                headers: new Headers({
+                    "Content-Type": "application/json",
+                }),
                 json: async () => mockResponse,
             }))
         )
@@ -88,6 +91,9 @@ describe("createAccessToken", async () => {
             "fetch",
             vi.fn(async () => ({
                 ok: true,
+                headers: new Headers({
+                    "Content-Type": "application/json",
+                }),
                 json: async () => mockResponse,
             }))
         )
@@ -121,6 +127,9 @@ describe("createAccessToken", async () => {
             "fetch",
             vi.fn(async () => ({
                 ok: true,
+                headers: new Headers({
+                    "Content-Type": "application/json",
+                }),
                 json: async () => mockResponse,
             }))
         )

--- a/packages/core/test/actions/callback/callback.test.ts
+++ b/packages/core/test/actions/callback/callback.test.ts
@@ -129,11 +129,17 @@ describe("callbackAction", () => {
 
         mockFetch.mockResolvedValueOnce({
             ok: true,
+            headers: new Headers({
+                "Content-Type": "application/json",
+            }),
             json: async () => accessTokenMock,
         })
 
         mockFetch.mockResolvedValueOnce({
             ok: true,
+            headers: new Headers({
+                "Content-Type": "application/json",
+            }),
             json: async () => userInfoMock,
         })
 
@@ -225,11 +231,17 @@ describe("callbackAction", () => {
 
         mockFetch.mockResolvedValueOnce({
             ok: true,
+            headers: new Headers({
+                "Content-Type": "application/json",
+            }),
             json: async () => accessTokenMock,
         })
 
         mockFetch.mockResolvedValueOnce({
             ok: true,
+            headers: new Headers({
+                "Content-Type": "application/json",
+            }),
             json: async () => userInfoMock,
         })
 
@@ -327,11 +339,17 @@ describe("callbackAction", () => {
 
         mockFetch.mockResolvedValueOnce({
             ok: true,
+            headers: new Headers({
+                "Content-Type": "application/json",
+            }),
             json: async () => accessTokenMock,
         })
 
         mockFetch.mockResolvedValueOnce({
             ok: true,
+            headers: new Headers({
+                "Content-Type": "application/json",
+            }),
             json: async () => userInfoMock,
         })
 

--- a/packages/core/test/actions/callback/userinfo.test.ts
+++ b/packages/core/test/actions/callback/userinfo.test.ts
@@ -17,6 +17,9 @@ describe("getUserInfo", () => {
             "fetch",
             vi.fn(async () => ({
                 ok: true,
+                headers: new Headers({
+                    "Content-Type": "application/json",
+                }),
                 json: async () => mockResponse,
             }))
         )
@@ -49,6 +52,9 @@ describe("getUserInfo", () => {
             "fetch",
             vi.fn(async () => ({
                 ok: true,
+                headers: new Headers({
+                    "Content-Type": "application/json",
+                }),
                 json: async () => mockResponse,
             }))
         )
@@ -99,6 +105,9 @@ describe("getUserInfo", () => {
             "fetch",
             vi.fn(async () => ({
                 ok: true,
+                headers: new Headers({
+                    "Content-Type": "application/json",
+                }),
                 json: async () => mockResponse,
             }))
         )

--- a/packages/core/test/actions/session/session.test.ts
+++ b/packages/core/test/actions/session/session.test.ts
@@ -148,11 +148,17 @@ describe("sessionAction", () => {
 
         mockFetch.mockResolvedValueOnce({
             ok: true,
+            headers: new Headers({
+                "Content-Type": "application/json",
+            }),
             json: async () => accessTokenMock,
         })
 
         mockFetch.mockResolvedValueOnce({
             ok: true,
+            headers: new Headers({
+                "Content-Type": "application/json",
+            }),
             json: async () => userInfoMock,
         })
 

--- a/packages/core/test/actions/signIn/signIn.test.ts
+++ b/packages/core/test/actions/signIn/signIn.test.ts
@@ -11,6 +11,29 @@ afterEach(() => {
     vi.unstubAllEnvs()
 })
 
+vi.mock("@aura-stack/rate-limiter", async () => {
+    const actual = await vi.importActual<typeof import("@aura-stack/rate-limiter")>("@aura-stack/rate-limiter")
+    return {
+        ...actual,
+        createRateLimiter: (...args: Parameters<typeof actual.createRateLimiter>) => {
+            const limiters = actual.createRateLimiter(...args)
+
+            for (const limiter of Object.values(limiters)) {
+                limiter.check = vi.fn().mockResolvedValue({
+                    ok: true,
+                    limit: Number.MAX_SAFE_INTEGER,
+                    remaining: Number.MAX_SAFE_INTEGER,
+                    resetAt: Date.now() + 60000,
+                    retryAfter: 0,
+                    toResponse: () => new Response(),
+                })
+            }
+
+            return limiters
+        },
+    }
+})
+
 describe("signIn action", () => {
     test("default signIn", async () => {
         const signIn = await GET(new Request("https://example.com/auth/signIn/oauth-provider"))

--- a/packages/core/test/actions/signInCredentials/signInCredentials.test.ts
+++ b/packages/core/test/actions/signInCredentials/signInCredentials.test.ts
@@ -12,6 +12,29 @@ afterEach(() => {
     vi.unstubAllEnvs()
 })
 
+vi.mock("@aura-stack/rate-limiter", async () => {
+    const actual = await vi.importActual<typeof import("@aura-stack/rate-limiter")>("@aura-stack/rate-limiter")
+    return {
+        ...actual,
+        createRateLimiter: (...args: Parameters<typeof actual.createRateLimiter>) => {
+            const limiters = actual.createRateLimiter(...args)
+
+            for (const limiter of Object.values(limiters)) {
+                limiter.check = vi.fn().mockResolvedValue({
+                    ok: true,
+                    limit: Number.MAX_SAFE_INTEGER,
+                    remaining: Number.MAX_SAFE_INTEGER,
+                    resetAt: Date.now() + 60000,
+                    retryAfter: 0,
+                    toResponse: () => new Response(),
+                })
+            }
+
+            return limiters
+        },
+    }
+})
+
 describe("signInCredentials action", async () => {
     const csrfToken = await createCSRF(jose)
 

--- a/packages/core/test/actions/signUp/signUp.test.ts
+++ b/packages/core/test/actions/signUp/signUp.test.ts
@@ -19,6 +19,29 @@ const payload = {
     password: "1234567890",
 }
 
+vi.mock("@aura-stack/rate-limiter", async () => {
+    const actual = await vi.importActual<typeof import("@aura-stack/rate-limiter")>("@aura-stack/rate-limiter")
+    return {
+        ...actual,
+        createRateLimiter: (...args: Parameters<typeof actual.createRateLimiter>) => {
+            const limiters = actual.createRateLimiter(...args)
+
+            for (const limiter of Object.values(limiters)) {
+                limiter.check = vi.fn().mockResolvedValue({
+                    ok: true,
+                    limit: Number.MAX_SAFE_INTEGER,
+                    remaining: Number.MAX_SAFE_INTEGER,
+                    resetAt: Date.now() + 60000,
+                    retryAfter: 0,
+                    toResponse: () => new Response(),
+                })
+            }
+
+            return limiters
+        },
+    }
+})
+
 describe("signUp API", async () => {
     const csrfToken = await createCSRF(jose)
 

--- a/packages/core/test/actions/updateSession/updateSession.test.ts
+++ b/packages/core/test/actions/updateSession/updateSession.test.ts
@@ -3,7 +3,30 @@ import { createAuth } from "@/createAuth.ts"
 import { createCSRF } from "@/shared/crypto.ts"
 import { UserIdentityArkType, UserIdentityValibot } from "@/shared/identity.ts"
 import { jose, PATCH, sessionPayload } from "@test/presets.ts"
-import { describe, test, expect } from "vitest"
+import { describe, test, expect, vi } from "vitest"
+
+vi.mock("@aura-stack/rate-limiter", async () => {
+    const actual = await vi.importActual<typeof import("@aura-stack/rate-limiter")>("@aura-stack/rate-limiter")
+    return {
+        ...actual,
+        createRateLimiter: (...args: Parameters<typeof actual.createRateLimiter>) => {
+            const limiters = actual.createRateLimiter(...args)
+
+            for (const limiter of Object.values(limiters)) {
+                limiter.check = vi.fn().mockResolvedValue({
+                    ok: true,
+                    limit: Number.MAX_SAFE_INTEGER,
+                    remaining: Number.MAX_SAFE_INTEGER,
+                    resetAt: Date.now() + 60000,
+                    retryAfter: 0,
+                    toResponse: () => new Response(),
+                })
+            }
+
+            return limiters
+        },
+    }
+})
 
 describe("updateSession action", () => {
     test("invalid session", async () => {

--- a/packages/core/test/api/signIn.test.ts
+++ b/packages/core/test/api/signIn.test.ts
@@ -11,6 +11,29 @@ afterEach(() => {
     vi.unstubAllEnvs()
 })
 
+vi.mock("@aura-stack/rate-limiter", async () => {
+    const actual = await vi.importActual<typeof import("@aura-stack/rate-limiter")>("@aura-stack/rate-limiter")
+    return {
+        ...actual,
+        createRateLimiter: (...args: Parameters<typeof actual.createRateLimiter>) => {
+            const limiters = actual.createRateLimiter(...args)
+
+            for (const limiter of Object.values(limiters)) {
+                limiter.check = vi.fn().mockResolvedValue({
+                    ok: true,
+                    limit: Number.MAX_SAFE_INTEGER,
+                    remaining: Number.MAX_SAFE_INTEGER,
+                    resetAt: Date.now() + 60000,
+                    retryAfter: 0,
+                    toResponse: () => new Response(),
+                })
+            }
+
+            return limiters
+        },
+    }
+})
+
 describe("signIn API", () => {
     test("throws error when provider is missing", async () => {
         expect(await api.signIn("unsupported", { headers: new Headers() })).toMatchObject({

--- a/packages/core/test/api/signInCredentials.test.ts
+++ b/packages/core/test/api/signInCredentials.test.ts
@@ -12,6 +12,29 @@ afterEach(() => {
     vi.unstubAllEnvs()
 })
 
+vi.mock("@aura-stack/rate-limiter", async () => {
+    const actual = await vi.importActual<typeof import("@aura-stack/rate-limiter")>("@aura-stack/rate-limiter")
+    return {
+        ...actual,
+        createRateLimiter: (...args: Parameters<typeof actual.createRateLimiter>) => {
+            const limiters = actual.createRateLimiter(...args)
+
+            for (const limiter of Object.values(limiters)) {
+                limiter.check = vi.fn().mockResolvedValue({
+                    ok: true,
+                    limit: Number.MAX_SAFE_INTEGER,
+                    remaining: Number.MAX_SAFE_INTEGER,
+                    resetAt: Date.now() + 60000,
+                    retryAfter: 0,
+                    toResponse: () => new Response(),
+                })
+            }
+
+            return limiters
+        },
+    }
+})
+
 describe("signInCredentials API", async () => {
     const csrfToken = await createCSRF(jose)
 

--- a/packages/core/test/api/signUp.test.ts
+++ b/packages/core/test/api/signUp.test.ts
@@ -20,6 +20,29 @@ const payload = {
     password: "1234567890",
 }
 
+vi.mock("@aura-stack/rate-limiter", async () => {
+    const actual = await vi.importActual<typeof import("@aura-stack/rate-limiter")>("@aura-stack/rate-limiter")
+    return {
+        ...actual,
+        createRateLimiter: (...args: Parameters<typeof actual.createRateLimiter>) => {
+            const limiters = actual.createRateLimiter(...args)
+
+            for (const limiter of Object.values(limiters)) {
+                limiter.check = vi.fn().mockResolvedValue({
+                    ok: true,
+                    limit: Number.MAX_SAFE_INTEGER,
+                    remaining: Number.MAX_SAFE_INTEGER,
+                    resetAt: Date.now() + 60000,
+                    retryAfter: 0,
+                    toResponse: () => new Response(),
+                })
+            }
+
+            return limiters
+        },
+    }
+})
+
 describe("signUp API", async () => {
     const csrfToken = await createCSRF(jose)
 

--- a/packages/core/test/api/updateSession.test.ts
+++ b/packages/core/test/api/updateSession.test.ts
@@ -14,6 +14,29 @@ afterEach(() => {
     vi.unstubAllEnvs()
 })
 
+vi.mock("@aura-stack/rate-limiter", async () => {
+    const actual = await vi.importActual<typeof import("@aura-stack/rate-limiter")>("@aura-stack/rate-limiter")
+    return {
+        ...actual,
+        createRateLimiter: (...args: Parameters<typeof actual.createRateLimiter>) => {
+            const limiters = actual.createRateLimiter(...args)
+
+            for (const limiter of Object.values(limiters)) {
+                limiter.check = vi.fn().mockResolvedValue({
+                    ok: true,
+                    limit: Number.MAX_SAFE_INTEGER,
+                    remaining: Number.MAX_SAFE_INTEGER,
+                    resetAt: Date.now() + 60000,
+                    retryAfter: 0,
+                    toResponse: () => new Response(),
+                })
+            }
+
+            return limiters
+        },
+    }
+})
+
 describe("updateSession API", () => {
     test("invalid session", async () => {
         vi.stubEnv("BASE_URL", "http://localhost:3000")

--- a/packages/core/test/presets.ts
+++ b/packages/core/test/presets.ts
@@ -61,6 +61,14 @@ const auth = createAuth({
             } as User
         },
     },
+    rateLimiter: {
+        signIn: {
+            algorithm: "fixed-window",
+            limit: 5,
+            windowMs: 60 * 1000,
+            keyGenerator: () => "",
+        },
+    },
 })
 
 export const {

--- a/packages/core/test/presets.ts
+++ b/packages/core/test/presets.ts
@@ -61,14 +61,6 @@ const auth = createAuth({
             } as User
         },
     },
-    rateLimiter: {
-        signIn: {
-            algorithm: "fixed-window",
-            limit: 5,
-            windowMs: 60 * 1000,
-            keyGenerator: () => "",
-        },
-    },
 })
 
 export const {

--- a/packages/core/test/rate-limiter.test.ts
+++ b/packages/core/test/rate-limiter.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest"
+import { jose, PATCH, POST, sessionPayload } from "./presets.ts"
+import { createCSRF } from "@/shared/crypto.ts"
+
+describe("Rate Limiter", async () => {
+    const csrfToken = await createCSRF(jose)
+
+    const createRequest = async (request: Request, totalRequests: number, allowedLimit: number) => {
+        const expectedRejections = totalRequests - allowedLimit
+        const requests = Array.from({ length: totalRequests }).map(() => request)
+        const responses = await Promise.all(requests.map((req) => (req.method === "PATCH" ? PATCH(req) : POST(req))))
+
+        const successfulResponses = responses.filter((res) => res.status === 200)
+        const rejectedResponses = responses.filter((res) => res.status === 429)
+
+        expect(successfulResponses.length).toBe(allowedLimit)
+        expect(rejectedResponses.length).toBe(expectedRejections)
+
+        if (rejectedResponses.length > 0) {
+            const targetReject = rejectedResponses[0]
+            expect(targetReject.headers.get("Retry-After")).toBeDefined()
+        }
+    }
+
+    test("signInCredentials", async () => {
+        const request = new Request("http://localhost/auth/signIn/credentials", {
+            method: "POST",
+            body: JSON.stringify({
+                username: "Alice",
+                password: "1234567890",
+            }),
+            headers: {
+                "x-forwarded-for": "192.168.1.50",
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}`,
+            },
+        })
+        await createRequest(request, 10, 8)
+    })
+
+    test("signUp", async () => {
+        const request = new Request("http://localhost/auth/signUp", {
+            method: "POST",
+            body: JSON.stringify({
+                name: "Alice",
+                nickname: "Alices_1",
+                password: "1234567890",
+            }),
+            headers: {
+                "x-forwarded-for": "192.168.1.50",
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}`,
+            },
+        })
+        await createRequest(request, 7, 5)
+    })
+
+    test("updateSession", async () => {
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const request = new Request("http://localhost/auth/session", {
+            method: "PATCH",
+            body: JSON.stringify({
+                user: {
+                    name: "Alice",
+                },
+            }),
+            headers: {
+                "x-forwarded-for": "192.168.1.50",
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.session_token=${sessionToken}; aura-auth.csrf_token=${csrfToken}`,
+            },
+        })
+        await createRequest(request, 12, 10)
+    })
+})

--- a/packages/core/test/rate-limiter.test.ts
+++ b/packages/core/test/rate-limiter.test.ts
@@ -5,9 +5,9 @@ import { createCSRF } from "@/shared/crypto.ts"
 describe("Rate Limiter", async () => {
     const csrfToken = await createCSRF(jose)
 
-    const createRequest = async (request: Request, totalRequests: number, allowedLimit: number) => {
+    const createRequest = async (makeRequest: () => Request, totalRequests: number, allowedLimit: number) => {
         const expectedRejections = totalRequests - allowedLimit
-        const requests = Array.from({ length: totalRequests }).map(() => request)
+        const requests = Array.from({ length: totalRequests }).map(() => makeRequest())
         const responses = await Promise.all(requests.map((req) => (req.method === "PATCH" ? PATCH(req) : POST(req))))
 
         const successfulResponses = responses.filter((res) => res.status === 200)
@@ -23,54 +23,57 @@ describe("Rate Limiter", async () => {
     }
 
     test("signInCredentials", async () => {
-        const request = new Request("http://localhost/auth/signIn/credentials", {
-            method: "POST",
-            body: JSON.stringify({
-                username: "Alice",
-                password: "1234567890",
-            }),
-            headers: {
-                "x-forwarded-for": "192.168.1.50",
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}`,
-            },
-        })
-        await createRequest(request, 10, 8)
+        const makeRequest = () =>
+            new Request("http://localhost/auth/signIn/credentials", {
+                method: "POST",
+                body: JSON.stringify({
+                    username: "Alice",
+                    password: "1234567890",
+                }),
+                headers: {
+                    "x-forwarded-for": "192.168.1.50",
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `aura-auth.csrf_token=${csrfToken}`,
+                },
+            })
+        await createRequest(makeRequest, 10, 8)
     })
 
     test("signUp", async () => {
-        const request = new Request("http://localhost/auth/signUp", {
-            method: "POST",
-            body: JSON.stringify({
-                name: "Alice",
-                nickname: "Alices_1",
-                password: "1234567890",
-            }),
-            headers: {
-                "x-forwarded-for": "192.168.1.50",
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}`,
-            },
-        })
-        await createRequest(request, 7, 5)
+        const makeRequest = () =>
+            new Request("http://localhost/auth/signUp", {
+                method: "POST",
+                body: JSON.stringify({
+                    name: "Alice",
+                    nickname: "Alices_1",
+                    password: "1234567890",
+                }),
+                headers: {
+                    "x-forwarded-for": "192.168.1.50",
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `aura-auth.csrf_token=${csrfToken}`,
+                },
+            })
+        await createRequest(makeRequest, 7, 5)
     })
 
     test("updateSession", async () => {
         const sessionToken = await jose.encodeJWT(sessionPayload)
 
-        const request = new Request("http://localhost/auth/session", {
-            method: "PATCH",
-            body: JSON.stringify({
-                user: {
-                    name: "Alice",
+        const makeRequest = () =>
+            new Request("http://localhost/auth/session", {
+                method: "PATCH",
+                body: JSON.stringify({
+                    user: {
+                        name: "Alice",
+                    },
+                }),
+                headers: {
+                    "x-forwarded-for": "192.168.1.50",
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `aura-auth.session_token=${sessionToken}; aura-auth.csrf_token=${csrfToken}`,
                 },
-            }),
-            headers: {
-                "x-forwarded-for": "192.168.1.50",
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.session_token=${sessionToken}; aura-auth.csrf_token=${csrfToken}`,
-            },
-        })
-        await createRequest(request, 12, 10)
+            })
+        await createRequest(makeRequest, 12, 10)
     })
 })

--- a/packages/elysia/test/index.test.ts
+++ b/packages/elysia/test/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "vitest"
 import { app, auth } from "./presets.ts"
+import { createCSRF } from "@aura-stack/auth/crypto"
 
 describe("GET /api/auth/signIn/github", () => {
     test("redirects to GitHub's OAuth page", async () => {
@@ -96,9 +97,15 @@ describe("GET /api/protected", () => {
 
 describe("POST /api/auth/signIn/credentials", () => {
     test("returns 401 when invalid credentials are provided", async () => {
+        const csrfToken = await createCSRF(auth.jose)
+
         const res = await app.handle(
             new Request("http://localhost/api/auth/signIn/credentials", {
                 method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `aura-auth.csrf_token=${csrfToken}`,
+                },
                 body: JSON.stringify({ username: "invalid", password: "invalid" }),
             })
         )
@@ -111,11 +118,15 @@ describe("POST /api/auth/signIn/credentials", () => {
     })
 
     test("returns 200 and a session cookie when valid credentials are provided", async () => {
+        const csrfToken = await createCSRF(auth.jose)
+
         const res = await app.handle(
             new Request("http://localhost/api/auth/signIn/credentials", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `aura-auth.csrf_token=${csrfToken}`,
                 },
                 body: JSON.stringify({ username: "valid", password: "valid" }),
             })

--- a/packages/express/test/index.test.ts
+++ b/packages/express/test/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "vitest"
 import supertest from "supertest"
 import { app, auth } from "./presets.ts"
+import { createCSRF } from "@aura-stack/auth/crypto"
 
 describe("GET /api/auth/signIn/github", () => {
     test("redirects to GitHub's OAuth page", async () => {
@@ -86,9 +87,13 @@ describe("GET /api/protected", () => {
 
 describe("POST /api/auth/signIn/credentials", () => {
     test("returns 401 when invalid credentials are provided", async () => {
+        const csrfToken = await createCSRF(auth.jose)
+
         const response = await supertest(app)
             .post("/api/auth/signIn/credentials")
             .send({ username: "invalid", password: "invalid" })
+            .set("X-CSRF-Token", csrfToken)
+            .set("Cookie", `aura-auth.csrf_token=${csrfToken}`)
         expect(response.status).toBe(401)
         expect(response.body).toMatchObject({
             success: false,
@@ -97,7 +102,13 @@ describe("POST /api/auth/signIn/credentials", () => {
     })
 
     test("returns 200 and a session cookie when valid credentials are provided", async () => {
-        const response = await supertest(app).post("/api/auth/signIn/credentials").send({ username: "valid", password: "valid" })
+        const csrfToken = await createCSRF(auth.jose)
+
+        const response = await supertest(app)
+            .post("/api/auth/signIn/credentials")
+            .send({ username: "valid", password: "valid" })
+            .set("X-CSRF-Token", csrfToken)
+            .set("Cookie", `aura-auth.csrf_token=${csrfToken}`)
         expect(response.status).toBe(200)
         expect(response.body).toMatchObject({
             success: true,
@@ -109,9 +120,13 @@ describe("POST /api/auth/signIn/credentials", () => {
 
 describe("PATCH /api/auth/session", () => {
     test("returns 401 when no session cookie is present", async () => {
+        const csrfToken = await createCSRF(auth.jose)
+
         const response = await supertest(app)
             .patch("/api/auth/session")
             .send({ user: { name: "Jane Doe" } })
+            .set("X-CSRF-Token", csrfToken)
+            .set("Cookie", `aura-auth.csrf_token=${csrfToken}`)
         expect(response.status).toBe(400)
         expect(response.body).toMatchObject({
             session: null,

--- a/packages/hono/test/index.test.ts
+++ b/packages/hono/test/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "vitest"
 import { app, auth } from "./presets.ts"
+import { createCSRF } from "@aura-stack/auth/crypto"
 
 describe("GET /api/auth/signIn/github", () => {
     test("redirects to GitHub's OAuth page", async () => {
@@ -92,10 +93,14 @@ describe("GET /api/protected", () => {
 
 describe("POST /api/auth/signIn/credentials", () => {
     test("returns 401 when invalid credentials are provided", async () => {
+        const csrfToken = await createCSRF(auth.jose)
+
         const res = await app.request("/api/auth/signIn/credentials", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}`,
             },
             body: JSON.stringify({ username: "invalid", password: "invalid" }),
         })
@@ -108,10 +113,14 @@ describe("POST /api/auth/signIn/credentials", () => {
     })
 
     test("returns 200 and a session cookie when valid credentials are provided", async () => {
+        const csrfToken = await createCSRF(auth.jose)
+
         const res = await app.request("/api/auth/signIn/credentials", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}`,
             },
             body: JSON.stringify({ username: "valid", password: "valid" }),
         })

--- a/packages/next/test/pages-router/handler.test.ts
+++ b/packages/next/test/pages-router/handler.test.ts
@@ -82,6 +82,8 @@ describe("toHandler", () => {
     })
 
     test("POST /auth/signIn/credentials", async () => {
+        const csrfToken = await createCSRF(auth.jose)
+
         const { res } = await createHandler({
             method: "POST",
             url: "/auth/signIn/credentials",
@@ -89,6 +91,8 @@ describe("toHandler", () => {
                 Host: "localhost:3000",
                 "X-Forwarded-Proto": "http",
                 "Content-Type": "application/json",
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}`,
             },
             body: {
                 username: "john.doe",
@@ -119,9 +123,10 @@ describe("toHandler", () => {
         })
         expect(res.statusCode).toBe(422)
         expect(res._getJSONData()).toEqual({
-            type: "ROUTER_ERROR",
-            code: "INVALID_REQUEST",
-            message: {
+            type: "VALIDATION",
+            code: "UNPROCESSABLE_ENTITY",
+            message: "The request body or parameter schema layout contains input format errors.",
+            details: {
                 password: {
                     code: "invalid_type",
                     message: "Invalid input: expected string, received undefined",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -691,6 +691,9 @@ importers:
       '@aura-stack/jose':
         specifier: workspace:*
         version: link:../jose
+      '@aura-stack/rate-limiter':
+        specifier: workspace:*
+        version: link:../rate-limiter
       '@aura-stack/router':
         specifier: ^0.9.0
         version: 0.9.0(arktype@2.2.0)(typebox@1.1.38)(valibot@1.4.0(typescript@5.9.3))(zod@4.3.5)


### PR DESCRIPTION
## Description

This pull request introduces several security hardening improvements, with a primary focus on rate limiting for authentication-related endpoints.

Rate limiting has been added to the sign-in, sign-up, and session update flows, helping applications mitigate abuse, brute-force attempts, and denial-of-service attacks. Limits can be applied based on the client's IP address or any custom key generation strategy defined by the application.

In addition to rate limiting, this PR strengthens password hashing and OAuth response validation to further improve the overall security posture of the authentication system.

### Key Changes

* Added rate limiting to:

  * Sign-in flows
  * Sign-up flows
  * Session update flows

* Increased PBKDF2-SHA256 password hashing iterations from **100,000** to **600,000**.

* Added content-type validation for OAuth provider responses before parsing response bodies.

* Reduced unnecessary JSON parsing by validating response metadata before calling `response.json()`.

### Security Benefits

* Helps mitigate DoS and DDoS attacks against authentication endpoints.
* Reduces the effectiveness of brute-force and credential-stuffing attacks.
* Strengthens password storage through increased PBKDF2 work factors.
* Improves validation of OAuth provider responses.
* Reduces the attack surface associated with malformed or unexpected responses.
* Provides configurable rate-limiting strategies based on IP addresses or custom identifiers.


@coderabbitai ignore