### PR TITLE
feat(oauth): add `Facebook` OAuth provider

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the `Facebook` OAuth provider to the supported integrations in Aura Auth. [#210](https://github.com/aura-stack-ts/auth/pull/210)
+
 - Added the `Authentik` OpenID Connect provider, enabling authentication through Authentik accounts with minimal configuration. [#199](https://github.com/aura-stack-ts/auth/pull/199)
 
 - Added the `Hugging Face` OpenID Connect provider, enabling authentication through Hugging Face accounts with minimal configuration. [#198](https://github.com/aura-stack-ts/auth/pull/198)

--- a/packages/core/src/oauth/facebook.ts
+++ b/packages/core/src/oauth/facebook.ts
@@ -1,0 +1,64 @@
+import type { OAuthProviderCredentials, User } from "@/@types/index.js"
+
+export interface FacebookProfile {
+    id: string
+    first_name: string
+    last_name: string
+    middle_name: string
+    name: string
+    name_format: string
+    picture: unknown
+    short_name: string
+    about: string
+    age_range: unknown
+    birthday: string
+    client_business_id: string
+    education: string
+    favorite_athletes: string[]
+    favorite_teams: string[]
+    gender: string
+    hometown: {
+        id: string
+        description: string
+        from: string | null
+        name: string | null
+        with: string
+    }
+}
+
+/**
+ * Facebook OAuth Provider
+ *
+ * @see [Facebook - Getting Started with Facebook Login](https://developers.facebook.com/docs/facebook-login/getting-started)
+ * @see [Facebook - Configure Your OAuth Settings](https://developers.facebook.com/docs/facebook-login/security#redirect-uris)
+ * @see [Facebook - Permissions Reference](https://developers.facebook.com/docs/permissions/reference)
+ * @see [Facebook - Login Review](https://developers.facebook.com/docs/facebook-login/review/)
+ * @see [Facebook - Manually Build a Login Flow](https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow)
+ * @see [Facebook - App](https://developers.facebook.com/)
+ * @see [Facebook - User](https://developers.facebook.com/docs/graph-api/reference/user)
+ */
+export const facebook = <DefaultUser extends User = User>(
+    options?: Partial<OAuthProviderCredentials<FacebookProfile, DefaultUser>>
+): OAuthProviderCredentials<FacebookProfile, DefaultUser> => {
+    return {
+        id: "facebook",
+        name: "Facebook",
+        authorize: {
+            url: "https://www.facebook.com/v24.0/dialog/oauth",
+            params: {
+                scope: "email public_profile",
+                responseType: "code",
+            },
+        },
+        accessToken: "https://graph.facebook.com/v24.0/oauth/access_token",
+        userInfo: "https://graph.facebook.com/me?fields=id,name,email,picture",
+        profile: (profile) =>
+            ({
+                sub: profile.id.toString(),
+                name: profile.name,
+                email: null,
+                image: profile.picture,
+            }) as DefaultUser,
+        ...options,
+    }
+}


### PR DESCRIPTION
## Description

This pull request adds the `Facebook` OAuth provider to the list of supported OAuth integrations in `@aura-stack/auth`.

The provider implementation follows the existing OAuth provider architecture and can be configured through the `oauth` option in `createAuth()`.

### Usage

```ts
import { createAuth } from "@aura-stack/auth"

export const auth = createAuth({
  oauth: ["facebook"],
})

export const { handlers } = auth
```

> [!NOTE]
> This pull request is currently marked as **Draft** because the Facebook OAuth integration has not yet been fully validated.
>
> While Meta provides documentation for creating a Facebook application, the OAuth setup process is fragmented and difficult to follow. Several referenced URLs and endpoints are outdated or no longer available, making it challenging to complete an end-to-end integration and verify the implementation.
>
> Once the provider has been successfully configured and validated against a real Facebook application, this PR will be ready for review.
