### PR TITLE
docs(ai): add AI resources section

### DIFF
--- a/docs/src/content/docs/(core)/ai-resources/meta.json
+++ b/docs/src/content/docs/(core)/ai-resources/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "AI Resources",
-  "pages": ["skills", "[LLMS.txt](/llms-full.txt)"],
+  "pages": ["skills", "[LLMs.txt](/llms-full.txt)"],
   "defaultOpen": false
 }

--- a/docs/src/content/docs/(core)/ai-resources/meta.json
+++ b/docs/src/content/docs/(core)/ai-resources/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "AI Resources",
+  "pages": ["skills", "[LLMS.txt](/llms-full.txt)"],
+  "defaultOpen": false
+}

--- a/docs/src/content/docs/(core)/ai-resources/skills.mdx
+++ b/docs/src/content/docs/(core)/ai-resources/skills.mdx
@@ -3,9 +3,9 @@ title: Skills
 description: A curated list of skills and resources for AI development, including tutorials, guides, and best practices.
 ---
 
-[Agent Skills](https://agentskills.io/home) are modular, reusable capabilities that allows AI agents to perform specific tasks with a set of instructions and tools and usually write down in `SKILL.md` files.
+[Agent Skills](https://agentskills.io/home) are modular, reusable capabilities that allow AI agents to perform specific tasks using a set of instructions and tools, usually documented in `SKILL.md` files.
 
-These set of skills can used to build more complex AI agents and applications using the Aura Auth library. You can installed them use [skill.sh](https://www.skills.sh/) CLI tool
+These skills can be used to build more complex AI agents and applications with the Aura Auth library. You can install them using the [skill.sh CLI](https://www.skills.sh/).
 
 ```npm
 npx skills add aura-stack-ts/auth

--- a/docs/src/content/docs/(core)/ai-resources/skills.mdx
+++ b/docs/src/content/docs/(core)/ai-resources/skills.mdx
@@ -1,0 +1,20 @@
+---
+title: Skills
+description: A curated list of skills and resources for AI development, including tutorials, guides, and best practices.
+---
+
+[Agent Skills](https://agentskills.io/home) are modular, reusable capabilities that allows AI agents to perform specific tasks with a set of instructions and tools and usually write down in `SKILL.md` files.
+
+These set of skills can used to build more complex AI agents and applications using the Aura Auth library. You can installed them use [skill.sh](https://www.skills.sh/) CLI tool
+
+```npm
+npx skills add aura-stack-ts/auth
+```
+
+**OR**
+
+```npm
+npx skills add aura-stack-ts/auth --skill <skill-name>
+```
+
+Review the [skills repository](https://github.com/aura-stack-ts/auth/tree/master/skills) for a complete list of available skills and their documentation.

--- a/docs/src/content/docs/(core)/meta.json
+++ b/docs/src/content/docs/(core)/meta.json
@@ -8,6 +8,7 @@
     "integrations",
     "oauth",
     "security",
+    "ai-resources",
     "api-reference",
     "---Community---",
     "contributing",


### PR DESCRIPTION
## Description

This pull request adds an **AI Resources** section to the documentation site. The new section centralizes AI-related resources for Aura Auth, making it easier for AI assistants and developers to discover and consume documentation tailored for AI-powered workflows.

This PR introduces documentation for Aura Auth skills as well as the `llms-full.txt` resource generated by Fumadocs.

### Key Changes

* Added the **AI Resources** section to the documentation.
* Added documentation for Aura Auth skills.
* Added the `llms-full.txt` resource to the AI Resources section.
* Improved discoverability of AI-specific documentation and resources.


@coderabbitai ignore


