### PR TITLE
feat(react): introduce `useProviderTokens` hook

### DIFF
--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Re-exported `useProviderTokens()` from `@aura-stack/react`, making the hook available directly from this package. The hook exposes `getProviderTokens()` and `isPending` for retrieving provider `accessToken` and `refreshToken` values after a successful OAuth or OpenID Connect (OIDC) sign-in. [#214](https://github.com/aura-stack-ts/auth/pull/214)
+
 ---
 
 ## [0.2.1] - 2026-07-04

--- a/packages/next/src/client.ts
+++ b/packages/next/src/client.ts
@@ -9,6 +9,7 @@ export {
     useSignOut,
     useUpdateSession,
     useSignUp,
+    useProviderTokens,
     type AuthClientOptions,
     type AuthProviderProps,
 } from "@aura-stack/react"

--- a/packages/next/src/pages/client.ts
+++ b/packages/next/src/pages/client.ts
@@ -8,6 +8,7 @@ export {
     useSignInCredentials,
     useSignOut,
     useUpdateSession,
+    useProviderTokens,
     type AuthClientOptions,
     type AuthProviderProps,
 } from "@aura-stack/react"

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Re-exported `useProviderTokens()` from `@aura-stack/react`, making the hook available directly from this package. The hook exposes `getProviderTokens()` and `isPending` for retrieving provider `accessToken` and `refreshToken` values after a successful OAuth or OpenID Connect (OIDC) sign-in. [#214](https://github.com/aura-stack-ts/auth/pull/214)
+
 ---
 
 ## [0.2.1] - 2026-07-04

--- a/packages/react-router/src/client.tsx
+++ b/packages/react-router/src/client.tsx
@@ -7,6 +7,7 @@ export {
     useUpdateSession,
     useSignOut,
     useSignUp,
+    useProviderTokens,
     type AuthClientOptions,
 } from "@aura-stack/react"
 export { AuthProvider, type AuthProviderProps } from "@/context"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added the `useProviderTokens()` hook for retrieving the `accessToken` and `refreshToken` issued after a successful OAuth or OpenID Connect (OIDC) sign-in. The hook communicates with the `GET /providers/:oauth/tokens` endpoint and exposes `getProviderTokens()` and `isPending` for managing token retrieval. [#214](https://github.com/aura-stack-ts/auth/pull/214)
+
 ---
 
 ## [0.2.1] - 2026-07-04

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -15,6 +15,7 @@ import type {
     SignUpReturn,
     UpdateSessionOptions,
     UpdateSessionReturn,
+    GetProviderTokensReturn,
 } from "@aura-stack/auth/types"
 import type { Context } from "@/@types/types.ts"
 
@@ -304,6 +305,51 @@ export const useSignOut = () => {
     )
 
     return { signOut, isPending } as const
+}
+
+/**
+ * Fetches the provider tokens for a given OAuth provider.
+ *
+ * @returns An object containing the accessToken, refreshToken, and expiresIn values, along with a isPending state
+ * @example
+ * import { useEffect } from "react"
+ *
+ * const Page = () => {
+ *   const [songs, setSongs] = useState<string[]>([])
+ *   const { getProviderTokens, isPending } = useProviderTokens()
+ *
+ *   useEffect(() => {
+ *     const fetchTokens = async () => {
+ *       const { accessToken } = await getProviderTokens("spotify")
+ *
+ *       const response = await fetch("https://api.spotify.com/v1/me/top/tracks", {
+ *         headers: {
+ *           Authorization: `Bearer ${accessToken}`,
+ *         }
+ *       })
+ *       const data = await response.json()
+ *       setSongs(data.items.map((item: any) => item.name))
+ *     }
+ *
+ *     fetchTokens()
+ *   }, [])
+ * }
+ */
+export const useProviderTokens = () => {
+    const { client } = useAssertContext()
+    const { execute, isPending } = useAsyncAction()
+
+    const getProviderTokens = useCallback(
+        (oauth: LiteralUnion<BuiltInOAuthProvider>): Promise<GetProviderTokensReturn> => {
+            return execute(async () => {
+                const tokens = await client.getProviderTokens(oauth)
+                return tokens
+            })
+        },
+        [client, execute]
+    )
+
+    return { getProviderTokens, isPending } as const
 }
 
 /**

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -320,7 +320,9 @@ export const useSignOut = () => {
  *
  *   useEffect(() => {
  *     const fetchTokens = async () => {
- *       const { accessToken } = await getProviderTokens("spotify")
+ *       const { success, tokens } = await getProviderTokens("spotify")
+ *       if (!success || !tokens) return
+ *       const { accessToken } = tokens
  *
  *       const response = await fetch("https://api.spotify.com/v1/me/top/tracks", {
  *         headers: {

--- a/packages/react/test/hooks/presets.tsx
+++ b/packages/react/test/hooks/presets.tsx
@@ -2,9 +2,15 @@ import { vi } from "vitest"
 import { AuthProvider } from "@/context.tsx"
 import type { AuthClientInstance, AuthProviderProps } from "@/@types/types.ts"
 import type { Session, User } from "@aura-stack/auth"
+import type { OAuthTokenPayload } from "@aura-stack/auth/types"
 
 export const mockUser = { id: "1", email: "test@example.com", name: "Test User" } as unknown as User
 export const mockSession = { user: mockUser, expires: new Date(Date.now() + 3600 * 1000).toISOString() } as Session
+export const providerTokens = {
+    accessToken: "access_token",
+    refreshToken: "refresh_token",
+    expiresAt: Date.now(),
+} as OAuthTokenPayload
 
 export const createMockClient = () =>
     ({
@@ -17,6 +23,7 @@ export const createMockClient = () =>
             redirectURL: "/dashboard",
         }),
         signUp: vi.fn().mockResolvedValue({ redirectURL: "/welcome" }),
+        getProviderTokens: vi.fn().mockResolvedValue(providerTokens),
     }) as Partial<AuthClientInstance> as AuthClientInstance
 
 export const wrapper = ({ children, client, initialSession, redirect }: AuthProviderProps) => (

--- a/packages/react/test/hooks/useProviderTokens.test.tsx
+++ b/packages/react/test/hooks/useProviderTokens.test.tsx
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { act, render, renderHook, screen, waitFor } from "@testing-library/react"
+import { useProviderTokens } from "@/hooks.ts"
+import { createMockClient, mockSession, providerTokens, wrapper } from "@test/hooks/presets.tsx"
+import { userEvent } from "@testing-library/user-event"
+
+afterEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+})
+
+describe("useProviderTokens", () => {
+    test("useProviderTokens without AuthProvider should throw an error", () => {
+        expect(() => renderHook(() => useProviderTokens())).toThrow("Auth hooks must be used within an <AuthProvider>.")
+    })
+
+    test("successfully fetches provider tokens from the client", async () => {
+        const client = createMockClient()
+        client.getProviderTokens = vi.fn().mockResolvedValueOnce({
+            success: true,
+            tokens: providerTokens,
+        })
+
+        const { result } = renderHook(() => useProviderTokens(), {
+            wrapper: ({ children }) => wrapper({ children, client, initialSession: mockSession }),
+        })
+
+        let output
+        await act(async () => {
+            output = await result.current.getProviderTokens("github")
+        })
+
+        expect(client.getProviderTokens).toHaveBeenCalledWith("github")
+        expect(output).toEqual({
+            success: true,
+            tokens: providerTokens,
+        })
+    })
+
+    test("handles client token fetching errors gracefully", async () => {
+        const client = createMockClient()
+        client.getProviderTokens = vi.fn().mockRejectedValueOnce(new Error("Failed to fetch provider tokens"))
+
+        const { result } = renderHook(() => useProviderTokens(), {
+            wrapper: ({ children }) => wrapper({ children, client, initialSession: mockSession }),
+        })
+
+        await act(async () => {
+            await expect(result.current.getProviderTokens("google")).rejects.toThrow("Failed to fetch provider tokens")
+        })
+    })
+
+    test("getProviderTokens with isPending state tracking", async () => {
+        const client = createMockClient()
+        client.getProviderTokens = vi.fn().mockImplementation(() => {
+            return new Promise((resolve) =>
+                setTimeout(
+                    () =>
+                        resolve({
+                            success: true,
+                            tokens: providerTokens,
+                        }),
+                    100
+                )
+            )
+        })
+
+        const { result } = renderHook(() => useProviderTokens(), {
+            wrapper: ({ children }) => wrapper({ children, client, initialSession: mockSession }),
+        })
+
+        const call = result.current.getProviderTokens("github")
+
+        await waitFor(() => {
+            expect(result.current.isPending).toBe(true)
+        })
+
+        await act(async () => {
+            await call
+        })
+
+        expect(result.current.isPending).toBe(false)
+    })
+
+    test("render disabled action layout element when fetching tokens is pending", async () => {
+        const user = userEvent.setup()
+
+        const client = createMockClient()
+        client.getProviderTokens = vi.fn().mockImplementation(() => {
+            return new Promise((resolve) => {
+                setTimeout(
+                    () =>
+                        resolve({
+                            success: true,
+                            tokens: providerTokens,
+                        }),
+                    100
+                )
+            })
+        })
+
+        const TokenViewer = () => {
+            const { getProviderTokens, isPending } = useProviderTokens()
+
+            return (
+                <div>
+                    <button disabled={isPending} onClick={() => getProviderTokens("github")}>
+                        {isPending ? "Loading Tokens..." : "Load Github Tokens"}
+                    </button>
+                </div>
+            )
+        }
+
+        render(<TokenViewer />, {
+            wrapper: ({ children }) => wrapper({ children, client, initialSession: mockSession }),
+        })
+
+        const button = screen.getByRole("button", { name: "Load Github Tokens" })
+        await user.click(button)
+
+        expect(screen.getByRole("button", { name: "Loading Tokens..." })).toBeDefined()
+    })
+})

--- a/packages/react/test/hooks/useProviderTokens.test.tsx
+++ b/packages/react/test/hooks/useProviderTokens.test.tsx
@@ -118,6 +118,8 @@ describe("useProviderTokens", () => {
         const button = screen.getByRole("button", { name: "Load Github Tokens" })
         await user.click(button)
 
-        expect(screen.getByRole("button", { name: "Loading Tokens..." })).toBeDefined()
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: "Loading Tokens..." })).toBeDefined()
+        })
     })
 })


### PR DESCRIPTION
## Description

This pull request introduces the `useProviderTokens` hook to the `@aura-stack/react` package.

The hook provides a React-friendly interface for the `getProviderTokens()` client function exposed by `createAuthClient()`, allowing applications to retrieve OAuth or OpenID Connect (OIDC) provider tokens after a successful sign-in.

Internally, the hook interacts with the mounted `GET /providers/:oauth/tokens` endpoint and returns the provider's credentials, including the access token and refresh token (when available). This enables React applications to seamlessly access third-party APIs on behalf of authenticated users.


### Related PRs
- #213 
- #212 

@coderabbitai ignore