### PR TITLE
chore(skills): add integration reference for create-auth skill

### DIFF
--- a/skills/create-auth/SKILL.md
+++ b/skills/create-auth/SKILL.md
@@ -20,7 +20,7 @@ Use this skill whenever the user asks for Aura Auth setup, auth route wiring, OA
 
 ## Output Contract (Strict)
 
-Always return ALL of the following unless explicitly scoped otherwise:
+Always return ALL of the following unless explicitly scoped otherwise. If the user asks for a subset, produce only the requested pieces.
 
 1. Setup plan customized to detected runtime and framework.
 2. Correct install commands for package manager and adapters.
@@ -57,42 +57,46 @@ Return all of the following in one response unless the user asks for a subset:
 
 Before writing files, collect or detect:
 
-1. Runtime/framework:
-   - Read project indicators (package.json, deno.json, framework config files).
-   - If multiple frameworks are found, ask user to choose primary auth host.
-2. Package manager from lockfile:
-   - `pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `bun.lock`.
-3. OAuth provider target:
-   - Default to `github` when unspecified.
-4. Local and deployment URLs:
-   - Default local to http://localhost:3000 if unknown.
-5. Scope:
-   - Server-only setup or server + client helper.
+1. Runtime / framework detection (priority order):
+   - Inspect `package.json`, `deno.json`, `wrangler.jsonc`, `next.config.ts`, `astro.config.mjs`, `tsconfig.json` and `apps/*` folders.
+   - If adapters appear in `packages/` (e.g., `packages/next`, `packages/express`, `packages/astro`) prefer those conventions.
+   - If multiple runtime candidates are present, ask: "Which runtime should host auth (e.g., nextjs, express, cloudflare)?"
+2. Package manager and install command:
+   - Check `pnpm-lock.yaml`, `pnpm-workspace.yaml` -> use `pnpm`.
+   - Check `package-lock.json` -> use `npm`.
+   - Check `yarn.lock` -> use `yarn`.
+   - Check `bun.lockb` or `bun` in `engines` -> use `bun`.
+3. OAuth provider(s):
+   - Default to `github` if not specified. Ask which providers they want when not obvious.
+4. Local and production base URLs:
+   - Default local to `http://localhost:3000`. Ask for deployed host if known (e.g., Vercel, Cloudflare, Supabase).
+5. Scope and client-side needs:
+   - Ask whether the repository contains a frontend that should receive `createAuthClient` snippets.
 
-If critical inputs are missing and cannot be inferred, ask concise follow-up questions before writing code.
+Follow-up questions should be minimal and only when necessary (two short questions maximum recommended).
 
 ### Secret generation consent flow (mandatory)
 
-Before generating secrets, ask:
+Always ask before generating or printing real secrets.
 
-> "Do you want me to generate secure `AURA_AUTH_SALT` and `AURA_AUTH_SECRET` values now?"
+Ask: "Do you want me to generate secure `AURA_AUTH_SALT` and `AURA_AUTH_SECRET` values now?"
 
-- If user accepts: run a generation command and return values once.
-- If user declines: keep placeholders and explain where to generate later.
+- If the user accepts: generate secure values locally (explain the generation method) and paste them once in the response. Also print an `export`/`.env` snippet and recommend copying to a secure vault.
+- If the user declines: leave placeholders in the templates and point to `scripts/update-auth-env.sh` for a safe, idempotent local updater.
 
-Idempotent `.env` updater script: see [scripts/update-auth-env.sh](scripts/update-auth-env.sh).
-
-Run it with: [script](./scripts/update-auth-env.sh)
-
-Never auto-generate without consent. Always ask first and explain the benefits of using generated secrets.
+Never generate or commit secrets without explicit user consent.
 
 ---
+
+Only official adapter packages should be recommended when available. For unsupported adapters recommend using the `@aura-stack/auth` core package plus a minimal adapter shim with clear examples.
+
+The repo contains many `packages/*` adapters — prefer their conventions when wiring routes and examples.
 
 ## Implementation Steps
 
 ### 1) Install Dependencies
 
-Use detected package manager. Example:
+Use the detected package manager. Example (pnpm detected in this repo):
 
 ```bash
 pnpm add @aura-stack/auth
@@ -100,7 +104,7 @@ pnpm add @aura-stack/auth
 
 ### 2) Create auth module
 
-Default module example (src/lib/auth.ts):
+Default module example (server source path depending on framework, e.g. `src/lib/auth.ts`):
 
 ```ts
 import { createAuth } from "@aura-stack/auth"
@@ -111,177 +115,13 @@ export const { handlers, jose, api } = createAuth({
 })
 ```
 
-Prefer minimal defaults first, then layer advanced options only if user asks.
-
-### 3) Wire route handlers correctly
-
-The handler mount must match basePath exactly.
-
-Next.js App Router (src/app/api/auth/[...aura]/route.ts):
-
-```ts
-import { handlers } from "@/lib/auth"
-
-export const { GET, POST, PATCH } = handlers
-```
-
-Next.js Pages Router:
-
-```ts
-import { handlers } from "@/lib/auth"
-export default async function handler(req, res) {
-  const response = await handlers.ALL(req)
-  res.status(response.status).set(response.headers).send(response.body)
-}
-```
-
-Astro:
-
-```ts
-import { handlers } from "@/lib/auth"
-
-import type { APIRoute } from "astro"
-
-export const GET: APIRoute = async ({ request }) => {
-  return await handlers.GET(request)
-}
-
-export const POST: APIRoute = async ({ request }) => {
-  return await handlers.POST(request)
-}
-```
-
-React Router:
-
-```ts
-import { handlers } from "~/lib/auth"
-import type { Route } from "./+types/api.auth.$"
-
-export const loader = async ({ request }: Route.LoaderArgs) => {
-  return handlers.GET(request)
-}
-
-export const action = async ({ request }: Route.ActionArgs) => {
-  return handlers.POST(request)
-}
-```
-
-TanStack Start:
-
-```ts
-import { handlers } from "@/lib/auth"
-import { createFileRoute } from "@tanstack/react-router"
-
-export const Route = createFileRoute("/api/auth/$")({
-  server: {
-    handlers: {
-      GET: async ({ request }) => {
-        return await handlers.GET(request)
-      },
-      POST: async ({ request }) => {
-        return await handlers.POST(request)
-      },
-      PATCH: async ({ request }) => {
-        return await handlers.PATCH(request)
-      },
-    },
-  },
-})
-```
-
-Express:
-
-```ts
-app.use("/api/auth", async (req, res) => {
-  const response = await handlers.ALL(toWebRequest(req))
-  return toExpressResponse(response, res)
-})
-```
-
-```ts
-app.use("/api/auth", async (req, res) => {
-  const response = await handlers.ALL(toWebRequest(req))
-  return toExpressResponse(response, res)
-})
-```
-
-Hono:
-
-```ts
-app.all("/api/auth/*", async (ctx) => {
-  return await handlers.ALL(ctx.req.raw)
-})
-```
-
-Elysia:
-
-```ts
-import { handlers } from "@/lib/auth"
-import type { Context } from "elysia"
-
-app.all("/api/auth/*", handlers.ALL)
-```
-
-Cloudflare Worker:
-
-```ts
-if (new URL(request.url).pathname.startsWith("/api/auth/")) {
-  return await handlers.ALL(request)
-}
-```
-
-Deno or Supabase Edge Function:
-
-```ts
-import { handlers } from "@/lib/auth"
-Deno.serve(async (request) => {
-  const pathname = new URL(request.url).pathname
-  if (pathname.startsWith("/api/auth/")) {
-    return await handlers.ALL(request)
-  }
-})
-```
-
-Vercel Edge Function:
-
-```ts
-import { handlers } from "@/lib/_auth"
-
-export const GET = async (request: Request) => {
-  return await handlers.GET(request)
-}
-
-export const POST = async (request: Request) => {
-  return await handlers.POST(request)
-}
-
-export const PATCH = async (request: Request) => {
-  return await handlers.PATCH(request)
-}
-```
+For more detials about createAuth function read [createAuth Reference](./reference/create-auth.md)
 
 ### 4) Client compatibility gate
 
-Create createAuthClient only for client-capable targets.
+Only add `createAuthClient` when the detected target includes a frontend runtime that will call the auth endpoints directly (Next.js app, Astro, React app, etc.).
 
-Client-capable:
-
-- Next.js
-- Nuxt
-- Astro
-- React Router
-- TanStack Start
-
-Server-only by default:
-
-- Express API-only
-- Hono API-only
-- Cloudflare Worker API-only
-- Deno/Bun backend-only
-
-If server-only, respond with:
-
-This target is server-only, so I will not create a client auth API here. If you have a separate frontend app, I can set up createAuthClient there.
+If the project is API-only (Express, Hono, Cloudflare Worker, standalone Deno/Bun service), do not generate client code — instead output a concise note explaining how to integrate a separate frontend.
 
 ### 5) Add client helper only when allowed
 
@@ -322,10 +162,12 @@ Provider key map examples:
 
 Security requirements:
 
-- Never print real secrets unless user explicitly asked to generate them now.
-- Never commit populated .env files.
-- Ensure .env is ignored by .gitignore.
-- Keep .env.example placeholders only.
+Security requirements:
+
+- Never print real secrets unless the user explicitly asks to generate them now.
+- Never commit populated `.env` files.
+- Ensure `.env` is ignored by `.gitignore`.
+- Keep `.env.example` placeholders only.
 
 ---
 
@@ -341,6 +183,8 @@ const session = await api.getSession({
 
 If client helper is created, include at least one client action:
 
+If client helper is created, include at least one client action:
+
 ```ts
 await authClient.signIn("github", { redirect: true })
 ```
@@ -351,9 +195,11 @@ await authClient.signIn("github", { redirect: true })
 
 Every answer generated with this skill must be:
 
-1. Correct for the detected framework routing model.
+Every answer generated with this skill must be:
+
+1. Correct for the detected framework routing model and use the repository's adapter conventions when present.
 2. Minimal in code changes and aligned with user conventions.
-3. Explicit about why each created file exists.
+3. Explicit about why each created or modified file exists and where to place it.
 4. Safe about secrets and environment handling.
 5. Actionable to run without extra hidden assumptions.
 
@@ -376,6 +222,65 @@ Every answer generated with this skill must be:
 
 ## 6. Troubleshooting (Ordered)
 ```
+
+## createAuth Configuration Options (Summary)
+
+When producing `createAuth` examples, include and explain the most common configuration options. For full details, link to the detailed reference: [reference/create-auth.md](reference/create-auth.md).
+
+- `oauth`: Array of built-in provider IDs or full provider configs (e.g., `"github"` or `{ id: "custom", authorize: { url: "..." }, clientId, clientSecret }`). See provider examples in [reference/create-auth.md](reference/create-auth.md#oauth).
+- `session`: Session strategy and JWT settings (strategy: `"jwt"` or others, `jwt.mode`, `jwt.maxAge`). Default recommendation: sealed JWT with 7-day expiry.
+- `secret`: Cryptographic secret or keys; prefer environment variables `AURA_AUTH_SECRET` / `AUTH_SECRET` and ask for consent before generating.
+- `cookies`: `prefix`, `overrides` for individual cookie names and strategies (`secure`, `host`, `standard`). Link to cookie guidance in [reference/create-auth.md](reference/create-auth.md#cookies).
+- `basePath`: Mount path for auth routes (default `/auth`). Ensure route handlers match this path exactly — see each integration doc.
+- `baseURL`: Public application URL for redirect construction; recommend setting in production.
+- `identity`: Identity schema and validation options (`schema`, `skipValidation`, `unknownKeys`). See identity docs in [reference/create-auth.md](reference/create-auth.md#identity-schema).
+- `credentials`: Credentials provider for username/password flows (authorize handler, hashing helpers).
+- `signUp`: Sign-up flow configuration and callbacks for user creation.
+- `rateLimiter`: Rate limiting rules for auth endpoints.
+- `trustedOrigins` & `trustedProxyHeaders`: Configure redirect validation and proxy awareness (use carefully).
+- `logger`: `true` or custom logger implementing Aura Auth `Logger` interface.
+
+When generating examples for a specific framework, link to the integration guide under `reference/integrations/` (examples below).
+
+## Integration Guides (quick links)
+
+- Astro: [reference/integrations/astro.md](reference/integrations/astro.md)
+- Next.js App Router: [reference/integrations/nextjs-app-router.md](reference/integrations/nextjs-app-router.md)
+- Next.js Pages Router: [reference/integrations/nextjs-pages-router.md](reference/integrations/nextjs-pages-router.md)
+- Express: [reference/integrations/express.md](reference/integrations/express.md)
+- Elysia: [reference/integrations/elysia.md](reference/integrations/elysia.md)
+- Hono: [reference/integrations/hono.md](reference/integrations/hono.md)
+- React: [reference/integrations/react.md](reference/integrations/react.md)
+- React Router: [reference/integrations/react-router.md](reference/integrations/react-router.md)
+- Cloudflare Workers: [reference/integrations/cloudflare-workers.md](reference/integrations/cloudflare-workers.md)
+- Vercel Edge Functions: [reference/integrations/vercel-edge-functions.md](reference/integrations/vercel-edge-functions.md)
+- Supabase Edge Functions: [reference/integrations/supabase-edge-functions.md](reference/integrations/supabase-edge-functions.md)
+- TanStack Start: [reference/integrations/tanstack-start.md](reference/integrations/tanstack-start.md)
+
+Include the relevant integration link in every response when the framework is detected.
+
+## Example Prompts
+
+- "Set up Aura Auth for my Next.js app with GitHub and Google providers, using pnpm."
+- "Add auth handlers to `apps/astro` and create a client helper in `apps/astro/src/client.ts`."
+- "I want an Express API-only auth server; don't generate client code."
+
+## Iteration & Delivery
+
+1. Draft: produce the plan and code snippets.
+2. Ask the user for missing inputs (provider, host, consent for secrets).
+3. Apply changes (create files) only after confirmation.
+4. Run a light verification checklist and update until green.
+
+## Suggested Next Customizations
+
+- Add a `create-auth` generator script (`bin/create-auth`) to scaffold files automatically.
+- Add framework-specific tests under `packages/*/test` to verify example routes.
+- Create `docs/content/docs/examples/auth-quickstart.mdx` with copy-paste examples for the most common stacks.
+
+---
+
+References used from the repository: `packages/` adapter folders and `docs/content/docs` examples.
 
 ---
 

--- a/skills/create-auth/reference/create-auth.md
+++ b/skills/create-auth/reference/create-auth.md
@@ -1,0 +1,327 @@
+---
+name: create-auth
+title: Create Auth Function
+description: Implement production-ready Aura Auth createAuth configuration for any supported runtime or framework, including OAuth providers, session strategy, cookie security, routing, environment variables, identity schema, and deployment best practices.
+---
+
+# Purpose
+
+Use this skill whenever a user asks to:
+
+- set up authentication
+- create an Aura Auth configuration
+- initialize `createAuth`
+- configure OAuth login
+- add GitHub, GitLab, Google, Bitbucket, Discord, or custom OAuth providers
+- configure JWT sessions
+- wire auth routes
+- configure authentication in Next.js, Express, Hono, Cloudflare Workers, Bun, Node.js, or similar runtimes
+- debug Aura Auth configuration
+- configure authentication environment variables
+- customize identity schemas
+- configure cookies, trusted origins, or proxies
+
+Invoke this skill even if the user does not explicitly mention `@aura-stack/auth`, but their request is clearly about creating an Aura Auth server.
+
+---
+
+# Responsibilities
+
+When invoked, produce a complete production-ready authentication setup instead of only answering the immediate question.
+
+Unless the user explicitly requests otherwise, include:
+
+- `createAuth()` configuration
+- OAuth provider configuration
+- required environment variables
+- session configuration
+- routing integration
+- security recommendations
+- explanation of why each option is used
+
+Avoid placeholder implementations when a complete solution can be generated.
+
+---
+
+# Default Configuration
+
+Unless the user specifies otherwise, generate:
+
+```ts
+createAuth({
+  oauth: [],
+  session: {
+    strategy: "jwt",
+    jwt: {
+      mode: "sealed",
+      maxAge: 60 * 60 * 24 * 7,
+    },
+  },
+})
+```
+
+Use sealed JWT sessions as the default recommendation.
+
+---
+
+# OAuth
+
+## Built-in providers
+
+Prefer provider IDs whenever no customization is required.
+
+Example:
+
+```ts
+oauth: ["github"]
+```
+
+or
+
+```ts
+oauth: ["github", "gitlab", "bitbucket"]
+```
+
+---
+
+## Custom provider configuration
+
+Use explicit provider configuration whenever the user needs:
+
+- custom scopes
+- custom endpoints
+- enterprise OAuth
+- self-hosted providers
+- overridden client credentials
+
+Generate the provider using Aura Auth's OAuth helpers whenever available.
+
+Only fall back to manually implementing an `OAuthProvider` if necessary.
+
+---
+
+## Environment variables
+
+Never hardcode secrets.
+
+Prefer automatic environment variable loading.
+
+Aura Auth automatically looks for
+
+```
+<PROVIDER>_CLIENT_ID
+<PROVIDER>_CLIENT_SECRET
+```
+
+Example:
+
+```
+GITHUB_CLIENT_ID
+GITHUB_CLIENT_SECRET
+```
+
+Do not manually pass these values unless customization is required.
+
+---
+
+# Secret Configuration
+
+Prefer environment variables.
+
+Recommend:
+
+```
+AURA_AUTH_SECRET
+```
+
+or
+
+```
+AUTH_SECRET
+```
+
+Never embed production secrets inside generated code.
+
+If the secret is missing, mention that Aura Auth throws during initialization.
+
+If the user asks how to generate one, recommend a cryptographically secure random 32-byte secret.
+
+---
+
+# Session Strategy
+
+Unless requested otherwise:
+
+- use JWT
+- use sealed mode
+- use a 7-day expiration
+
+Recommend:
+
+```ts
+session: {
+    strategy: "jwt",
+    jwt: {
+        mode: "sealed",
+        maxAge: 60 * 60 * 24 * 7
+    }
+}
+```
+
+Only recommend signed or encrypted JWTs if the user explicitly needs them.
+
+---
+
+# Cookies
+
+Only customize cookies when requested.
+
+Explain that cookie overrides are security-sensitive.
+
+Keep:
+
+- httpOnly
+- secure
+- sameSite
+
+using Aura Auth defaults unless the user has a specific requirement.
+
+Avoid recommending custom cookie names unless necessary.
+
+---
+
+# Base URL
+
+Recommend explicitly setting:
+
+```ts
+baseURL: "https://example.com"
+```
+
+for production deployments.
+
+Explain that relying on header inference may fail behind proxies.
+
+---
+
+# Base Path
+
+Unless requested otherwise:
+
+```ts
+basePath: "/auth"
+```
+
+The path must always begin with `/`.
+
+---
+
+# Trusted Origins
+
+Only configure trusted origins if the application requires:
+
+- multiple frontend origins
+- CORS
+- redirect validation
+
+Prefer explicit origins over wildcard patterns.
+
+Use wildcard matching only when the user's deployment requires it.
+
+Warn that permissive origins create security risks.
+
+---
+
+# Trusted Proxy Headers
+
+Recommend enabling only when the application is behind:
+
+- Cloudflare
+- Vercel
+- Netlify
+- Heroku
+- AWS Load Balancer
+- reverse proxy
+- CDN
+
+Do not enable for localhost or direct deployments.
+
+---
+
+# Identity Schema
+
+If the user needs additional user fields:
+
+- role
+- organization
+- permissions
+- tenant
+- username
+
+extend `UserIdentity`.
+
+Recommend supplying the inferred schema type to `createAuth`.
+
+Example:
+
+```ts
+createAuth({
+  identity: {
+    schema,
+  },
+})
+```
+
+Use `strip` for unknown keys unless another behavior is explicitly requested.
+
+---
+
+# Logger
+
+For development:
+
+```ts
+logger: true
+```
+
+For production, recommend either:
+
+- the built-in logger with an appropriate log level
+- a custom logger implementing Aura Auth's Logger interface
+
+---
+
+# Security Guidelines
+
+Always recommend:
+
+- environment variables for secrets
+- explicit baseURL in production
+- sealed JWT mode
+- httpOnly cookies
+- least-privilege OAuth scopes
+- explicit trusted origins
+- avoiding wildcard origins unless necessary
+
+Warn users whenever they customize:
+
+- cookies
+- trusted origins
+- trusted proxy headers
+- cryptographic secrets
+
+---
+
+# Response Style
+
+When generating code:
+
+- produce complete working examples
+- omit unrelated configuration
+- follow Aura Auth best practices
+- explain production recommendations
+- avoid unnecessary customization
+
+If the user asks about a specific option (for example `trustedOrigins`), explain only that option while preserving its security implications.
+
+If the user asks to build an authentication server, generate the complete `createAuth` configuration instead of isolated snippets.

--- a/skills/create-auth/reference/create-auth.md
+++ b/skills/create-auth/reference/create-auth.md
@@ -109,15 +109,15 @@ Prefer automatic environment variable loading.
 Aura Auth automatically looks for
 
 ```
-<PROVIDER>_CLIENT_ID
-<PROVIDER>_CLIENT_SECRET
+AURA_AUTH_<PROVIDER>_CLIENT_ID
+AURA_AUTH_<PROVIDER>_CLIENT_SECRET
 ```
 
 Example:
 
 ```
-GITHUB_CLIENT_ID
-GITHUB_CLIENT_SECRET
+AURA_AUTH_GITHUB_CLIENT_ID
+AURA_AUTH_GITHUB_CLIENT_SECRET
 ```
 
 Do not manually pass these values unless customization is required.

--- a/skills/create-auth/reference/integrations/astro.md
+++ b/skills/create-auth/reference/integrations/astro.md
@@ -3,7 +3,7 @@ name: Astro
 description: Implement production-ready @aura-stack/auth setup. Use this skill when users ask for auth setup in Astro applications using the @aura-stack/auth package
 ---
 
-> Aura Auth doens't provide a built-in astro package, so its recomeded to use the core package @aura-stack/auth.
+> Aura Auth doesn't provide a built-in Astro package, so it's recommended to use the core package `@aura-stack/auth`.
 
 ## Implementation Steps
 
@@ -20,7 +20,7 @@ pnpm add @aura-stack/auth
 Default module example (src/lib/auth.ts):
 
 ```ts
-import { createAuth } from "@aura-stack/next"
+import { createAuth } from "@aura-stack/auth"
 
 export const { handlers, jose, api } = createAuth({
   oauth: ["github"],

--- a/skills/create-auth/reference/integrations/astro.md
+++ b/skills/create-auth/reference/integrations/astro.md
@@ -1,0 +1,61 @@
+---
+name: Astro
+description: Implement production-ready @aura-stack/auth setup. Use this skill when users ask for auth setup in Astro applications using the @aura-stack/auth package
+---
+
+> Aura Auth doens't provide a built-in astro package, so its recomeded to use the core package @aura-stack/auth.
+
+## Implementation Steps
+
+### 1) Install Dependencies
+
+Use detected package manager. Example
+
+```bash
+pnpm add @aura-stack/auth
+```
+
+### 2) Create auth module
+
+Default module example (src/lib/auth.ts):
+
+```ts
+import { createAuth } from "@aura-stack/next"
+
+export const { handlers, jose, api } = createAuth({
+  oauth: ["github"],
+  basePath: "/api/auth",
+})
+```
+
+Prefer minimal defaults first, then layer advanced options only if user asks.
+
+### 3) Wire route handlers correctly
+
+The handler mount must match basePath exactly (src/pages/api/auth/[...all].ts):
+
+```ts
+import { handlers } from "@/lib/auth"
+import type { APIRoute } from "astro"
+
+export const GET: APIRoute = async ({ request }) => {
+  return await handlers.GET(request)
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  return await handlers.POST(request)
+}
+```
+
+### 5) Add client helper only when allowed
+
+Create createAuthClient only for client-capable targets.
+
+```ts
+import { createAuthClient } from "@aura-stack/auth/client"
+
+export const authClient = createAuthClient({
+  basePath: "/api/auth",
+  baseURL: "http://localhost:3000",
+})
+```

--- a/skills/create-auth/reference/integrations/cloudflare-workers.md
+++ b/skills/create-auth/reference/integrations/cloudflare-workers.md
@@ -1,9 +1,9 @@
 ---
-name: Hono
-description: Implement production-ready @aura-stack/hono setup, including server setup and middlewares. Use this skill when users ask for auth setup in Hono backend applications.
+name: Cloudflare Workers
+description: Implement production-ready `@aura-stack/auth` setup for Cloudflare Workers. Use this skill when users ask for auth setup in Cloudflare Workers.
 ---
 
-> Aura Auth doens't provide a built-in Cloudflare Worker package, so its recomeded to use the core package @aura-stack/auth.
+> Aura Auth doesn't provide a built-in Cloudflare Worker package, so it's recommended to use the core package `@aura-stack/auth`.
 
 ## Implementation Steps
 
@@ -32,7 +32,7 @@ Prefer minimal defaults first, then layer advanced options only if user asks.
 
 ### 3) Wire route handlers correctly
 
-The handler mount must match basePath exactly (src/app/pages/auth/[...aura].ts):
+The handler mount must match basePath exactly (e.g., `src/index.ts` or `functions/auth/[[path]].ts`):
 
 ```ts
 import { handlers } from "../lib/auth"

--- a/skills/create-auth/reference/integrations/cloudflare-workers.md
+++ b/skills/create-auth/reference/integrations/cloudflare-workers.md
@@ -1,0 +1,45 @@
+---
+name: Hono
+description: Implement production-ready @aura-stack/hono setup, including server setup and middlewares. Use this skill when users ask for auth setup in Hono backend applications.
+---
+
+> Aura Auth doens't provide a built-in Cloudflare Worker package, so its recomeded to use the core package @aura-stack/auth.
+
+## Implementation Steps
+
+### 1) Install Dependencies
+
+Use detected package manager. Example
+
+```bash
+pnpm add @aura-stack/auth
+```
+
+### 2) Create auth module
+
+Default module example (src/lib/auth.ts):
+
+```ts
+import { createAuth } from "@aura-stack/auth"
+
+export const { handlers, jose, api } = createAuth({
+  oauth: ["github"],
+  basePath: "/api/auth",
+})
+```
+
+Prefer minimal defaults first, then layer advanced options only if user asks.
+
+### 3) Wire route handlers correctly
+
+The handler mount must match basePath exactly (src/app/pages/auth/[...aura].ts):
+
+```ts
+import { handlers } from "../lib/auth"
+
+export default {
+  async fetch(request): Promise<Response> {
+    return await handlers.ALL(request)
+  },
+} satisfies ExportedHandler<Env>
+```

--- a/skills/create-auth/reference/integrations/elysia.md
+++ b/skills/create-auth/reference/integrations/elysia.md
@@ -1,0 +1,77 @@
+---
+name: Elysia
+description: Implement production-ready @aura-stack/elysia setup, including server setup and middlewares. Use this skill when users ask for auth setup in Elysia backend applications.
+---
+
+## Implementation Steps
+
+### 1) Install Dependencies
+
+Use detected package manager. Example
+
+```bash
+pnpm add @aura-stack/elysia
+```
+
+### 2) Create auth module
+
+Default module example (src/lib/auth.ts):
+
+```ts
+import { createAuth } from "@aura-stack/elysia"
+
+export const { toHandler, withAuth, jose, api } = createAuth({
+  oauth: ["github"],
+  basePath: "/api/auth",
+})
+```
+
+Prefer minimal defaults first, then layer advanced options only if user asks.
+
+### 3) Wire route handlers correctly
+
+The handler mount must match basePath exactly ("/auth/\*"):
+
+```ts
+import { Elysia } from "elysia"
+import { toHandler } from "@/lib/auth"
+
+const app = new Elysia()
+
+app.all("/api/auth/*", toHandler)
+
+app.listen(3000)
+```
+
+### 4) Middlewares
+
+The `withAuth` middlewares extracts if there's active session otherwise returns null
+
+```ts
+import { Elysia } from "elysia"
+import { toHandler, withAuth } from "@/lib/auth"
+
+const app = new Elysia()
+
+app.get("/", () => "Welcome to the Aura Auth Elysia App!")
+
+app.all("/api/auth/*", toHandler)
+
+app.derive(withAuth).get("/api/protected", (ctx) => {
+  if (!ctx.session) {
+    return Response.json(
+      {
+        error: "Unauthorized",
+        message: "Active session required.",
+      },
+      { status: 401 }
+    )
+  }
+  return Response.json({
+    message: "You have access to this protected resource.",
+    session: ctx?.session,
+  })
+})
+
+app.listen(3000)
+```

--- a/skills/create-auth/reference/integrations/express.md
+++ b/skills/create-auth/reference/integrations/express.md
@@ -1,0 +1,75 @@
+---
+name: Express
+description: Implement production-ready @aura-stack/express setup, including server setup and middlewares. Use this skill when users ask for auth setup in Express backend applications.
+---
+
+## Implementation Steps
+
+### 1) Install Dependencies
+
+Use detected package manager. Example
+
+```bash
+pnpm add @aura-stack/express
+```
+
+### 2) Create auth module
+
+Default module example (src/lib/auth.ts):
+
+```ts
+import { createAuth } from "@aura-stack/express"
+
+export const { toHandler, withAuth, jose, api } = createAuth({
+  oauth: ["github"],
+  basePath: "/api/auth",
+})
+```
+
+Prefer minimal defaults first, then layer advanced options only if user asks.
+
+### 3) Wire route handlers correctly
+
+The handler mount must match basePath exactly ("/auth/\*"):
+
+```ts
+import express, { type Express } from "express"
+import { toHandler, withAuth } from "@/lib/auth.js"
+
+const app: Express = express()
+
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
+
+app.all("/api/auth/*", toHandler)
+
+app.listen(3000)
+```
+
+### 4) Middlewares
+
+The `withAuth` middlewares extracts if there's active session otherwise returns null
+
+```ts
+import express, { type Express } from "express"
+import { toHandler, withAuth } from "@/lib/auth.js"
+
+const app: Express = express()
+
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
+
+app.all("/api/auth/*", toHandler)
+
+app.get("/api/protected", withAuth, (_, res) => {
+  if (!res.locals.session) {
+    return res.status(401).json({ message: "Unauthorized" })
+  }
+  return res.json({
+    message: "You have access to this protected resource.",
+    session: res.locals.session,
+  })
+})
+
+app.listen(PORT)
+```

--- a/skills/create-auth/reference/integrations/hono.md
+++ b/skills/create-auth/reference/integrations/hono.md
@@ -1,0 +1,71 @@
+---
+name: Hono
+description: Implement production-ready @aura-stack/hono setup, including server setup and middlewares. Use this skill when users ask for auth setup in Hono backend applications.
+---
+
+## Implementation Steps
+
+### 1) Install Dependencies
+
+Use detected package manager. Example
+
+```bash
+pnpm add @aura-stack/hono
+```
+
+### 2) Create auth module
+
+Default module example (src/lib/auth.ts):
+
+```ts
+import { createAuth } from "@aura-stack/hono"
+
+export const { toHandler, withAuth, jose, api } = createAuth({
+  oauth: ["github"],
+  basePath: "/api/auth",
+})
+```
+
+Prefer minimal defaults first, then layer advanced options only if user asks.
+
+### 3) Wire route handlers correctly
+
+The handler mount must match basePath exactly ("/auth/\*"):
+
+```ts
+import { Hono } from "hono"
+import { toHandler, withAuth } from "@/lib/auth"
+
+const app = new Hono()
+
+app.all("/api/auth/*", toHandler)
+
+export default app
+```
+
+### 4) Middlewares
+
+The `withAuth` middlewares extracts if there's active session otherwise returns null
+
+```ts
+import { Hono } from "hono"
+import { toHandler, withAuth } from "@/lib/auth"
+
+const app = new Hono()
+
+app.all("/auth/*", toHandler)
+
+app.get("/api/protected", withAuth, (ctx) => {
+  const session = ctx.get("session")
+  if (!session) {
+    return ctx.json({ message: "Unauthorized" }, 401)
+  }
+
+  return ctx.json({
+    message: "You have access to this protected resource.",
+    session,
+  })
+})
+
+export default app
+```

--- a/skills/create-auth/reference/integrations/hono.md
+++ b/skills/create-auth/reference/integrations/hono.md
@@ -30,7 +30,7 @@ Prefer minimal defaults first, then layer advanced options only if user asks.
 
 ### 3) Wire route handlers correctly
 
-The handler mount must match basePath exactly ("/auth/\*"):
+The handler mount must match basePath exactly ("/api/auth/\*"):
 
 ```ts
 import { Hono } from "hono"
@@ -53,7 +53,7 @@ import { toHandler, withAuth } from "@/lib/auth"
 
 const app = new Hono()
 
-app.all("/auth/*", toHandler)
+app.all("/api/auth/*", toHandler)
 
 app.get("/api/protected", withAuth, (ctx) => {
   const session = ctx.get("session")

--- a/skills/create-auth/reference/integrations/nextjs-app-router.md
+++ b/skills/create-auth/reference/integrations/nextjs-app-router.md
@@ -1,0 +1,54 @@
+---
+name: Next.js App Router
+description: Implement production-ready @aura-stack/next setup, including Route Handlers, Client Side Rendering, Server Side Rendering. Use this skill when users ask for auth setup in Next.js App Router applications.
+---
+
+## Implementation Steps
+
+### 1) Install Dependencies
+
+Use detected package manager. Example
+
+```bash
+pnpm add @aura-stack/next
+```
+
+### 2) Create auth module
+
+Default module example (src/lib/auth.ts):
+
+```ts
+import { createAuth } from "@aura-stack/next"
+
+export const { handlers, jose, api } = createAuth({
+  oauth: ["github"],
+  basePath: "/api/auth",
+})
+```
+
+Prefer minimal defaults first, then layer advanced options only if user asks.
+
+### 3) Wire route handlers correctly
+
+The handler mount must match basePath exactly (src/app/api/auth/[...aura]/route.ts):
+
+```ts
+import { handlers } from "@/lib/auth"
+
+export const { GET, POST, PATCH } = handlers
+```
+
+### 5) Add client helper only when allowed
+
+Create createAuthClient only for client-capable targets.
+
+```ts
+import { createAuthClient } from "@aura-stack/next/client"
+
+export const authClient = createAuthClient({
+  basePath: "/api/auth",
+  baseURL: "http://localhost:3000",
+})
+
+export const { getSession, signIn, signInCredentials, signUp, updateSession, signOut } = authClient
+```

--- a/skills/create-auth/reference/integrations/nextjs-pages-router.md
+++ b/skills/create-auth/reference/integrations/nextjs-pages-router.md
@@ -30,7 +30,7 @@ Prefer minimal defaults first, then layer advanced options only if user asks.
 
 ### 3) Wire route handlers correctly
 
-The handler mount must match basePath exactly (src/app/pages/auth/[...aura].ts):
+The handler mount must match basePath exactly (src/pages/auth/[...aura].ts):
 
 ```ts
 import { toHandler } from "@/lib/auth"

--- a/skills/create-auth/reference/integrations/nextjs-pages-router.md
+++ b/skills/create-auth/reference/integrations/nextjs-pages-router.md
@@ -1,0 +1,54 @@
+---
+name: Next.js Pages Router
+description: Implement production-ready @aura-stack/next setup, including Route Handlers, Client Side Rendering, Server Side Rendering. Use this skill when users ask for auth setup in Next.js Pages Router applications.
+---
+
+## Implementation Steps
+
+### 1) Install Dependencies
+
+Use detected package manager. Example
+
+```bash
+pnpm add @aura-stack/next
+```
+
+### 2) Create auth module
+
+Default module example (src/lib/auth.ts):
+
+```ts
+import { createAuth } from "@aura-stack/next/pages"
+
+export const { toHandler, jose, api } = createAuth({
+  oauth: ["github"],
+  basePath: "/api/auth",
+})
+```
+
+Prefer minimal defaults first, then layer advanced options only if user asks.
+
+### 3) Wire route handlers correctly
+
+The handler mount must match basePath exactly (src/app/pages/auth/[...aura].ts):
+
+```ts
+import { toHandler } from "@/lib/auth"
+
+export default toHandler
+```
+
+### 5) Add client helper only when allowed
+
+Create createAuthClient only for client-capable targets.
+
+```ts
+import { createAuthClient } from "@aura-stack/next/pages/client"
+
+export const authClient = createAuthClient({
+  basePath: "/api/auth",
+  baseURL: "http://localhost:3000",
+})
+
+export const { getSession, signIn, signInCredentials, signUp, updateSession, signOut } = authClient
+```

--- a/skills/create-auth/reference/integrations/react-router.md
+++ b/skills/create-auth/reference/integrations/react-router.md
@@ -41,7 +41,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 }
 
 export const action = async ({ request }: Route.ActionArgs) => {
-  return handlers.POST(request)
+  return handlers.ALL(request)
 }
 ```
 

--- a/skills/create-auth/reference/integrations/react-router.md
+++ b/skills/create-auth/reference/integrations/react-router.md
@@ -1,0 +1,61 @@
+---
+name: React Router v7
+description: Implement production-ready @aura-stack/react-router setup, including Route Handlers, Client Side Rendering, Server Side Rendering. Use this skill when users ask for auth setup in React Router v7 applications.
+---
+
+## Implementation Steps
+
+### 1) Install Dependencies
+
+Use detected package manager. Example
+
+```bash
+pnpm add @aura-stack/react-router
+```
+
+### 2) Create auth module
+
+Default module example (src/lib/auth.ts):
+
+```ts
+import { createAuth } from "@aura-stack/react-router"
+
+export const { handlers, jose, api } = createAuth({
+  oauth: ["github"],
+  basePath: "/api/auth",
+})
+```
+
+Prefer minimal defaults first, then layer advanced options only if user asks.
+
+### 3) Wire route handlers correctly
+
+The handler mount must match basePath exactly (app/routes/api.auth.$.ts):
+
+```ts
+import { handlers } from "~/lib/auth"
+import type { Route } from "./+types/api.auth.$"
+
+export const loader = async ({ request }: Route.LoaderArgs) => {
+  return handlers.GET(request)
+}
+
+export const action = async ({ request }: Route.ActionArgs) => {
+  return handlers.POST(request)
+}
+```
+
+### 5) Add client helper only when allowed
+
+Create createAuthClient only for client-capable targets.
+
+```ts
+import { createAuthClient } from "@aura-stack/react-router/client"
+
+export const authClient = createAuthClient({
+  basePath: "/api/auth",
+  baseURL: "http://localhost:3000",
+})
+
+export const { getSession, signIn, signInCredentials, signUp, updateSession, signOut } = authClient
+```

--- a/skills/create-auth/reference/integrations/react.md
+++ b/skills/create-auth/reference/integrations/react.md
@@ -1,0 +1,44 @@
+---
+name: React
+description: Implement production-ready @aura-stack/react setup, including Route Handlers, Client Side Rendering, Server Side Rendering. Use this skill when users ask for auth setup in React applications.
+---
+
+## Implementation Steps
+
+### 1) Install Dependencies
+
+Use detected package manager. Example
+
+```bash
+pnpm add @aura-stack/react
+```
+
+### 2) Create Client Auth module
+
+Default module example (src/lib/auth-client.ts):
+
+```ts
+import { createAuthClient } from "@aura-stack/react"
+
+export const authClient = createAuthClient({
+  basePath: "/api/auth",
+  baseURL: "https://localhost:3000",
+})
+
+export const { getSession, signIn, signInCredentials, signUp, updateSession, signOut } = authClient
+```
+
+Prefer minimal defaults first, then layer advanced options only if user asks.
+
+### 5) Add server auth instance helper only when allowed
+
+Create createAuth only for client-capable targets. Default module example (src/lib/auth.ts):
+
+```ts
+import { createAuth } from "@aura-stack/react/server"
+
+export const { handlers, jose, api } = createAuth({
+  oauth: ["github"],
+  basePath: "/api/auth",
+})
+```

--- a/skills/create-auth/reference/integrations/supabase-edge-functions.md
+++ b/skills/create-auth/reference/integrations/supabase-edge-functions.md
@@ -1,0 +1,43 @@
+---
+name: Hono
+description: Implement production-ready @aura-stack/hono setup, including server setup and middlewares. Use this skill when users ask for auth setup in Hono backend applications.
+---
+
+> Aura Auth doens't provide a built-in Cloudflare Worker package, so its recomeded to use the core package @aura-stack/auth.
+
+## Implementation Steps
+
+### 1) Install Dependencies
+
+Use detected package manager. Example
+
+```bash
+pnpm add @aura-stack/auth
+```
+
+### 2) Create auth module
+
+Default module example (functions/_shared_/auth.ts):
+
+```ts
+import { createAuth } from "@aura-stack/auth"
+
+export const { handlers, jose, api } = createAuth({
+  oauth: ["github"],
+  basePath: "/api/auth",
+})
+```
+
+Prefer minimal defaults first, then layer advanced options only if user asks.
+
+### 3) Wire route handlers correctly
+
+The handler mount must match basePath exactly (functions/auth/index.ts):
+
+```ts
+import { handlers } from "../lib/auth"
+
+Deno.serve(async (request) => {
+  return await handlers.ALL(request)
+})
+```

--- a/skills/create-auth/reference/integrations/supabase-edge-functions.md
+++ b/skills/create-auth/reference/integrations/supabase-edge-functions.md
@@ -1,9 +1,9 @@
 ---
-name: Hono
-description: Implement production-ready @aura-stack/hono setup, including server setup and middlewares. Use this skill when users ask for auth setup in Hono backend applications.
+name: Supabase Edge Functions
+description: Implement auth setup for Supabase Edge Functions using @aura-stack/auth.
 ---
 
-> Aura Auth doens't provide a built-in Cloudflare Worker package, so its recomeded to use the core package @aura-stack/auth.
+> Aura Auth doesn't provide a built-in Supabase Edge Functions package, so it's recommended to use the core package `@aura-stack/auth`.
 
 ## Implementation Steps
 
@@ -35,7 +35,7 @@ Prefer minimal defaults first, then layer advanced options only if user asks.
 The handler mount must match basePath exactly (functions/auth/index.ts):
 
 ```ts
-import { handlers } from "../lib/auth"
+import { handlers } from "../_shared/auth"
 
 Deno.serve(async (request) => {
   return await handlers.ALL(request)

--- a/skills/create-auth/reference/integrations/tanstack-start.md
+++ b/skills/create-auth/reference/integrations/tanstack-start.md
@@ -1,0 +1,71 @@
+---
+name: TanStack React Start
+description: Implement production-ready @aura-stack/auth setup. Use this skill when users ask for auth setup in TanStack React Start applications using the @aura-stack/auth package
+---
+
+> Aura Auth doens't provide a built-in TanStack React Start package, so its recomeded to use the core package @aura-stack/auth.
+
+## Implementation Steps
+
+### 1) Install Dependencies
+
+Use detected package manager. Example
+
+```bash
+pnpm add @aura-stack/auth
+```
+
+### 2) Create auth module
+
+Default module example (src/lib/auth.ts):
+
+```ts
+import { createAuth } from "@aura-stack/next"
+
+export const { handlers, jose, api } = createAuth({
+  oauth: ["github"],
+  basePath: "/api/auth",
+})
+```
+
+Prefer minimal defaults first, then layer advanced options only if user asks.
+
+### 3) Wire route handlers correctly
+
+The handler mount must match basePath exactly (src/routes/api/auth.$.ts):
+
+```ts
+import { handlers } from "@/lib/auth"
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/api/auth/$")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        return await handlers.GET(request)
+      },
+      POST: async ({ request }) => {
+        return await handlers.POST(request)
+      },
+      PATCH: async ({ request }) => {
+        return await handlers.PATCH(request)
+      },
+    },
+  },
+})
+```
+
+### 5) Add client helper only when allowed
+
+Create createAuthClient only for client-capable targets.
+
+```ts
+import { createAuthClient } from "@aura-stack/auth/client"
+
+export const authClient = createAuthClient({
+  basePath: "/api/auth",
+  baseURL: "http://localhost:3000",
+})
+
+export const { getSession, signIn, signInCredentials, signUp, updateSession, signOut } = authClient
+```

--- a/skills/create-auth/reference/integrations/tanstack-start.md
+++ b/skills/create-auth/reference/integrations/tanstack-start.md
@@ -3,7 +3,7 @@ name: TanStack React Start
 description: Implement production-ready @aura-stack/auth setup. Use this skill when users ask for auth setup in TanStack React Start applications using the @aura-stack/auth package
 ---
 
-> Aura Auth doens't provide a built-in TanStack React Start package, so its recomeded to use the core package @aura-stack/auth.
+> Aura Auth doesn't provide a built-in TanStack React Start package, so it's recommended to use the core package `@aura-stack/auth`.
 
 ## Implementation Steps
 
@@ -20,7 +20,7 @@ pnpm add @aura-stack/auth
 Default module example (src/lib/auth.ts):
 
 ```ts
-import { createAuth } from "@aura-stack/next"
+import { createAuth } from "@aura-stack/auth"
 
 export const { handlers, jose, api } = createAuth({
   oauth: ["github"],

--- a/skills/create-auth/reference/integrations/vercel-edge-functions.md
+++ b/skills/create-auth/reference/integrations/vercel-edge-functions.md
@@ -1,0 +1,51 @@
+---
+name: Hono
+description: Implement production-ready @aura-stack/hono setup, including server setup and middlewares. Use this skill when users ask for auth setup in Hono backend applications.
+---
+
+> Aura Auth doens't provide a built-in Vercel Edge Functions package, so its recomeded to use the core package @aura-stack/auth.
+
+## Implementation Steps
+
+### 1) Install Dependencies
+
+Use detected package manager. Example
+
+```bash
+pnpm add @aura-stack/auth
+```
+
+### 2) Create auth module
+
+Default module example (api/\_auth.ts):
+
+```ts
+import { createAuth } from "@aura-stack/auth"
+
+export const { handlers, jose, api } = createAuth({
+  oauth: ["github"],
+  basePath: "/api/auth",
+})
+```
+
+Prefer minimal defaults first, then layer advanced options only if user asks.
+
+### 3) Wire route handlers correctly
+
+The handler mount must match basePath exactly (api/auth/index.ts):
+
+```ts
+import { handlers } from "../_auth"
+
+export const GET = async (request: Request) => {
+  return await handlers.GET(request)
+}
+
+export const POST = async (request: Request) => {
+  return await handlers.POST(request)
+}
+
+export const PATCH = async (request: Request) => {
+  return await handlers.PATCH(request)
+}
+```

--- a/skills/create-auth/reference/integrations/vercel-edge-functions.md
+++ b/skills/create-auth/reference/integrations/vercel-edge-functions.md
@@ -1,9 +1,9 @@
 ---
-name: Hono
-description: Implement production-ready @aura-stack/hono setup, including server setup and middlewares. Use this skill when users ask for auth setup in Hono backend applications.
+name: Vercel Edge Functions
+description: Implement production-ready `@aura-stack/auth` setup for Vercel Edge Functions. Use this skill when users ask for auth setup in Vercel Edge Functions.
 ---
 
-> Aura Auth doens't provide a built-in Vercel Edge Functions package, so its recomeded to use the core package @aura-stack/auth.
+> Aura Auth doesn't provide a built-in Vercel Edge Functions package, so it's recommended to use the core package `@aura-stack/auth`.
 
 ## Implementation Steps
 


### PR DESCRIPTION
## Description

This pull request adds integration references to the `create-auth` skill.

The `create-auth` agent skill now references framework-specific integration guides, allowing it to provide basic setup instructions for supported frameworks using either the dedicated packages provided by Aura Auth or the core `@aura-stack/auth` package.

The integration references include topics such as:
- Installation
- Creating an auth instance
- Creating an auth client instance
- Additional framework-specific setup steps

Additionally, this PR adds references for the available `create-auth` configuration options, enabling the agent to provide more detailed information about each option.

The included integration references correspond to the frameworks available in the Aura Auth demos/apps—that is, frameworks officially supported by Aura Auth or frameworks that can be implemented using Aura Auth.

@coderabbitai ignore