### PR TITLE
fix(core): fix OIDC provider initial config loading

### DIFF
--- a/apps/nextjs/app-router/next.config.ts
+++ b/apps/nextjs/app-router/next.config.ts
@@ -16,6 +16,10 @@ const nextConfig: NextConfig = {
                 protocol: "https",
                 hostname: "bitbucket.org",
             },
+            {
+                protocol: "https",
+                hostname: "lh3.googleusercontent.com",
+            },
         ],
     },
 }

--- a/packages/core/src/actions/oidc/resolve-provider.ts
+++ b/packages/core/src/actions/oidc/resolve-provider.ts
@@ -67,7 +67,9 @@ export const createOpenIDPlaceholder = (
         },
         accessToken: "",
         userInfo: "",
-        oidc: { issuer: config.issuer },
+        oidc: {
+            issuer: config.issuer,
+        },
     }
 }
 

--- a/packages/core/src/api/signIn.ts
+++ b/packages/core/src/api/signIn.ts
@@ -62,9 +62,12 @@ export const signIn = async (
         })
 
         const resolvedProvider = isOIDC ? await resolveOpenIDProvider(provider) : provider
-        ctx.logger?.log("OIDC_PROVIDER_RESOLVED", {
-            structuredData: { oauth_provider: oauth, oidc: isOIDC },
-        })
+
+        if (isOIDC) {
+            ctx.logger?.log("OIDC_PROVIDER_RESOLVED", {
+                structuredData: { oauth_provider: oauth, oidc: isOIDC },
+            })
+        }
 
         let authorization: string
         let state: string

--- a/packages/core/src/api/signIn.ts
+++ b/packages/core/src/api/signIn.ts
@@ -57,7 +57,14 @@ export const signIn = async (
         const redirectToValue = await createRedirectTo(request, redirectTo, ctx)
 
         const isOIDC = isOIDCProvider(provider)
+        ctx.logger?.log("SIGN_IN_PROVIDER_TYPE_DETECTED", {
+            structuredData: { oauth_provider: oauth, oidc: isOIDC },
+        })
+
         const resolvedProvider = isOIDC ? await resolveOpenIDProvider(provider) : provider
+        ctx.logger?.log("OIDC_PROVIDER_RESOLVED", {
+            structuredData: { oauth_provider: oauth, oidc: isOIDC },
+        })
 
         let authorization: string
         let state: string

--- a/packages/core/src/oauth/index.ts
+++ b/packages/core/src/oauth/index.ts
@@ -109,6 +109,10 @@ const defineOAuthProviderConfig = (config: BuiltInOAuthProvider | RuntimeOAuthPr
         const oauthConfig = builtInOAuthProviders[config]()
         const parsed = OAuthProviderCredentialsSchema.safeParse({ ...oauthConfig, ...definition })
         if (!parsed.success) {
+            const openIDParsed = OpenIDProviderSchema.safeParse({ ...oauthConfig, ...definition })
+            if (openIDParsed.success) {
+                return defineOpenIDProviderConfig(openIDParsed.data as OpenIDProvider)
+            }
             throw new AuraAuthError({ code: "INVALID_OAUTH_PROVIDER_SCHEMA_CONFIG", cause: parsed.error })
         }
         return parsed.data

--- a/packages/core/src/shared/logger.ts
+++ b/packages/core/src/shared/logger.ts
@@ -327,6 +327,18 @@ export const logMessages = {
         msgId: "OAUTH_INVALID_CONTENT_TYPE",
         message: "OAuth endpoint returned an invalid Content-Type header",
     },
+    SIGN_IN_PROVIDER_TYPE_DETECTED: {
+        facility: 4,
+        severity: "info",
+        msgId: "SIGN_IN_PROVIDER_TYPE_DETECTED",
+        message: "Detected OAuth provider type (OIDC or standard)",
+    },
+    OIDC_PROVIDER_RESOLVED: {
+        facility: 4,
+        severity: "info",
+        msgId: "OIDC_PROVIDER_RESOLVED",
+        message: "OIDC provider configuration resolved successfully",
+    },
 } as const
 
 export const createLogEntry = <T extends keyof typeof logMessages>(key: T, overrides?: Partial<SyslogOptions>): SyslogOptions => {

--- a/packages/core/test/actions/callback/access-token.test.ts
+++ b/packages/core/test/actions/callback/access-token.test.ts
@@ -1,7 +1,9 @@
 import { describe, test, expect, vi } from "vitest"
 import { createPKCE } from "@/shared/crypto.ts"
-import { oauthCustomService } from "@test/presets.ts"
+import { oauthCustomService, openIDCustomProvider, openIDMetadata } from "@test/presets.ts"
 import { createAccessToken } from "@/actions/callback/access-token.ts"
+import { resolveOpenIDProvider } from "@/actions/oidc/resolve-provider.ts"
+import type { RuntimeOAuthProvider } from "@/@types/oauth.ts"
 
 describe("createAccessToken", async () => {
     const { codeVerifier } = await createPKCE()
@@ -152,6 +154,65 @@ describe("createAccessToken", async () => {
                 "Content-Type": "application/x-www-form-urlencoded",
             },
             body: new URLSearchParams(bodyParams).toString(),
+            signal: expect.any(AbortSignal),
+        })
+    })
+
+    test("OIDC provider", async () => {
+        const mockFetch = vi.fn()
+
+        vi.stubGlobal("fetch", mockFetch)
+
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            headers: new Headers({
+                "Content-Type": "application/json",
+            }),
+            json: async () => openIDMetadata,
+        })
+
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            headers: new Headers({
+                "Content-Type": "application/json",
+            }),
+            json: async () => ({
+                access_token: "access_123",
+                token_type: "Bearer",
+            }),
+        })
+
+        const config = await resolveOpenIDProvider({
+            ...openIDCustomProvider,
+            oidc: { issuer: openIDCustomProvider.issuer },
+        } as unknown as RuntimeOAuthProvider)
+
+        expect(fetch).toHaveBeenCalledWith("https://id.example.com/.well-known/openid-configuration", {
+            headers: { Accept: "application/json" },
+            signal: expect.any(AbortSignal),
+        })
+
+        const accessToken = await createAccessToken(
+            config,
+            "http://localhost:3000/auth/callback/openid-provider",
+            "authorization_code_123",
+            codeVerifier
+        )
+
+        expect(fetch).toHaveBeenCalledWith("https://id.example.com/oauth/token", {
+            method: "POST",
+            headers: {
+                Accept: "application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: new URLSearchParams({
+                client_id: "oidc_client_id",
+                client_secret: "oidc_client_secret",
+                code: "authorization_code_123",
+                redirect_uri: "http://localhost:3000/auth/callback/openid-provider",
+                grant_type: "authorization_code",
+                code_verifier: codeVerifier,
+            }).toString(),
             signal: expect.any(AbortSignal),
         })
     })

--- a/packages/core/test/actions/callback/access-token.test.ts
+++ b/packages/core/test/actions/callback/access-token.test.ts
@@ -199,6 +199,11 @@ describe("createAccessToken", async () => {
             codeVerifier
         )
 
+        expect(accessToken).toEqual({
+            access_token: "access_123",
+            token_type: "Bearer",
+        })
+
         expect(fetch).toHaveBeenCalledWith("https://id.example.com/oauth/token", {
             method: "POST",
             headers: {

--- a/packages/core/test/api/signIn.test.ts
+++ b/packages/core/test/api/signIn.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest"
 import { getSetCookie } from "@/cookie.ts"
 import { createAuth } from "@/createAuth.ts"
-import { api, oauthCustomService, openIDCustomProvider, openIDMetadata } from "@test/presets.ts"
+import { api, oauthCustomService, openIDMetadata } from "@test/presets.ts"
 
 beforeEach(() => {
     vi.stubEnv("BASE_URL", undefined)
@@ -159,7 +159,7 @@ describe("signIn API", () => {
         expect(getSetCookie(response, "aura-auth.redirect_to")).toBe("/")
     })
 
-    test("signIn OIDC provider sets nonce cookie and openid scope", async () => {
+    test("signIn OIDC custom provider", async () => {
         vi.stubEnv("BASE_URL", "https://example.com")
 
         vi.stubGlobal(
@@ -171,17 +171,18 @@ describe("signIn API", () => {
             }))
         )
 
-        const oidcApi = createAuth({ oauth: [openIDCustomProvider] }).api
-        const signIn = await oidcApi.signIn("oidc-provider")
-        const response = signIn.toResponse()
+        const output = await api.signIn("oidc-provider")
 
+        expect(output).toEqual({
+            success: true,
+            redirect: true,
+            signInURL: expect.stringMatching(openIDMetadata.authorization_endpoint),
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+        const response = output.toResponse()
+        expect(response).toBeInstanceOf(Response)
         expect(response.status).toBe(302)
         expect(getSetCookie(response, "aura-auth.nonce")).toBeDefined()
-
-        const location = response.headers.get("Location")!
-        const searchParams = new URL(location).searchParams
-        expect(searchParams.get("nonce")).toBeTruthy()
-        expect(searchParams.get("scope")).toContain("openid")
-        expect(location).toContain(openIDMetadata.authorization_endpoint)
     })
 })

--- a/packages/core/test/presets.ts
+++ b/packages/core/test/presets.ts
@@ -1,6 +1,6 @@
 import { createAuth } from "@/createAuth.ts"
 import type { JWTPayload } from "@/jose.ts"
-import type { OAuthProviderCredentials, User } from "@/@types/index.ts"
+import type { OAuthProviderCredentials, OpenIDProvider, User } from "@/@types/index.ts"
 
 export const oauthCustomService: OAuthProviderCredentials = {
     id: "oauth-provider",
@@ -14,7 +14,7 @@ export const oauthCustomService: OAuthProviderCredentials = {
     clientSecret: "oauth_client_secret",
 }
 
-export const openIDCustomProvider = {
+export const openIDCustomProvider: OpenIDProvider = {
     id: "oidc-provider",
     name: "OIDC",
     issuer: "https://id.example.com",
@@ -31,7 +31,7 @@ export const openIDMetadata = {
     grant_types_supported: ["authorization_code"],
     subject_types_supported: ["public"],
     id_token_signing_alg_values_supported: ["RS256"],
-}
+} as const
 
 export const oauthCustomServiceProfile: OAuthProviderCredentials = {
     ...oauthCustomService,
@@ -56,7 +56,7 @@ export const sessionPayload: JWTPayload = {
 }
 
 const auth = createAuth({
-    oauth: [oauthCustomService, oauthCustomServiceProfile],
+    oauth: [oauthCustomService, oauthCustomServiceProfile, openIDCustomProvider],
     logger: true,
     credentials: {
         authorize: async ({ credentials }) => {


### PR DESCRIPTION
## Description

This pull request fixes the initial loading and resolution of OpenID Connect (OIDC) provider configurations.

Previously, OIDC providers were only correctly resolved when configured directly as provider objects. Provider definitions resolved from identifiers were incorrectly treated as OAuth 2.0 providers, causing the OIDC-specific configuration to be skipped.

As a result, OIDC providers did not load required fields such as `issuer` and `jwks_uri`, preventing the provider from being initialized with the complete OpenID Connect configuration.

This issue was introduced in the previous PR that added OpenID Connect support and was overlooked during the provider resolution implementation.

### Root Cause

The provider resolution flow only handled OAuth provider parsing when loading provider definitions from identifiers. OIDC provider definitions were not validated against the OpenID provider schema before being processed, causing them to fall back to the OAuth provider path.

### Fix

The provider loading logic now attempts to parse resolved provider definitions using the OpenID provider schema before falling back to OAuth provider handling.

```diff
+ const openIDParsed = OpenIDProviderSchema.safeParse({
+   ...oauthConfig,
+   ...definition,
+ })
+
+ if (openIDParsed.success) {
+   return defineOpenIDProviderConfig(
+     openIDParsed.data as OpenIDProvider
+   )
+ }
```


@coderabbitai ignore
