### PR TITLE
docs(api-reference): add client API reference documentation

### DIFF
--- a/docs/src/content/docs/(core)/api-reference/client/createAuthClient.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/createAuthClient.mdx
@@ -2,3 +2,209 @@
 title: createAuthClient
 description: Create an Aura Auth client for your app with the given configuration.
 ---
+
+## Signature
+
+```ts lineNumbers
+function createAuthClient<DefaultUser extends User = User, SignUpPayload extends Record<string, any> = Record<string, any>>(
+  options: AuthClientOptions
+): {
+  getSession(): Promise<Session<User> | null>
+  signIn<Options extends SignInOptions>(
+    oauth: LiteralUnion<BuiltInOAuthProvider>,
+    options?: Options | undefined
+  ): Promise<SignInReturn<Options>>
+  signInCredentials<Options extends SignInCredentialsOptions>(options: Options): Promise<SignInCredentialsReturn<Options>>
+  signUp<Options extends SignUpOptions<Record<string, any>>>(options: Options): Promise<SignUpReturn<Options>>
+  updateSession<Options extends UpdateSessionOptions<User>>(options: Options): Promise<UpdateSessionReturn<Options, User>>
+  signOut<Options extends SignOutOptions>(options?: Options): Promise<SignOutReturn<Options>>
+}
+```
+
+## Returns
+
+`createAuthClient()` returns an Auth Client instance for client-side usage, exposing the following methods:
+
+| Method                | Description                                                                                                | Link                                                           |
+| --------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `getSession()`        | Retrieves the current session from the `GET /auth/session` endpoint                                        | [Docs](/docs/api-reference/client/functions/getSession)        |
+| `signIn()`            | Initiates the sign-in process for the specified OAuth provider from the `GET /auth/signIn/:oauth` endpoint | [Docs](/docs/api-reference/client/functions/signIn)            |
+| `signInCredentials()` | Signs in a user with their email and password from the `POST /auth/signIn/credentials` endpoint            | [Docs](/docs/api-reference/client/functions/signInCredentials) |
+| `signUp()`            | Creates a new user account from the `POST /auth/signUp` endpoint                                           | [Docs](/docs/api-reference/client/functions/signUp)            |
+| `updateSession()`     | Updates the current session from the `PATCH /auth/session` endpoint                                        | [Docs](/docs/api-reference/client/functions/updateSession)     |
+| `signOut()`           | Signs out the current user from the `POST /auth/signOut` endpoint                                          | [Docs](/docs/api-reference/client/functions/signOut)           |
+
+<Callout type="info">
+  The Auth Client instance is designed for client-side usage and talks to the Aura Auth HTTP handler endpoints over `fetch`. It is
+  not intended for server-side usage — if you need to perform server-side flows, use the `api` object instead. See the [Server API
+  Reference](/docs/api-reference/server/api).
+</Callout>
+
+## Options
+
+`baseURL`, `basePath`, and `headers` configure how requests are addressed. `fetch`, `cache`, `credentials`, and `mode` are passed straight through to the underlying `fetch()` call the client makes internally — if you're familiar with the Fetch API, these behave exactly as they would in a normal `fetch()` call.
+
+### `baseURL`
+
+Base URL of the application used to construct absolute URLs for redirects and API calls. It should include the protocol and domain, and optionally a port if not standard (80 for HTTP, 443 for HTTPS). If not set, Aura Auth attempts to infer it from the request headers, which may not always be reliable.
+
+<Callout type="warning">
+  Setting `baseURL` is recommended for production environments to ensure consistent URL generation. Relying on header inference
+  can lead to incorrect URLs, especially behind proxies or load balancers, which may cause authentication failures or security
+  issues.
+</Callout>
+
+```ts title="lib/auth-client.ts" lineNumbers
+import { createAuthClient } from "@aura-stack/auth/client"
+
+export const authClient = createAuthClient({
+  baseURL: "https://api.example.com",
+})
+```
+
+### `basePath`
+
+Base path for the Aura Auth HTTP handler endpoints. Defaults to `/auth`. Set this if your Aura Auth handlers are mounted at a different path.
+
+```ts title="lib/auth-client.ts" lineNumbers
+import { createAuthClient } from "@aura-stack/auth/client"
+
+export const authClient = createAuthClient({
+  basePath: "/auth",
+  baseURL: "https://api.example.com",
+})
+```
+
+### `headers`
+
+Default headers to include in every request made by the Auth Client instance.
+
+#### Static headers
+
+```ts title="lib/auth-client.ts" lineNumbers
+import { createAuthClient } from "@aura-stack/auth/client"
+
+export const authClient = createAuthClient({
+  baseURL: "https://api.example.com",
+  headers: {
+    "X-Custom-Header": "MyCustomValue",
+  },
+})
+```
+
+#### Dynamic headers
+
+Pass a function returning a headers object to compute headers per-request — useful for attaching a token that changes over time.
+
+```ts title="lib/auth-client.ts" lineNumbers
+import { createAuthClient } from "@aura-stack/auth/client"
+
+export const authClient = createAuthClient({
+  baseURL: "https://api.example.com",
+  headers: () => {
+    return {
+      Authorization: `Bearer ${getAuthToken()}`,
+    }
+  },
+})
+```
+
+### `fetch`
+
+A custom `fetch` implementation for the Auth Client instance to use instead of the global `fetch` available in the environment.
+
+```ts title="lib/auth-client.ts" lineNumbers
+import { createAuthClient } from "@aura-stack/auth/client"
+
+export const authClient = createAuthClient({
+  baseURL: "https://api.example.com",
+  fetch: async (input, init) => {
+    // Custom fetch logic here
+    return fetch(input, init)
+  },
+})
+```
+
+### `cache`
+
+Sets the [Fetch API `cache` mode](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#cache) used for requests (`"default"`, `"no-store"`, `"reload"`, `"no-cache"`, `"force-cache"`, or `"only-if-cached"`). Defaults to `"no-store"`, the standard browser HTTP cache behavior.
+
+```ts title="lib/auth-client.ts" lineNumbers
+import { createAuthClient } from "@aura-stack/auth/client"
+
+export const authClient = createAuthClient({
+  baseURL: "https://api.example.com",
+  cache: "no-store",
+})
+```
+
+### `credentials`
+
+Sets the [Fetch API `credentials` mode](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#credentials) (`"omit"`, `"same-origin"`, or `"include"`), controlling whether cookies are sent with cross-origin requests. Defaults to `"include"`, the standard `fetch()` default
+
+```ts title="lib/auth-client.ts" lineNumbers
+import { createAuthClient } from "@aura-stack/auth/client"
+
+export const authClient = createAuthClient({
+  baseURL: "https://api.example.com",
+  credentials: "include",
+})
+```
+
+### `mode`
+
+Sets the [Fetch API `mode`](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#mode) (`"cors"`, `"no-cors"`, or `"same-origin"`). Defaults to `"cors"`, the standard `fetch()` default for cross-origin requests.
+
+```ts title="lib/auth-client.ts" lineNumbers
+import { createAuthClient } from "@aura-stack/auth/client"
+
+export const authClient = createAuthClient({
+  baseURL: "https://api.example.com",
+  mode: "cors",
+})
+```
+
+## Generic types
+
+`createAuthClient` accepts two generic parameters, `DefaultUser` and `SignUpPayload`, letting you type the client to match your application's user shape and sign-up payload.
+
+### `DefaultUser`
+
+Infer this from your `createAuth` configuration with the `InferUser` utility type, or provide your own type directly.
+
+```ts title="lib/auth-client.ts" lineNumbers
+import { auth } from "@/lib/auth"
+import { createAuthClient } from "@aura-stack/auth/client"
+
+type User = InferUser<typeof auth>
+
+export const authClient = createAuthClient<User>({
+  baseURL: "https://api.example.com",
+})
+```
+
+<Callout type="info">
+  This is only necessary if you've customized `identity.schema` in your `createAuth` configuration. If you haven't, the default
+  `User` type is used automatically. See [Identity Schema](/docs/configuration/identity-schema#type-inference).
+</Callout>
+
+### `SignUpPayload`
+
+Defines the shape of the payload sent during sign-up — useful when your sign-up form collects fields beyond the default set.
+
+```ts title="lib/auth-client.ts" lineNumbers
+import { auth } from "@/lib/auth"
+import { createAuthClient } from "@aura-stack/auth/client"
+import type { User } from "@aura-stack/auth"
+
+type SignUpPayload = {
+  username: string
+  nickname: string
+  email: string
+  password: string
+}
+
+export const authClient = createAuthClient<User, SignUpPayload>({
+  baseURL: "https://api.example.com",
+})
+```

--- a/docs/src/content/docs/(core)/api-reference/client/functions/getSession.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/getSession.mdx
@@ -2,3 +2,54 @@
 title: getSession
 description: Get the current session for a user with Aura Auth.
 ---
+
+The `getSession` client method retrieves the active user session from a client-side or browser context. It verifies the session token's integrity and returns the associated user data if the session is valid.
+
+```ts title="syntax.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const session = await authClient.getSession()
+```
+
+## Reference
+
+This function accepts no parameters — session data is read automatically from the browser's cookies.
+
+### Returns
+
+| Return Type                             | Description                                        |
+| --------------------------------------- | -------------------------------------------------- |
+| `Promise<Session<DefaultUser> \| null>` | Resolves to the current session object, or `null`. |
+
+<Callout type="info">
+  This return shape is intentionally simpler than the server-side [`api.getSession`](/docs/api-reference/server/api/get-session),
+  which returns `{ session, success, headers }`. The client doesn't need the `headers` field that server-side rolling
+  session rotation requires — the browser already handles the refreshed cookie automatically.
+</Callout>
+
+## Behavior
+
+- Cookies are read automatically from the browser context — you don't need to handle them manually.
+- If there is no valid session (missing, expired, or tampered token), the resolved value is `null`. This does not throw — a missing session is an expected, non-error outcome.
+
+## Usage
+
+### Get the current session
+
+```ts title="get-session.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const session = await authClient.getSession()
+```
+
+### Guarding a route
+
+```tsx title="protected-route.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const session = await authClient.getSession()
+
+if (!session) {
+  window.location.assign("/login")
+}
+```

--- a/docs/src/content/docs/(core)/api-reference/client/functions/meta.json
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Functions",
-  "pages": ["..."]
+  "pages": ["signIn", "signInCredentials", "signUp", "getSession", "updateSession", "signOut"]
 }

--- a/docs/src/content/docs/(core)/api-reference/client/functions/signIn.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/signIn.mdx
@@ -2,3 +2,75 @@
 title: signIn
 description: Sign in to your Aura app with a built-in or custom OAuth provider.
 ---
+
+The `signIn` client function is the primary programmatic entry point for initiating an authentication flow with any configured OAuth 2.0 or OpenID Connect (OIDC) provider, from a client-side or browser context.
+
+```ts title="sign-in.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const output = await authClient.signIn("google", {
+  redirectTo: "/dashboard",
+})
+```
+
+## Reference
+
+### Parameters
+
+| Parameter  | Type            | Required | Description                                                      |
+| ---------- | --------------- | -------- | ---------------------------------------------------------------- |
+| providerId | `string`        | Yes      | The id of the OAuth provider to use for sign-in.                 |
+| options    | `SignInOptions` | No       | An object containing additional options for the sign-in process. |
+
+### SignInOptions
+
+| Option     | Type      | Default   | Description                                                                                            |
+| ---------- | --------- | --------- | ------------------------------------------------------------------------------------------------------ |
+| redirect   | `boolean` | `false`   | Whether to redirect via `window.location.assign` (`true`) or return the result as an object (`false`). |
+| redirectTo | `string`  | undefined | The URL to redirect to after a successful sign-in.                                                     |
+
+<Callout type="info">
+  `redirect` defaults to `false` here — unlike the other client methods, which default to `true`. This is intentional: `signIn`
+  navigates the browser to a **cross-origin** OAuth provider URL, and doing that via a `Location` header on a `fetch()` response
+  runs into CORS restrictions on cross-origin redirects. To avoid that, the client resolves the authorize URL and navigates
+  manually with `window.location.assign`, which requires you to opt in or handle the navigation yourself.
+</Callout>
+
+### Returns
+
+| Return Type                      | Description                                                                                                |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `Promise<SignInReturn<Options>>` | Resolves to an object containing `signInURL`, `redirect`, and `success` — see [Behavior](#behavior) below. |
+
+## Behavior
+
+- Cookies are set automatically in the browser context — you don't need to handle them manually.
+- The return value depends on the `redirect` option:
+  - **`redirect: false`** (default) — resolves to an object with `signInURL`, `redirect: false`, and `success`, letting you handle navigation yourself.
+  - **`redirect: true`** — the client navigates the browser to the OAuth provider's authorize URL via `window.location.assign`. Nothing meaningful is returned to inspect programmatically; the navigation itself is the result.
+- If sign-in fails to initiate (e.g. an unknown `providerId`), `signInURL` resolves to `null` and `success` is `false`.
+
+## Usage
+
+### Social login
+
+```tsx title="social-login.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const output = await authClient.signIn("github", {
+  redirect: true,
+  redirectTo: "/dashboard",
+})
+```
+
+### Manual navigation
+
+```tsx title="manual-navigation.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const output = await authClient.signIn("google")
+
+if (output.success) {
+  window.location.assign(output.signInURL)
+}
+```

--- a/docs/src/content/docs/(core)/api-reference/client/functions/signInCredentials.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/signInCredentials.mdx
@@ -2,3 +2,114 @@
 title: signInCredentials
 description: Sign in to your Aura Auth app using a username or email and password. This is a built-in credential provider that can be used in addition to OAuth providers.
 ---
+
+The `signInCredentials` client method is the primary programmatic entry point for authenticating a user with a username/email and password, from a client-side or browser context.
+
+```ts title="sign-in.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const output = await authClient.signInCredentials({
+  payload: {
+    username: "user@example.com",
+    password: "password123",
+  },
+  redirectTo: "/dashboard",
+})
+```
+
+## Reference
+
+### Parameters
+
+| Parameter | Type                       | Required | Description                                                       |
+| --------- | -------------------------- | -------- | ----------------------------------------------------------------- |
+| options   | `SignInCredentialsOptions` | Yes      | An object containing the credentials payload and request context. |
+
+### SignInCredentialsOptions
+
+| Option     | Type                 | Default   | Description                                                                                            |
+| ---------- | -------------------- | --------- | ------------------------------------------------------------------------------------------------------ |
+| payload    | `CredentialsPayload` | —         | The credentials for the sign-in attempt. Required — without it there's nothing to authenticate.        |
+| redirect   | `boolean`            | `true`    | Whether to redirect via `window.location.assign` (`true`) or return the result as an object (`false`). |
+| redirectTo | `string`             | undefined | The URL to redirect to after a successful sign-in.                                                     |
+
+### Returns
+
+| Return Type                                 | Description                                                                                            |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `Promise<SignInCredentialsReturn<Options>>` | Resolves to an object containing `redirectURL`, `redirect`, and `success` — see [Behavior](#behavior). |
+
+## Behavior
+
+- Cookies are set automatically in the browser context — you don't need to handle them manually.
+- The CSRF token is automatically loaded and sent with the request — you don't need to handle it manually.
+- Sign-in success depends entirely on your configured [`credentials.authorize`](/docs/api-reference/server/createAuth#credentials) function on the server, which validates the submitted credentials and returns the `User` object (or `null` if invalid).
+- The return value depends on the `redirect` option:
+  - **`redirect: true`** (default) — navigates to `redirectTo` (or the default post-login URL) via `window.location.assign`.
+  - **`redirect: false`** — resolves to an object with `redirectURL`, `redirect: false`, and `success`, letting you handle navigation yourself.
+- If the sign-in attempt fails (invalid credentials), `redirectURL` resolves to `null` and `success` is `false`.
+
+<Callout type="info">
+  Unlike [`signIn`](/docs/api-reference/client/functions/signIn), `redirect` defaults to `true` here — this method navigates to a
+  same-origin URL (`redirectTo`), so there's no cross-origin CORS concern to opt out of by default.
+</Callout>
+
+## Setup
+
+```ts title="lib/auth.ts" lineNumbers
+import { createAuth } from "@aura-stack/auth"
+import { createSecretValue } from "@aura-stack/auth/crypto"
+
+export const auth = createAuth({
+  oauth: [],
+  credentials: {
+    authorize: async ({ credentials }) => {
+      if (!credentials || !credentials.username || !credentials.password) {
+        return null
+      }
+
+      const sub = createSecretValue(10)
+      return {
+        sub,
+        name: "John Doe",
+        email: credentials.username,
+        image: `https://avatars.dicebear.com/api/initials/${sub}.svg`,
+      }
+    },
+  },
+})
+```
+
+## Usage
+
+### Sign in with credentials
+
+```ts title="credentials-login.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const output = await authClient.signInCredentials({
+  payload: {
+    username: "johndoe@example.com",
+    password: "password",
+  },
+})
+```
+
+### Manual navigation
+
+```tsx title="manual-navigation.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const output = await authClient.signInCredentials({
+  payload: {
+    username: "alice@example.com",
+    password: "password",
+  },
+  redirect: false,
+  redirectTo: "/dashboard",
+})
+
+if (output.success) {
+  window.location.assign(output.redirectURL)
+}
+```

--- a/docs/src/content/docs/(core)/api-reference/client/functions/signOut.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/signOut.mdx
@@ -2,3 +2,70 @@
 title: signOut
 description: Sign out of your Aura app and clear the current session.
 ---
+
+The `signOut` client method signs out the current user: it invalidates the session token and clears the session cookie, from a client-side or browser context.
+
+```ts title="sign-out.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const output = await authClient.signOut({
+  redirectTo: "/login",
+})
+```
+
+## Reference
+
+### Parameters
+
+| Parameter | Type             | Required | Description                                                       |
+| --------- | ---------------- | -------- | ----------------------------------------------------------------- |
+| options   | `SignOutOptions` | No       | An object containing additional options for the sign-out process. |
+
+### SignOutOptions
+
+| Option     | Type      | Default   | Description                                                                                            |
+| ---------- | --------- | --------- | ------------------------------------------------------------------------------------------------------ |
+| redirect   | `boolean` | `true`    | Whether to redirect via `window.location.assign` (`true`) or return the result as an object (`false`). |
+| redirectTo | `string`  | undefined | The URL to redirect to after sign-out completes.                                                       |
+
+### Returns
+
+| Return Type                       | Description                                                                |
+| --------------------------------- | -------------------------------------------------------------------------- |
+| `Promise<SignOutReturn<Options>>` | Resolves to an object containing `redirectURL`, `redirect`, and `success`. |
+
+## Behavior
+
+- Cookies are cleared automatically in the browser context — you don't need to handle them manually.
+- The CSRF token is automatically loaded and sent with the request — you don't need to handle it manually.
+- The return value depends on the `redirect` option:
+  - **`redirect: true`** (default) — navigates to `redirectTo` (or the default post-sign-out URL) via `window.location.assign`.
+  - **`redirect: false`** — resolves to an object with `redirectURL`, `redirect: false`, and `success`, letting you handle navigation yourself.
+- If sign-out fails (e.g. missing or mismatched CSRF token, or no active session to invalidate), `redirectURL` resolves to `null` and `success` is `false`.
+
+## Usage
+
+### Sign out
+
+```ts title="sign-out.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const output = await authClient.signOut({
+  redirectTo: "/login",
+})
+```
+
+### Manual navigation
+
+```tsx title="manual-navigation.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const output = await authClient.signOut({
+  redirect: false,
+  redirectTo: "/login",
+})
+
+if (output.success) {
+  window.location.assign(output.redirectURL)
+}
+```

--- a/docs/src/content/docs/(core)/api-reference/client/functions/signUp.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/signUp.mdx
@@ -2,3 +2,110 @@
 title: signUp
 description: Sign up a new user with Aura Auth.
 ---
+
+The `signUp` client method is the primary programmatic entry point for registering a new user, from a client-side or browser context.
+
+```ts title="syntax.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const output = await authClient.signUp({
+  payload: {
+    username: "user@example.com",
+    password: "password123",
+  },
+  redirectTo: "/dashboard",
+})
+```
+
+## Reference
+
+### Parameters
+
+| Parameter | Type            | Required | Description                                                      |
+| --------- | --------------- | -------- | ---------------------------------------------------------------- |
+| options   | `SignUpOptions` | No       | An object containing additional options for the sign-up process. |
+
+### SignUpOptions
+
+| Option     | Type                      | Default   | Description                                                                                            |
+| ---------- | ------------------------- | --------- | ------------------------------------------------------------------------------------------------------ |
+| payload    | `Record<string, unknown>` | undefined | The user registration data, matching your configured `signUp.schema` (if set).                         |
+| redirect   | `boolean`                 | `true`    | Whether to redirect via `window.location.assign` (`true`) or return the result as an object (`false`). |
+| redirectTo | `string`                  | undefined | The URL to redirect to after a successful sign-up.                                                     |
+
+### Returns
+
+| Return Type                      | Description                                                                                            |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `Promise<SignUpReturn<Options>>` | Resolves to an object containing `redirectURL`, `redirect`, and `success` — see [Behavior](#behavior). |
+
+## Behavior
+
+- Cookies are set automatically in the browser context — you don't need to handle them manually.
+- The CSRF token is automatically loaded and sent with the request — you don't need to handle it manually.
+- Sign-up success depends entirely on your configured [`signUp.onCreateUser`](/docs/api-reference/server/create-auth#signup) function on the server, which validates the submitted data and returns the `User` object (or `null` if invalid).
+- The return value depends on the `redirect` option:
+  - **`redirect: true`** (default) — navigates to `redirectTo` (or the default post-sign-up URL) via `window.location.assign`.
+  - **`redirect: false`** — resolves to an object with `redirectURL`, `redirect: false`, and `success`, letting you handle navigation yourself.
+- If the sign-up attempt fails (e.g. `onCreateUser` returns `null`, or `payload` fails `signUp.schema` validation), `redirectURL` resolves to `null` and `success` is `false`.
+
+## Setup
+
+```ts title="lib/auth.ts" lineNumbers
+import { createAuth } from "@aura-stack/auth"
+import { createSecretValue } from "@aura-stack/auth/crypto"
+
+export const auth = createAuth({
+  oauth: [],
+  signUp: {
+    onCreateUser: async ({ payload }) => {
+      if (!payload || !payload.username || !payload.password) {
+        return null
+      }
+
+      const sub = createSecretValue(10)
+      return {
+        sub,
+        name: "John Doe",
+        email: payload.username,
+        image: `https://avatars.dicebear.com/api/initials/${sub}.svg`,
+      }
+    },
+  },
+})
+```
+
+## Usage
+
+### Sign up
+
+```ts title="credentials-signup.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const output = await authClient.signUp({
+  payload: {
+    username: "johndoe@example.com",
+    password: "password",
+  },
+  redirectTo: "/dashboard",
+})
+```
+
+### Manual navigation
+
+```tsx title="manual-navigation.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const output = await authClient.signUp({
+  payload: {
+    username: "johndoe@example.com",
+    password: "password",
+  },
+  redirect: false,
+  redirectTo: "/dashboard",
+})
+
+if (output.success) {
+  window.location.assign(output.redirectURL)
+}
+```

--- a/docs/src/content/docs/(core)/api-reference/client/functions/updateSession.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/updateSession.mdx
@@ -2,3 +2,85 @@
 title: updateSession
 description: Update the current session with new identity data or refresh the session.
 ---
+
+The `updateSession` client method modifies or refreshes the data stored in the current user's session payload, without requiring them to sign out and back in.
+
+```ts title="syntax.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const session = await authClient.updateSession({
+  session: {
+    user: {
+      nickname: "newnickname",
+    },
+  },
+})
+```
+
+## Reference
+
+### Parameters
+
+| Parameter | Type                                | Required | Description                                                   |
+| --------- | ----------------------------------- | -------- | ------------------------------------------------------------- |
+| options   | `UpdateSessionOptions<DefaultUser>` | Yes      | An object containing the session updates and request context. |
+
+### UpdateSessionOptions
+
+| Option     | Type                                | Default   | Description                                                                                            |
+| ---------- | ----------------------------------- | --------- | ------------------------------------------------------------------------------------------------------ |
+| session    | `DeepPartial<Session<DefaultUser>>` | undefined | The partial session data to merge into the current session.                                            |
+| redirect   | `boolean`                           | `true`    | Whether to redirect via `window.location.assign` (`true`) or return the result as an object (`false`). |
+| redirectTo | `string`                            | undefined | The URL to redirect to after a successful update.                                                      |
+
+### Returns
+
+| Return Type                             | Description                                                                           |
+| --------------------------------------- | ------------------------------------------------------------------------------------- |
+| `Promise<UpdateSessionReturn<Options>>` | Resolves to an object containing the updated session data, `redirect`, and `success`. |
+
+## Behavior
+
+- Cookies are set automatically in the browser context — you don't need to handle them manually.
+- The CSRF token is automatically loaded and sent with the request — you don't need to handle it manually.
+- The session token's integrity is verified before applying the update. If the session is invalid or expired, the call resolves with `success: false` rather than throwing.
+- The return value depends on the `redirect` option:
+  - **`redirect: true`** (default) — navigates to `redirectTo` (or the default post-update URL) via `window.location.assign`.
+  - **`redirect: false`** — resolves to an object with the updated session, `redirect: false`, and `success`, letting you handle navigation yourself.
+- If the update fails (invalid session, or data that doesn't match `identity.schema`), `success` is `false`.
+
+## Usage
+
+### Update session data
+
+```ts title="update-session.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const session = await authClient.updateSession({
+  session: {
+    user: {
+      nickname: "newnickname",
+    },
+  },
+})
+```
+
+### With navigation
+
+```tsx title="manual-navigation.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const output = await authClient.updateSession({
+  session: {
+    user: {
+      nickname: "newnickname",
+    },
+  },
+  redirect: false,
+  redirectTo: "/dashboard",
+})
+
+if (output.success) {
+  window.location.assign(output.redirectURL)
+}
+```

--- a/docs/src/content/docs/(core)/api-reference/server/api/getSession.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/getSession.mdx
@@ -8,7 +8,7 @@ The `api.getSession` method retrieves the active user session on the server. It 
 ```ts title="syntax.ts" lineNumbers
 import { api } from "@/lib/auth"
 
-const { session, authenticated, headers } = await api.getSession({
+const { session, success, headers } = await api.getSession({
   headers: getHeaders(),
 })
 ```

--- a/docs/src/content/docs/(core)/api-reference/server/api/index.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/index.mdx
@@ -16,7 +16,7 @@ export interface AuthInstance<DefaultUser extends User = User, SignUpSchema exte
 <Callout type="info">
   These are the only functions exposed on `auth.api`. Internal implementation details of the OAuth flow — such as building the
   authorization redirect or handling the provider callback — are not part of this surface. See [OAuth Authorization
-  Flow](/docs/concepts/oauth-authorization-flow) for how those work internally.
+  Flow](/docs/concepts/oauth) for how those work internally.
 </Callout>
 
 <Cards>

--- a/docs/src/content/docs/(core)/api-reference/server/api/updateSession.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/updateSession.mdx
@@ -10,6 +10,11 @@ import { api } from "@/lib/auth"
 
 const session = await api.updateSession({
   headers: getHeaders(),
+  session: {
+    user: {
+      nickname: "newnickname",
+    },
+  },
 })
 ```
 


### PR DESCRIPTION
## Description

This pull request expands the **Client API Reference** documentation by adding comprehensive documentation for `createAuthClient()` and its client-side authentication methods.

The new documentation covers the complete client API, including authentication, session management, and user registration operations, providing developers with a centralized reference for integrating Aura Auth into client applications.

### Key Changes

* Added documentation for `createAuthClient()`.
* Added the `signIn()` client API reference.
* Added the `signInCredentials()` client API reference.
* Added the `getSession()` client API reference.
* Added the `updateSession()` client API reference.
* Added the `signUp()` client API reference.
* Added the `signOut()` client API reference.

