### PR TITLE
chore(release): bump package versions

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -110,6 +110,39 @@
     "@ark/util@0.56.0": {
       "integrity": "sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA=="
     },
+    "@aura-stack/auth@0.7.2_arktype@2.2.0_typebox@1.1.38_valibot@1.4.0_zod@4.3.5": {
+      "integrity": "sha512-fnlE+yIM90/ibGMSdIJRB20cJ1e7P8YYKY0ixCe0zrjYAdolVPUpDKiVEBnYzM9ICT2UNFSV4saGzhUtelIAAg==",
+      "dependencies": [
+        "@aura-stack/jose",
+        "@aura-stack/router@0.7.2_arktype@2.2.0_typebox@1.1.38_valibot@1.4.0_zod@4.3.5",
+        "arktype",
+        "typebox",
+        "valibot",
+        "zod"
+      ]
+    },
+    "@aura-stack/jose@0.6.0": {
+      "integrity": "sha512-wt1Jg6S42x1s9nqftvTBPXK/iYQX6Ihn01Oo5PO3i5ULW+QJNZFww6udicqzXKAFMu5rmez4e8L9qf/sx6uJaA==",
+      "dependencies": [
+        "jose"
+      ]
+    },
+    "@aura-stack/router@0.7.2_arktype@2.2.0_typebox@1.1.38_valibot@1.4.0_zod@4.3.5": {
+      "integrity": "sha512-Swxm9SDvJEmM+V3rxjyOm7Fvysnnw//e/7ZXS+7Gn01J9MD3EJNJDOOFKmlmtVwlPoLtLf/NVNGCMji4kb5kcw==",
+      "dependencies": [
+        "arktype",
+        "cookie@1.1.1",
+        "typebox",
+        "valibot",
+        "zod"
+      ],
+      "optionalPeers": [
+        "arktype",
+        "typebox",
+        "valibot",
+        "zod"
+      ]
+    },
     "@aura-stack/router@0.9.0_arktype@2.2.0_typebox@1.1.38_valibot@1.4.0_zod@4.3.5": {
       "integrity": "sha512-8yX9GJCAvyUMNawpNB8bCwQL+9ZLYFtsm6+btcj78XegtZ83uv6Ye16MKNhyadaCN5gA8OKAVAAKORzxq22dXg==",
       "dependencies": [
@@ -2026,7 +2059,7 @@
       },
       "packages/elysia": {
         "dependencies": [
-          "npm:@aura-stack/auth@~0.7.2",
+          "npm:@aura-stack/auth@0.8",
           "npm:elysia@^1.2.22"
         ],
         "packageJson": {
@@ -2037,7 +2070,7 @@
       },
       "packages/express": {
         "dependencies": [
-          "npm:@aura-stack/auth@~0.7.2",
+          "npm:@aura-stack/auth@0.8",
           "npm:express@^4.18.2"
         ],
         "packageJson": {
@@ -2049,7 +2082,7 @@
       },
       "packages/hono": {
         "dependencies": [
-          "npm:@aura-stack/auth@~0.7.2",
+          "npm:@aura-stack/auth@0.8",
           "npm:hono@4"
         ]
       },
@@ -2065,7 +2098,7 @@
       },
       "packages/next": {
         "dependencies": [
-          "npm:@aura-stack/react@0.1",
+          "npm:@aura-stack/react@0.2",
           "npm:next@16.1.6",
           "npm:react@19.2.3"
         ],
@@ -2077,13 +2110,13 @@
       },
       "packages/react": {
         "dependencies": [
-          "npm:@aura-stack/auth@~0.7.2",
+          "npm:@aura-stack/auth@0.8",
           "npm:react@^19.2.3"
         ]
       },
       "packages/react-router": {
         "dependencies": [
-          "npm:@aura-stack/react@0.1",
+          "npm:@aura-stack/react@0.2",
           "npm:react-router@^7.12.0",
           "npm:react@^19.2.3"
         ]

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [0.8.1] - 2026-07-04
+
+### Fixed
+
+- Republished the package to include the missing `huggingface` OAuth provider in the published package.
+  > This release contains no code changes compared to `v0.8.0`; it only corrects the published package contents.
+
+---
+
 ## [0.8.0] - 2026-07-04
 
 ### Added

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.8.0] - 2026-07-04
+
 ### Added
 
 - Added the `Authentik` OpenID Connect provider, enabling authentication through Authentik accounts with minimal configuration. [#199](https://github.com/aura-stack-ts/auth/pull/199)

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/auth",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -26,6 +26,7 @@
     "./oauth/gitlab": "./src/oauth/gitlab.ts",
     "./oauth/google": "./src/oauth/google.ts",
     "./oauth/hubspot": "./src/oauth/hubspot.ts",
+    "./oauth/huggingface": "./src/oauth/huggingface.ts",
     "./oauth/mailchimp": "./src/oauth/mailchimp.ts",
     "./oauth/notion": "./src/oauth/notion.ts",
     "./oauth/pinterest": "./src/oauth/pinterest.ts",

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/auth",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -15,8 +15,11 @@
     "./cookies": "./src/shared/cookies.ts",
     "./oauth": "./src/oauth/index.ts",
     "./oauth/atlassian": "./src/oauth/atlassian.ts",
+    "./oauth/authentik": "./src/oauth/authentik.ts",
     "./oauth/bitbucket": "./src/oauth/bitbucket.ts",
+    "./oauth/click-up": "./src/oauth/click-up.ts",
     "./oauth/discord": "./src/oauth/discord.ts",
+    "./oauth/dribbble": "./src/oauth/dribbble.ts",
     "./oauth/dropbox": "./src/oauth/dropbox.ts",
     "./oauth/figma": "./src/oauth/figma.ts",
     "./oauth/github": "./src/oauth/github.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/auth",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": false,
   "type": "module",
   "description": "Open-source authentication and authorization library for modern TypeScript and JavaScript applications. Framework-agnostic, runtime-agnostic and built on web standards.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/auth",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": false,
   "type": "module",
   "description": "Open-source authentication and authorization library for modern TypeScript and JavaScript applications. Framework-agnostic, runtime-agnostic and built on web standards.",

--- a/packages/device/deno.json
+++ b/packages/device/deno.json
@@ -5,6 +5,9 @@
   "tasks": {
     "dev": "deno run --watch src/index.ts"
   },
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "imports": {
     "@/": "./src/"
   },

--- a/packages/elysia/CHANGELOG.md
+++ b/packages/elysia/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [0.2.1] - 2026-07-04
+
+### Fixed
+
+- Republished the package to include the missing `huggingface` OAuth provider in the published package.
+  > This release contains no code changes compared to `v0.2.0`; it only corrects the published package contents.
+
+---
+
 ## [0.2.0] - 2026-07-04
 
 ### Added

--- a/packages/elysia/CHANGELOG.md
+++ b/packages/elysia/CHANGELOG.md
@@ -8,9 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] - 2026-07-04
+
 ### Added
 
 - Introduced an experimental `signUp` flow for both the API and endpoint definitions. The new action enables user account creation within the authentication system and provides customizable payload validation through the supported schema. To enable this feature, developers must configure the `signUp` option when calling `createAuth`. [#183](https://github.com/aura-stack-ts/auth/pull/183)
+
+### Changed
+
+- Updated the `@aura-stack/auth` dependency to `v0.8.0`. [#211](https://github.com/aura-stack-ts/auth/pull/211)
 
 ---
 

--- a/packages/elysia/deno.json
+++ b/packages/elysia/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/elysia",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -24,6 +24,7 @@
     "./oauth/gitlab": "./src/oauth/gitlab.ts",
     "./oauth/google": "./src/oauth/google.ts",
     "./oauth/hubspot": "./src/oauth/hubspot.ts",
+    "./oauth/huggingface": "./src/oauth/huggingface.ts",
     "./oauth/mailchimp": "./src/oauth/mailchimp.ts",
     "./oauth/notion": "./src/oauth/notion.ts",
     "./oauth/pinterest": "./src/oauth/pinterest.ts",
@@ -35,7 +36,7 @@
   "imports": {
     "@/": "./src/",
     "elysia": "npm:elysia@^1.2.22",
-    "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.0"
+    "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.1"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"],

--- a/packages/elysia/deno.json
+++ b/packages/elysia/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/elysia",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -13,12 +13,17 @@
     "./cookies": "./src/_core/cookies.ts",
     "./oauth": "./src/oauth/index.ts",
     "./oauth/atlassian": "./src/oauth/atlassian.ts",
+    "./oauth/authentik": "./src/oauth/authentik.ts",
     "./oauth/bitbucket": "./src/oauth/bitbucket.ts",
+    "./oauth/click-up": "./src/oauth/click-up.ts",
     "./oauth/discord": "./src/oauth/discord.ts",
+    "./oauth/dribbble": "./src/oauth/dribbble.ts",
     "./oauth/dropbox": "./src/oauth/dropbox.ts",
     "./oauth/figma": "./src/oauth/figma.ts",
     "./oauth/github": "./src/oauth/github.ts",
     "./oauth/gitlab": "./src/oauth/gitlab.ts",
+    "./oauth/google": "./src/oauth/google.ts",
+    "./oauth/hubspot": "./src/oauth/hubspot.ts",
     "./oauth/mailchimp": "./src/oauth/mailchimp.ts",
     "./oauth/notion": "./src/oauth/notion.ts",
     "./oauth/pinterest": "./src/oauth/pinterest.ts",
@@ -30,7 +35,7 @@
   "imports": {
     "@/": "./src/",
     "elysia": "npm:elysia@^1.2.22",
-    "@aura-stack/auth": "npm:@aura-stack/auth@^0.7.2"
+    "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.0"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"],

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/elysia",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "type": "module",
   "description": "Authentication integration for Elysia applications. Provides middleware, route handlers and session verification powered by Aura Auth.",

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/elysia",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "type": "module",
   "description": "Authentication integration for Elysia applications. Provides middleware, route handlers and session verification powered by Aura Auth.",

--- a/packages/express/CHANGELOG.md
+++ b/packages/express/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [0.2.1] - 2026-07-04
+
+### Fixed
+
+- Republished the package to include the missing `huggingface` OAuth provider in the published package.
+  > This release contains no code changes compared to `v0.2.0`; it only corrects the published package contents.
+
+---
+
 ## [0.2.0] - 2026-07-04
 
 ### Added

--- a/packages/express/CHANGELOG.md
+++ b/packages/express/CHANGELOG.md
@@ -8,9 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] - 2026-07-04
+
 ### Added
 
 - Introduced an experimental `signUp` flow for both the API and endpoint definitions. The new action enables user account creation within the authentication system and provides customizable payload validation through the supported schema. To enable this feature, developers must configure the `signUp` option when calling `createAuth`. [#183](https://github.com/aura-stack-ts/auth/pull/183)
+
+### Changed
+
+- Updated the `@aura-stack/auth` dependency to `v0.8.0`. [#211](https://github.com/aura-stack-ts/auth/pull/211)
 
 ---
 

--- a/packages/express/deno.json
+++ b/packages/express/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/express",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -13,12 +13,17 @@
     "./cookies": "./src/_core/cookies.ts",
     "./oauth": "./src/oauth/index.ts",
     "./oauth/atlassian": "./src/oauth/atlassian.ts",
+    "./oauth/authentik": "./src/oauth/authentik.ts",
     "./oauth/bitbucket": "./src/oauth/bitbucket.ts",
+    "./oauth/click-up": "./src/oauth/click-up.ts",
     "./oauth/discord": "./src/oauth/discord.ts",
+    "./oauth/dribbble": "./src/oauth/dribbble.ts",
     "./oauth/dropbox": "./src/oauth/dropbox.ts",
     "./oauth/figma": "./src/oauth/figma.ts",
     "./oauth/github": "./src/oauth/github.ts",
     "./oauth/gitlab": "./src/oauth/gitlab.ts",
+    "./oauth/google": "./src/oauth/google.ts",
+    "./oauth/hubspot": "./src/oauth/hubspot.ts",
     "./oauth/mailchimp": "./src/oauth/mailchimp.ts",
     "./oauth/notion": "./src/oauth/notion.ts",
     "./oauth/pinterest": "./src/oauth/pinterest.ts",
@@ -30,7 +35,7 @@
   "imports": {
     "@/": "./src/",
     "express": "npm:express@^4.18.2",
-    "@aura-stack/auth": "npm:@aura-stack/auth@^0.7.2"
+    "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.0"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]

--- a/packages/express/deno.json
+++ b/packages/express/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/express",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -24,6 +24,7 @@
     "./oauth/gitlab": "./src/oauth/gitlab.ts",
     "./oauth/google": "./src/oauth/google.ts",
     "./oauth/hubspot": "./src/oauth/hubspot.ts",
+    "./oauth/huggingface": "./src/oauth/huggingface.ts",
     "./oauth/mailchimp": "./src/oauth/mailchimp.ts",
     "./oauth/notion": "./src/oauth/notion.ts",
     "./oauth/pinterest": "./src/oauth/pinterest.ts",
@@ -35,7 +36,7 @@
   "imports": {
     "@/": "./src/",
     "express": "npm:express@^4.18.2",
-    "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.0"
+    "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.1"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/express",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "type": "module",
   "description": "Authentication integration for Express applications. Provides middleware, route handlers and session verification powered by Aura Auth.",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/express",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "type": "module",
   "description": "Authentication integration for Express applications. Provides middleware, route handlers and session verification powered by Aura Auth.",

--- a/packages/hono/CHANGELOG.md
+++ b/packages/hono/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [0.2.1] - 2026-07-04
+
+### Fixed
+
+- Republished the package to include the missing `huggingface` OAuth provider in the published package.
+  > This release contains no code changes compared to `v0.2.0`; it only corrects the published package contents.
+
+---
+
 ## [0.2.0] - 2026-07-04
 
 ### Added

--- a/packages/hono/CHANGELOG.md
+++ b/packages/hono/CHANGELOG.md
@@ -8,9 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] - 2026-07-04
+
 ### Added
 
 - Introduced an experimental `signUp` flow for both the API and endpoint definitions. The new action enables user account creation within the authentication system and provides customizable payload validation through the supported schema. To enable this feature, developers must configure the `signUp` option when calling `createAuth`. [#183](https://github.com/aura-stack-ts/auth/pull/183)
+
+### Changed
+
+- Updated the `@aura-stack/auth` dependency to `v0.8.0`. [#211](https://github.com/aura-stack-ts/auth/pull/211)
 
 ---
 

--- a/packages/hono/deno.json
+++ b/packages/hono/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/hono",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -24,6 +24,7 @@
     "./oauth/gitlab": "./src/oauth/gitlab.ts",
     "./oauth/google": "./src/oauth/google.ts",
     "./oauth/hubspot": "./src/oauth/hubspot.ts",
+    "./oauth/huggingface": "./src/oauth/huggingface.ts",
     "./oauth/mailchimp": "./src/oauth/mailchimp.ts",
     "./oauth/notion": "./src/oauth/notion.ts",
     "./oauth/pinterest": "./src/oauth/pinterest.ts",
@@ -35,7 +36,7 @@
   "imports": {
     "@/": "./src/",
     "hono": "npm:hono@^4.0.0",
-    "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.0"
+    "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.1"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]

--- a/packages/hono/deno.json
+++ b/packages/hono/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/hono",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -13,12 +13,17 @@
     "./cookies": "./src/_core/cookies.ts",
     "./oauth": "./src/oauth/index.ts",
     "./oauth/atlassian": "./src/oauth/atlassian.ts",
+    "./oauth/authentik": "./src/oauth/authentik.ts",
     "./oauth/bitbucket": "./src/oauth/bitbucket.ts",
+    "./oauth/click-up": "./src/oauth/click-up.ts",
     "./oauth/discord": "./src/oauth/discord.ts",
+    "./oauth/dribbble": "./src/oauth/dribbble.ts",
     "./oauth/dropbox": "./src/oauth/dropbox.ts",
     "./oauth/figma": "./src/oauth/figma.ts",
     "./oauth/github": "./src/oauth/github.ts",
     "./oauth/gitlab": "./src/oauth/gitlab.ts",
+    "./oauth/google": "./src/oauth/google.ts",
+    "./oauth/hubspot": "./src/oauth/hubspot.ts",
     "./oauth/mailchimp": "./src/oauth/mailchimp.ts",
     "./oauth/notion": "./src/oauth/notion.ts",
     "./oauth/pinterest": "./src/oauth/pinterest.ts",
@@ -30,7 +35,7 @@
   "imports": {
     "@/": "./src/",
     "hono": "npm:hono@^4.0.0",
-    "@aura-stack/auth": "npm:@aura-stack/auth@^0.7.2"
+    "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.0"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/hono",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "type": "module",
   "description": "Authentication integration for Hono applications. Provides middleware, route handlers and session verification powered by Aura Auth.",

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/hono",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "type": "module",
   "description": "Authentication integration for Hono applications. Provides middleware, route handlers and session verification powered by Aura Auth.",

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [0.2.1] - 2026-07-04
+
+### Fixed
+
+- Republished the package to include the missing `huggingface` OAuth provider in the published package.
+  > This release contains no code changes compared to `v0.2.0`; it only corrects the published package contents.
+
+---
+
 ## [0.2.0] - 2026-07-04
 
 ### Added

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -8,11 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] - 2026-07-04
+
 ### Added
 
 - Added a `useSignUp` hook for interacting with the mounted `POST /signUp` endpoint. It returns an object with `signUp` and `isPending` fields. [#184](https://github.com/aura-stack-ts/auth/pull/184)
 
 - Introduced an experimental `signUp` flow for both the API and endpoint definitions. The new action enables user account creation within the authentication system and provides customizable payload validation through the supported schema. To enable this feature, developers must configure the `signUp` option when calling `createAuth`. [#183](https://github.com/aura-stack-ts/auth/pull/183)
+
+### Changed
+
+- Updated the `@aura-stack/auth` dependency to `v0.8.0`. [#211](https://github.com/aura-stack-ts/auth/pull/211)
 
 ---
 

--- a/packages/next/deno.json
+++ b/packages/next/deno.json
@@ -1,10 +1,11 @@
 {
   "name": "@aura-stack/next",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",
     "./client": "./src/client.ts",
+    "./context": "./src/context.tsx",
     "./identity": "./src/_core/identity.ts",
     "./crypto": "./src/_core/crypto.ts",
     "./shared": "./src/_core/shared.ts",
@@ -15,12 +16,17 @@
     "./pages/context": "./src/pages/context.tsx",
     "./oauth": "./src/oauth/index.ts",
     "./oauth/atlassian": "./src/oauth/atlassian.ts",
+    "./oauth/authentik": "./src/oauth/authentik.ts",
     "./oauth/bitbucket": "./src/oauth/bitbucket.ts",
+    "./oauth/click-up": "./src/oauth/click-up.ts",
     "./oauth/discord": "./src/oauth/discord.ts",
+    "./oauth/dribbble": "./src/oauth/dribbble.ts",
     "./oauth/dropbox": "./src/oauth/dropbox.ts",
     "./oauth/figma": "./src/oauth/figma.ts",
     "./oauth/github": "./src/oauth/github.ts",
     "./oauth/gitlab": "./src/oauth/gitlab.ts",
+    "./oauth/google": "./src/oauth/google.ts",
+    "./oauth/hubspot": "./src/oauth/hubspot.ts",
     "./oauth/mailchimp": "./src/oauth/mailchimp.ts",
     "./oauth/notion": "./src/oauth/notion.ts",
     "./oauth/pinterest": "./src/oauth/pinterest.ts",
@@ -33,7 +39,7 @@
     "@/": "./src/",
     "next": "npm:next@16.1.6",
     "react": "npm:react@19.2.3",
-    "@aura-stack/react": "npm:@aura-stack/react@^0.1.0"
+    "@aura-stack/react": "npm:@aura-stack/react@^0.2.0"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/**/*.tsx", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]

--- a/packages/next/deno.json
+++ b/packages/next/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/next",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",
@@ -27,6 +27,7 @@
     "./oauth/gitlab": "./src/oauth/gitlab.ts",
     "./oauth/google": "./src/oauth/google.ts",
     "./oauth/hubspot": "./src/oauth/hubspot.ts",
+    "./oauth/huggingface": "./src/oauth/huggingface.ts",
     "./oauth/mailchimp": "./src/oauth/mailchimp.ts",
     "./oauth/notion": "./src/oauth/notion.ts",
     "./oauth/pinterest": "./src/oauth/pinterest.ts",
@@ -39,7 +40,7 @@
     "@/": "./src/",
     "next": "npm:next@16.1.6",
     "react": "npm:react@19.2.3",
-    "@aura-stack/react": "npm:@aura-stack/react@^0.2.0"
+    "@aura-stack/react": "npm:@aura-stack/react@^0.2.1"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/**/*.tsx", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/next",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "type": "module",
   "description": "Authentication integration for Next.js applications. Supports App Router, Server Components, Route Handlers and client-side authentication powered by Aura Auth.",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/next",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "type": "module",
   "description": "Authentication integration for Next.js applications. Supports App Router, Server Components, Route Handlers and client-side authentication powered by Aura Auth.",

--- a/packages/next/tsdown.config.ts
+++ b/packages/next/tsdown.config.ts
@@ -7,14 +7,17 @@ export default defineConfig({
     entry: [
         "src/index.ts",
         "src/client.ts",
+        "src/context.tsx",
         "src/oauth/index.ts",
         "src/oauth/*.ts",
         "src/_core/identity.ts",
         "src/_core/crypto.ts",
         "src/_core/shared.ts",
         "src/_core/cookies.ts",
-        "src/@types/index.ts",
         "src/pages/index.ts",
+        "src/pages/client.ts",
+        "src/pages/context.tsx",
+        "src/@types/index.ts",
     ],
     fixedExtension: false,
     deps: {

--- a/packages/rate-limiter/CHANGELOG.md
+++ b/packages/rate-limiter/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.1.0] - 2026-07-04
+
 ### Added
 
 - Added support for the `sliding-window` rate-limiter algorithm via the `createSlidingWindowAlgorithm` function. The function can be used standalone or integrated with the centralized `createRateLimiter` function. [#186](https://github.com/aura-stack-ts/auth/pull/186)

--- a/packages/rate-limiter/CHANGELOG.md
+++ b/packages/rate-limiter/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [0.1.1] - 2026-07-04
+
+### Fixed
+
+- Republished the package to correctly expose both the `/algorithms` entry point and individual `/algorithms/{algorithm}` entry points.
+  > This release contains no code changes compared to `v0.1.0`; it only fixes the published package exports.
+
+---
+
 ## [0.1.0] - 2026-07-04
 
 ### Added

--- a/packages/rate-limiter/deno.json
+++ b/packages/rate-limiter/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/rate-limiter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"

--- a/packages/rate-limiter/deno.json
+++ b/packages/rate-limiter/deno.json
@@ -1,17 +1,20 @@
 {
   "name": "@aura-stack/rate-limiter",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
   },
-  "export": {
+  "exports": {
     ".": "./src/index.ts",
     "./algorithms": "./src/algorithms/index.ts",
+    "./algorithms/fixed-window": "./src/algorithms/fixed-window.ts",
+    "./algorithms/leaky-bucket": "./src/algorithms/leaky-bucket.ts",
+    "./algorithms/sliding-window": "./src/algorithms/sliding-window.ts",
     "./algorithms/token-bucket": "./src/algorithms/token-bucket.ts",
-    "./types": "./src/@types/index.ts"
+    "./types": "./src/types.ts"
   },
-  "import": {
+  "imports": {
     "@/": "./src/"
   },
   "publish": {

--- a/packages/rate-limiter/package.json
+++ b/packages/rate-limiter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/rate-limiter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "type": "module",
   "description": "Rate limiting utilities for TypeScript and JavaScript applications with support for authentication flows powered by Aura Auth.",

--- a/packages/rate-limiter/package.json
+++ b/packages/rate-limiter/package.json
@@ -49,17 +49,17 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
-    "./types": "./dist/types.d.ts",
     "./algorithms": {
-      "types": "./dist/algorithms.d.ts",
-      "import": "./dist/algorithms.js",
-      "require": "./dist/algorithms.cjs"
+      "types": "./dist/algorithms/index.d.ts",
+      "import": "./dist/algorithms/index.js",
+      "require": "./dist/algorithms/index.cjs"
     },
     "./algorithms/*": {
       "types": "./dist/algorithms/*/index.d.ts",
       "import": "./dist/algorithms/*/index.js",
       "require": "./dist/algorithms/*/index.cjs"
-    }
+    },
+    "./types": "./dist/types.d.ts"
   },
   "author": "Aura Stack <aurastackjs@gmail.com> | Hernan Alvarado <halvaradop.dev@gmail.com>",
   "homepage": "https://aura-stack-auth.vercel.app",

--- a/packages/rate-limiter/package.json
+++ b/packages/rate-limiter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/rate-limiter",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": false,
   "type": "module",
   "description": "Rate limiting utilities for TypeScript and JavaScript applications with support for authentication flows powered by Aura Auth.",

--- a/packages/rate-limiter/tsdown.config.ts
+++ b/packages/rate-limiter/tsdown.config.ts
@@ -3,5 +3,5 @@ import { tsdownConfig } from "@aura-stack/tsdown-config"
 
 export default defineConfig({
     ...tsdownConfig,
-    entry: ["src/index.ts", "src/types.ts", "src/algorithms/index.ts"],
+    entry: ["src/index.ts", "src/algorithms/index.ts", "src/algorithms/*.ts", "src/types.ts"],
 })

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [0.2.1] - 2026-07-04
+
+### Fixed
+
+- Republished the package to include the missing `huggingface` OAuth provider in the published package.
+  > This release contains no code changes compared to `v0.2.0`; it only corrects the published package contents.
+
+---
+
 ## [0.2.0] - 2026-07-04
 
 ### Added

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -8,11 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] - 2026-07-04
+
 ### Added
 
 - Added a `useSignUp` hook for interacting with the mounted `POST /signUp` endpoint. It returns an object with `signUp` and `isPending` fields. [#184](https://github.com/aura-stack-ts/auth/pull/184)
 
 - Introduced an experimental `signUp` flow for both the API and endpoint definitions. The new action enables user account creation within the authentication system and provides customizable payload validation through the supported schema. To enable this feature, developers must configure the `signUp` option when calling `createAuth`. [#183](https://github.com/aura-stack-ts/auth/pull/183)
+
+### Changed
+
+- Updated the `@aura-stack/auth` dependency to `v0.8.0`. [#211](https://github.com/aura-stack-ts/auth/pull/211)
 
 ---
 

--- a/packages/react-router/deno.json
+++ b/packages/react-router/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/react-router",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -15,12 +15,17 @@
     "./types": "./src/@types/index.ts",
     "./oauth": "./src/oauth/index.ts",
     "./oauth/atlassian": "./src/oauth/atlassian.ts",
+    "./oauth/authentik": "./src/oauth/authentik.ts",
     "./oauth/bitbucket": "./src/oauth/bitbucket.ts",
+    "./oauth/click-up": "./src/oauth/click-up.ts",
     "./oauth/discord": "./src/oauth/discord.ts",
+    "./oauth/dribbble": "./src/oauth/dribbble.ts",
     "./oauth/dropbox": "./src/oauth/dropbox.ts",
     "./oauth/figma": "./src/oauth/figma.ts",
     "./oauth/github": "./src/oauth/github.ts",
     "./oauth/gitlab": "./src/oauth/gitlab.ts",
+    "./oauth/google": "./src/oauth/google.ts",
+    "./oauth/hubspot": "./src/oauth/hubspot.ts",
     "./oauth/mailchimp": "./src/oauth/mailchimp.ts",
     "./oauth/notion": "./src/oauth/notion.ts",
     "./oauth/pinterest": "./src/oauth/pinterest.ts",
@@ -33,7 +38,7 @@
     "@/": "./src/",
     "react": "npm:react@^19.2.3",
     "react-router": "npm:react-router@^7.12.0",
-    "@aura-stack/react": "npm:@aura-stack/react@^0.1.0"
+    "@aura-stack/react": "npm:@aura-stack/react@^0.2.0"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/**/*.tsx", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]

--- a/packages/react-router/deno.json
+++ b/packages/react-router/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/react-router",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -26,6 +26,7 @@
     "./oauth/gitlab": "./src/oauth/gitlab.ts",
     "./oauth/google": "./src/oauth/google.ts",
     "./oauth/hubspot": "./src/oauth/hubspot.ts",
+    "./oauth/huggingface": "./src/oauth/huggingface.ts",
     "./oauth/mailchimp": "./src/oauth/mailchimp.ts",
     "./oauth/notion": "./src/oauth/notion.ts",
     "./oauth/pinterest": "./src/oauth/pinterest.ts",
@@ -38,7 +39,7 @@
     "@/": "./src/",
     "react": "npm:react@^19.2.3",
     "react-router": "npm:react-router@^7.12.0",
-    "@aura-stack/react": "npm:@aura-stack/react@^0.2.0"
+    "@aura-stack/react": "npm:@aura-stack/react@^0.2.1"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/**/*.tsx", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/react-router",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "type": "module",
   "description": "Authentication integration for React Router applications with server-side rendering, route protection, session management and OAuth flows powered by Aura Auth.",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/react-router",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "type": "module",
   "description": "Authentication integration for React Router applications with server-side rendering, route protection, session management and OAuth flows powered by Aura Auth.",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [0.2.1] - 2026-07-04
+
+### Fixed
+
+- Republished the package to include the missing `huggingface` OAuth provider in the published package.
+  > This release contains no code changes compared to `v0.2.0`; it only corrects the published package contents.
+
+---
+
 ## [0.2.0] - 2026-07-04
 
 ### Added

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -8,11 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] - 2026-07-04
+
 ### Added
 
 - Added a `useSignUp` hook for interacting with the mounted `POST /signUp` endpoint. It returns an object with `signUp` and `isPending` fields. [#184](https://github.com/aura-stack-ts/auth/pull/184)
 
 - Introduced an experimental `signUp` flow for both the API and endpoint definitions. The new action enables user account creation within the authentication system and provides customizable payload validation through the supported schema. To enable this feature, developers must configure the `signUp` option when calling `createAuth`. [#183](https://github.com/aura-stack-ts/auth/pull/183)
+
+### Changed
+
+- Updated the `@aura-stack/auth` dependency to `v0.8.0`. [#211](https://github.com/aura-stack-ts/auth/pull/211)
 
 ---
 

--- a/packages/react/deno.json
+++ b/packages/react/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/react",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.tsx"
@@ -17,12 +17,17 @@
     "./types": "./src/@types/index.ts",
     "./oauth": "./src/oauth/index.ts",
     "./oauth/atlassian": "./src/oauth/atlassian.ts",
+    "./oauth/authentik": "./src/oauth/authentik.ts",
     "./oauth/bitbucket": "./src/oauth/bitbucket.ts",
+    "./oauth/click-up": "./src/oauth/click-up.ts",
     "./oauth/discord": "./src/oauth/discord.ts",
+    "./oauth/dribbble": "./src/oauth/dribbble.ts",
     "./oauth/dropbox": "./src/oauth/dropbox.ts",
     "./oauth/figma": "./src/oauth/figma.ts",
     "./oauth/github": "./src/oauth/github.ts",
     "./oauth/gitlab": "./src/oauth/gitlab.ts",
+    "./oauth/google": "./src/oauth/google.ts",
+    "./oauth/hubspot": "./src/oauth/hubspot.ts",
     "./oauth/mailchimp": "./src/oauth/mailchimp.ts",
     "./oauth/notion": "./src/oauth/notion.ts",
     "./oauth/pinterest": "./src/oauth/pinterest.ts",
@@ -34,7 +39,7 @@
   "imports": {
     "@/": "./src/",
     "react": "npm:react@^19.2.3",
-    "@aura-stack/auth": "npm:@aura-stack/auth@^0.7.2"
+    "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.0"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/**/*.tsx", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]

--- a/packages/react/deno.json
+++ b/packages/react/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/react",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.tsx"
@@ -28,6 +28,7 @@
     "./oauth/gitlab": "./src/oauth/gitlab.ts",
     "./oauth/google": "./src/oauth/google.ts",
     "./oauth/hubspot": "./src/oauth/hubspot.ts",
+    "./oauth/huggingface": "./src/oauth/huggingface.ts",
     "./oauth/mailchimp": "./src/oauth/mailchimp.ts",
     "./oauth/notion": "./src/oauth/notion.ts",
     "./oauth/pinterest": "./src/oauth/pinterest.ts",
@@ -39,7 +40,7 @@
   "imports": {
     "@/": "./src/",
     "react": "npm:react@^19.2.3",
-    "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.0"
+    "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.1"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/**/*.tsx", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/react",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "type": "module",
   "description": "React authentication utilities including providers, hooks and OAuth flows for client-side and hybrid applications powered by Aura Auth.",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/react",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "type": "module",
   "description": "React authentication utilities including providers, hooks and OAuth flows for client-side and hybrid applications powered by Aura Auth.",


### PR DESCRIPTION
## Description

This pull request publishes new releases of the packages to both npm and JSR registries:

- `@aura-stack/rate-limiter@0.1.0`
- `@aura-stack/auth@0.8.1`
- `@aura-stack/elysia@0.2.1`
- `@aura-stack/express@0.2.1`
- `@aura-stack/hono@0.2.1`
- `@aura-stack/react@0.2.1`
- `@aura-stack/react-router@0.2.1`
- `@aura-stack/next@0.2.1`  


### NPM

- https://www.npmjs.com/package/@aura-stack/rate-limiter
- https://www.npmjs.com/package/@aura-stack/auth
- https://www.npmjs.com/package/@aura-stack/elysia
- https://www.npmjs.com/package/@aura-stack/express
- https://www.npmjs.com/package/@aura-stack/hono
- https://www.npmjs.com/package/@aura-stack/react
- https://www.npmjs.com/package/@aura-stack/react-router
- https://www.npmjs.com/package/@aura-stack/next

### JSR
- https://jsr.io/@aura-stack/rate-limiter
- https://jsr.io/@aura-stack/auth
- https://jsr.io/@aura-stack/elysia
- https://jsr.io/@aura-stack/express
- https://jsr.io/@aura-stack/hono
- https://jsr.io/@aura-stack/react
- https://jsr.io/@aura-stack/react-router
- https://jsr.io/@aura-stack/next


@coderabbitai ignore