### PR TITLE
feat: add `api.getProviderTokens` to Next.js and React Router

### DIFF
--- a/packages/core/src/api/getProviderTokens.ts
+++ b/packages/core/src/api/getProviderTokens.ts
@@ -4,7 +4,7 @@ import { fetchAsync } from "@/shared/fetch-async.ts"
 import { secureApiHeaders } from "@/shared/headers.ts"
 import { verifyRateLimit } from "@/router/rate-limiter.ts"
 import { getBaseURL, getOriginURL } from "@/actions/signIn/authorization.ts"
-import { shouldRefresh, toUnionHeaders, verifyCSRFToken } from "@/shared/utils.ts"
+import { shouldRefresh, toUnionHeaders, verifyCSRFToken, verifySessionToken } from "@/shared/utils.ts"
 import { AuraAuthError, isAuraAuthError } from "@/shared/errors.ts"
 import type { LiteralUnion } from "@/@types/utility.ts"
 import type { OAuthTokenPayload } from "@/@types/session.ts"
@@ -68,6 +68,13 @@ export const getProviderTokens = async (
             throw new AuraAuthError({ code: "UNSUPPORTED_OAUTH_CONFIGURATION" })
         }
         const headers = new Headers(headersInit ?? requestInit?.headers)
+        await verifySessionToken({
+            headers,
+            cookies,
+            jwt: ctx.jwtManager,
+            logger: ctx.logger,
+        })
+
         await verifyCSRFToken({
             headers,
             cookies,

--- a/packages/core/test/actions/tokens/tokens.test.ts
+++ b/packages/core/test/actions/tokens/tokens.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi, afterEach, beforeEach } from "vitest"
 import { createAuth } from "@/createAuth.ts"
 import { createCSRF } from "@/shared/crypto.ts"
-import { GET, jose, oauthCustomService, oauthTokens } from "@test/presets.ts"
+import { GET, jose, oauthCustomService, oauthTokens, sessionPayload } from "@test/presets.ts"
 
 beforeEach(() => {
     vi.stubEnv("BASE_URL", undefined)
@@ -13,7 +13,7 @@ afterEach(() => {
     vi.unstubAllGlobals()
 })
 
-describe("tokensAction", () => {
+describe("tokensAction", async () => {
     const { encodeJWT } = jose
 
     test("should return 422 if the provider is not supported", async () => {
@@ -32,8 +32,23 @@ describe("tokensAction", () => {
         })
     })
 
-    test("should return 403 if CSRF token is missing", async () => {
+    test("should return 403 if session token is missing", async () => {
         const response = await GET(new Request("https://example.com/auth/providers/oauth-provider/tokens"))
+        expect(response.status).toBe(401)
+        expect(await response.json()).toEqual({
+            success: false,
+            tokens: null,
+        })
+    })
+
+    test("should return 403 if CSRF token is missing", async () => {
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const response = await GET(
+            new Request("https://example.com/auth/providers/oauth-provider/tokens", {
+                headers: { Cookie: `__Secure-aura-auth.session_token=${sessionToken}` },
+            })
+        )
         expect(response.status).toBe(403)
         expect(await response.json()).toEqual({
             success: false,
@@ -42,10 +57,13 @@ describe("tokensAction", () => {
     })
 
     test("should return 403 if CSRF token is invalid", async () => {
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
         const response = await GET(
             new Request("https://example.com/auth/providers/oauth-provider/tokens", {
                 headers: {
                     "x-csrf-token": "invalid-token",
+                    Cookie: `__Secure-aura-auth.session_token=${sessionToken}`,
                 },
             })
         )
@@ -58,12 +76,13 @@ describe("tokensAction", () => {
 
     test("should return 403 if provider token doesn not exist", async () => {
         const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
 
         const response = await GET(
             new Request("https://example.com/auth/providers/oauth-provider/tokens", {
                 headers: {
                     "X-CSRF-Token": csrfToken,
-                    Cookie: `__Secure-aura-auth.csrf_token=${csrfToken}`,
+                    Cookie: `__Secure-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.session_token=${sessionToken}`,
                 },
             })
         )
@@ -77,12 +96,13 @@ describe("tokensAction", () => {
     test("successfully get provider tokens", async () => {
         const csrfToken = await createCSRF(jose)
         const encodedTokens = await encodeJWT(oauthTokens as unknown as Record<string, unknown>)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
 
         const response = await GET(
             new Request("https://example.com/auth/providers/oauth-provider/tokens", {
                 headers: {
                     "X-CSRF-Token": csrfToken,
-                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}; __Secure-aura-auth.session_token=${sessionToken}`,
                 },
             })
         )
@@ -95,6 +115,7 @@ describe("tokensAction", () => {
 
     test("refreshToken config not provided", async () => {
         const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
 
         const encodedTokens = await jose.encodeJWT({
             ...oauthTokens,
@@ -110,7 +131,7 @@ describe("tokensAction", () => {
             new Request("https://example.com/auth/providers/oauth-provider/tokens", {
                 headers: {
                     "X-CSRF-Token": csrfToken,
-                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}; __Secure-aura-auth.session_token=${sessionToken}`,
                 },
             })
         )
@@ -124,6 +145,7 @@ describe("tokensAction", () => {
 
     test("refreshToken successfully refreshes tokens", async () => {
         const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
 
         const mockFetch = vi.fn().mockResolvedValueOnce({
             ok: true,
@@ -140,7 +162,7 @@ describe("tokensAction", () => {
             new Request("https://example.com/auth/providers/oauth-provider/tokens", {
                 headers: {
                     "X-CSRF-Token": csrfToken,
-                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}; __Secure-aura-auth.session_token=${sessionToken}`,
                 },
             })
         )
@@ -151,6 +173,7 @@ describe("tokensAction", () => {
             tokens: {
                 ...oauthTokens,
                 expiresAt: expect.any(Number),
+                issuedAt: expect.any(Number),
             },
         })
 
@@ -169,6 +192,7 @@ describe("tokensAction", () => {
 
     test("refreshToken fails when OAuth provider returns an error", async () => {
         const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
 
         const mockFetch = vi.fn().mockResolvedValueOnce({
             ok: false,
@@ -186,7 +210,7 @@ describe("tokensAction", () => {
             new Request("https://example.com/auth/providers/oauth-provider/tokens", {
                 headers: {
                     "X-CSRF-Token": csrfToken,
-                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}; __Secure-aura-auth.session_token=${sessionToken}`,
                 },
             })
         )
@@ -200,7 +224,7 @@ describe("tokensAction", () => {
 
     test("refreshToken handles unexpected network exceptions gracefully", async () => {
         const csrfToken = await createCSRF(jose)
-
+        const sessionToken = await jose.encodeJWT(sessionPayload)
         const mockFetch = vi.fn().mockRejectedValueOnce(new Error("Network connection lost"))
         vi.stubGlobal("fetch", mockFetch)
 
@@ -213,7 +237,7 @@ describe("tokensAction", () => {
             new Request("https://example.com/auth/providers/oauth-provider/tokens", {
                 headers: {
                     "X-CSRF-Token": csrfToken,
-                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}; __Secure-aura-auth.session_token=${sessionToken}`,
                 },
             })
         )
@@ -227,6 +251,7 @@ describe("tokensAction", () => {
 
     test("returns current tokens without refreshing when close to expiry but outside the refresh window", async () => {
         const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
 
         const mockFetch = vi.fn()
         vi.stubGlobal("fetch", mockFetch)
@@ -242,7 +267,7 @@ describe("tokensAction", () => {
             new Request("https://example.com/auth/providers/oauth-provider/tokens", {
                 headers: {
                     "X-CSRF-Token": csrfToken,
-                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}; __Secure-aura-auth.session_token=${sessionToken}`,
                 },
             })
         )
@@ -260,7 +285,7 @@ describe("tokensAction", () => {
 
     test("automatically refreshes the token when its lifetime falls inside the refresh window", async () => {
         const csrfToken = await createCSRF(jose)
-
+        const sessionToken = await jose.encodeJWT(sessionPayload)
         const mockFetch = vi.fn().mockResolvedValueOnce({
             ok: true,
             json: async () => ({
@@ -282,7 +307,7 @@ describe("tokensAction", () => {
             new Request("https://example.com/auth/providers/oauth-provider/tokens", {
                 headers: {
                     "X-CSRF-Token": csrfToken,
-                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}; __Secure-aura-auth.session_token=${sessionToken}`,
                 },
             })
         )
@@ -293,6 +318,7 @@ describe("tokensAction", () => {
             tokens: {
                 ...oauthTokens,
                 accessToken: "brand-new-refreshed-token",
+                issuedAt: expect.any(Number),
                 expiresAt: expect.any(Number),
             },
         })

--- a/packages/core/test/actions/tokens/tokens.test.ts
+++ b/packages/core/test/actions/tokens/tokens.test.ts
@@ -32,7 +32,7 @@ describe("tokensAction", async () => {
         })
     })
 
-    test("should return 403 if session token is missing", async () => {
+    test("should return 401 if session token is missing", async () => {
         const response = await GET(new Request("https://example.com/auth/providers/oauth-provider/tokens"))
         expect(response.status).toBe(401)
         expect(await response.json()).toEqual({

--- a/packages/core/test/api/getProviderTokens.test.ts
+++ b/packages/core/test/api/getProviderTokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest"
-import { api, jose, oauthCustomService, oauthTokens } from "@test/presets.ts"
+import { api, jose, oauthCustomService, oauthTokens, sessionPayload } from "@test/presets.ts"
 import { createCSRF } from "@/shared/crypto.ts"
 import { createAuth } from "@/createAuth.ts"
 
@@ -26,8 +26,28 @@ describe("getProviderTokens API", () => {
         })
     })
 
-    test("throws error when CSRF token is missing", async () => {
+    test("throws error when session token is missing", async () => {
         const output = await api.getProviderTokens("oauth-provider", { headers: new Headers() })
+        expect(output).toEqual({
+            success: false,
+            tokens: null,
+            error: {
+                code: "SESSION_NOT_FOUND",
+                message: "The session token is not found. There is no active session.",
+            },
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+    })
+
+    test("throws error when CSRF token is missing", async () => {
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const output = await api.getProviderTokens("oauth-provider", {
+            headers: {
+                Cookie: `aura-auth.session_token=${sessionToken}`,
+            },
+        })
         expect(output).toEqual({
             success: false,
             tokens: null,
@@ -42,10 +62,11 @@ describe("getProviderTokens API", () => {
 
     test("throws error when CSRF token is invalid", async () => {
         vi.stubEnv("BASE_URL", "https://example.com")
+        const sessionToken = await jose.encodeJWT(sessionPayload)
 
         const output = await api.getProviderTokens("oauth-provider", {
             headers: new Headers({
-                Cookie: "aura-auth.csrf_token=invalid-token",
+                Cookie: `aura-auth.csrf_token=invalid-token; aura-auth.session_token=${sessionToken}`,
                 "X-CSRF-Token": "invalid-token",
             }),
         })
@@ -64,11 +85,12 @@ describe("getProviderTokens API", () => {
     test("throws error when provider token does not exist", async () => {
         vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
 
         const output = await api.getProviderTokens("oauth-provider", {
             headers: {
                 "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}`,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}`,
             },
         })
         expect(output).toEqual({
@@ -86,13 +108,14 @@ describe("getProviderTokens API", () => {
     test("successfully gets provider tokens", async () => {
         vi.stubEnv("BASE_URL", "http://localhost:3000")
         const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
 
         const encodedTokens = await jose.encodeJWT(oauthTokens as unknown as Record<string, unknown>)
 
         const output = await api.getProviderTokens("oauth-provider", {
             headers: {
                 "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
             },
         })
         expect(output).toEqual({
@@ -106,6 +129,7 @@ describe("getProviderTokens API", () => {
     test("refreshToken config not provided", async () => {
         vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
 
         const encodedTokens = await jose.encodeJWT({
             ...oauthTokens,
@@ -118,7 +142,7 @@ describe("getProviderTokens API", () => {
         const output = await api.getProviderTokens("oauth-provider", {
             headers: {
                 "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
             },
         })
         expect(output).toEqual({
@@ -137,6 +161,7 @@ describe("getProviderTokens API", () => {
     test("refreshToken successfully refreshes tokens", async () => {
         vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
 
         const mockFetch = vi.fn()
 
@@ -155,7 +180,7 @@ describe("getProviderTokens API", () => {
         const output = await api.getProviderTokens("oauth-provider", {
             headers: {
                 "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
             },
         })
         expect(output).toEqual({
@@ -163,6 +188,7 @@ describe("getProviderTokens API", () => {
             tokens: {
                 ...oauthTokens,
                 expiresAt: expect.any(Number),
+                issuedAt: expect.any(Number),
             },
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
@@ -184,6 +210,7 @@ describe("getProviderTokens API", () => {
     test("refreshToken fails when OAuth provider returns an error", async () => {
         vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
 
         const mockFetch = vi.fn().mockResolvedValueOnce({
             ok: false,
@@ -200,7 +227,7 @@ describe("getProviderTokens API", () => {
         const output = await api.getProviderTokens("oauth-provider", {
             headers: {
                 "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
             },
         })
 
@@ -219,6 +246,7 @@ describe("getProviderTokens API", () => {
     test("refreshToken handles unexpected network exceptions gracefully", async () => {
         vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
 
         const mockFetch = vi.fn().mockRejectedValueOnce(new Error("Network connection lost"))
         vi.stubGlobal("fetch", mockFetch)
@@ -231,7 +259,7 @@ describe("getProviderTokens API", () => {
         const output = await api.getProviderTokens("oauth-provider", {
             headers: {
                 "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
             },
         })
 
@@ -250,7 +278,7 @@ describe("getProviderTokens API", () => {
     test("returns current tokens without refreshing when close to expiry but outside the refresh window", async () => {
         vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
-
+        const sessionToken = await jose.encodeJWT(sessionPayload)
         const mockFetch = vi.fn()
         vi.stubGlobal("fetch", mockFetch)
 
@@ -264,7 +292,7 @@ describe("getProviderTokens API", () => {
         const output = await api.getProviderTokens("oauth-provider", {
             headers: {
                 "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
             },
         })
 
@@ -283,6 +311,7 @@ describe("getProviderTokens API", () => {
     test("automatically refreshes the token when its lifetime falls inside the refresh window", async () => {
         vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
 
         const mockFetch = vi.fn().mockResolvedValueOnce({
             ok: true,
@@ -304,7 +333,7 @@ describe("getProviderTokens API", () => {
         const output = await api.getProviderTokens("oauth-provider", {
             headers: {
                 "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
             },
         })
 
@@ -314,6 +343,7 @@ describe("getProviderTokens API", () => {
                 ...oauthTokens,
                 accessToken: "brand-new-refreshed-token",
                 expiresAt: expect.any(Number),
+                issuedAt: expect.any(Number),
             },
             headers: expect.any(Headers),
             toResponse: expect.any(Function),

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the `api.getProviderTokens()` API with built-in support for automatically forwarding request headers via the `headers()` function from `next/headers`, simplifying server-side usage in Next.js applications. [#215](https://github.com/aura-stack-ts/auth/pull/215)
+
 - Re-exported `useProviderTokens()` from `@aura-stack/react`, making the hook available directly from this package. The hook exposes `getProviderTokens()` and `isPending` for retrieving provider `accessToken` and `refreshToken` values after a successful OAuth or OpenID Connect (OIDC) sign-in. [#214](https://github.com/aura-stack-ts/auth/pull/214)
 
 ---

--- a/packages/next/src/lib/api.ts
+++ b/packages/next/src/lib/api.ts
@@ -101,6 +101,12 @@ export const updateSession = <DefaultUser extends User = User>({ api }: AuthInst
     }
 }
 
+export const getProviderTokens = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
+    return async (oauth: LiteralUnion<BuiltInOAuthProvider>) => {
+        return await api.getProviderTokens(oauth, { headers: await headers() })
+    }
+}
+
 export const signOut = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
     return async <Options extends SignOutAPIOptions>(options?: Partial<Options>): Promise<NextSignOutReturn<Options>> => {
         const out = await api.signOut({
@@ -184,6 +190,20 @@ export const api = <DefaultUser extends User = User>(config: AuthInstance<Defaul
          * })
          */
         updateSession: updateSession<DefaultUser>(config),
+        /**
+         * Retrieves the OAuth provider tokens for the current session on the server-side. It allows access to the
+         * provider's access and refresh tokens, which can be used for making authenticated requests to the provider's API.
+         *
+         * @params options - Options for the API call, including headers to verify `session_token` cookie.
+         * @returns The object returned by the API call {@link GetProviderTokensAPIReturn}
+         * @example
+         * import { headers } from "next/headers"
+         *
+         * const response = await api.getProviderTokens("github", {
+         *   headers: await headers()
+         * })
+         */
+        getProviderTokens: getProviderTokens<DefaultUser>(config),
         /**
          * Signs out the current session on the server-side. It implements CSRF Protection by default, for
          * server-side calls it only verifies and validates the CSRF Token, it also provides Double-Submit

--- a/packages/next/src/lib/api.ts
+++ b/packages/next/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
     LiteralUnion,
     BuiltInOAuthProvider,
     SignInCredentialsAPIOptions,
+    GetProviderTokensAPIOptions,
 } from "@aura-stack/react/types"
 
 /**
@@ -102,8 +103,8 @@ export const updateSession = <DefaultUser extends User = User>({ api }: AuthInst
 }
 
 export const getProviderTokens = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async (oauth: LiteralUnion<BuiltInOAuthProvider>) => {
-        return await api.getProviderTokens(oauth, { headers: await headers() })
+    return async (oauth: LiteralUnion<BuiltInOAuthProvider>, options?: GetProviderTokensAPIOptions) => {
+        return await api.getProviderTokens(oauth, { headers: await headers(), ...options })
     }
 }
 

--- a/packages/next/test/app-router/api/getProviderTokens.test.ts
+++ b/packages/next/test/app-router/api/getProviderTokens.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test, vi, beforeEach } from "vitest"
+
+const { mockRedirect, mockHeaders, mockCookiesSet } = vi.hoisted(() => ({
+    mockRedirect: vi.fn(),
+    mockHeaders: vi.fn(),
+    mockCookiesSet: vi.fn(),
+}))
+
+vi.mock("next/navigation", () => ({
+    redirect: mockRedirect,
+}))
+
+vi.mock("next/headers", () => ({
+    headers: mockHeaders,
+    cookies: () =>
+        Promise.resolve({
+            set: mockCookiesSet,
+        }),
+}))
+
+import { getProviderTokens } from "@/lib/api"
+import type { AuthInstance } from "@aura-stack/react"
+
+const makeAuth = (apiOverrides: Partial<AuthInstance["api"]> = {}): AuthInstance => {
+    return {
+        api: {
+            getSession: vi.fn().mockResolvedValue({ success: false }),
+            signIn: vi.fn().mockResolvedValue({ success: false }),
+            signInCredentials: vi.fn().mockResolvedValue({
+                success: false,
+                redirectURL: null,
+                headers: new Headers(),
+            }),
+            updateSession: vi.fn().mockResolvedValue({
+                success: false,
+                session: null,
+                redirectURL: null,
+                headers: new Headers(),
+            }),
+            signOut: vi.fn().mockResolvedValue({
+                success: false,
+                redirectURL: null,
+                headers: new Headers(),
+            }),
+            ...apiOverrides,
+        },
+    } as unknown as AuthInstance
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    mockHeaders.mockResolvedValue(new Headers())
+})
+
+describe("getProviderTokens", () => {
+    test("returns success: false when the API reports failure", async () => {
+        const auth = makeAuth({
+            getProviderTokens: vi.fn().mockResolvedValue({ success: false }),
+        })
+
+        const output = await getProviderTokens(auth)("github")
+        expect(output).toEqual({ success: false })
+    })
+
+    test("returns success: true and tokens when the API reports success", async () => {
+        const auth = makeAuth({
+            getProviderTokens: vi.fn().mockResolvedValue({
+                success: true,
+                tokens: { accessToken: "abc123", refreshToken: "def456" },
+            }),
+        })
+
+        const output = await getProviderTokens(auth)("github")
+        expect(output).toEqual({
+            success: true,
+            tokens: { accessToken: "abc123", refreshToken: "def456" },
+        })
+    })
+
+    test("calls getProviderTokens with headers from next/headers", async () => {
+        const mock = vi.fn().mockResolvedValue({
+            success: true,
+            tokens: {
+                accessToken: "abc123",
+                refreshToken: "def456",
+            },
+        })
+        const auth = makeAuth({
+            getProviderTokens: mock,
+        })
+        const headers = new Headers({ "x-custom-header": "value" })
+        mockHeaders.mockResolvedValue(headers)
+
+        await getProviderTokens(auth)("github")
+        expect(mock).toHaveBeenCalledWith("github", { headers })
+    })
+})

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the `api.getProviderTokens()` API to retrieve provider `accessToken` and `refreshToken` values after a successful OAuth or OpenID Connect (OIDC) sign-in. [#215](https://github.com/aura-stack-ts/auth/pull/215)
+
 - Re-exported `useProviderTokens()` from `@aura-stack/react`, making the hook available directly from this package. The hook exposes `getProviderTokens()` and `isPending` for retrieving provider `accessToken` and `refreshToken` values after a successful OAuth or OpenID Connect (OIDC) sign-in. [#214](https://github.com/aura-stack-ts/auth/pull/214)
 
 ---

--- a/packages/react-router/src/@types/api.ts
+++ b/packages/react-router/src/@types/api.ts
@@ -16,6 +16,7 @@ import type {
     UpdateSessionOptions,
     User,
     Session,
+    GetProviderTokensAPIReturn,
 } from "@aura-stack/react/types"
 import type { BuiltInOAuthProvider, LiteralUnion } from "@aura-stack/react/types"
 
@@ -87,5 +88,6 @@ export interface ReactRouterAPI<DefaultUser extends User = User> {
     updateSession: <Options extends ReactRouterUpdateSessionAPIOptions<DefaultUser>>(
         options: Options
     ) => Promise<ReactRouterUpdateSessionReturn<Options, DefaultUser>>
+    getProviderTokens: (oauth: LiteralUnion<BuiltInOAuthProvider>) => Promise<GetProviderTokensAPIReturn>
     signOut: <Options extends ReactRouterSignOutAPIOptions>(options: Options) => Promise<ReactRouterSignOutReturn<Options>>
 }

--- a/packages/react-router/src/lib/api.ts
+++ b/packages/react-router/src/lib/api.ts
@@ -10,7 +10,12 @@ import type {
     ReactRouterUpdateSessionAPIOptions,
 } from "@/@types/api"
 import type { AuthInstance, Session, User } from "@aura-stack/react"
-import type { BuiltInOAuthProvider, GetSessionAPIOptions, LiteralUnion } from "@aura-stack/react/types"
+import type {
+    BuiltInOAuthProvider,
+    GetProviderTokensAPIReturn,
+    GetSessionAPIOptions,
+    LiteralUnion,
+} from "@aura-stack/react/types"
 
 export const getSession = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
     return async (options: GetSessionAPIOptions): Promise<Session<DefaultUser> | null> => {
@@ -64,6 +69,12 @@ export const updateSession = <DefaultUser extends User = User>({ api }: AuthInst
             return updated as ReactRouterUpdateSessionReturn<Options, DefaultUser>
         }
         return updated.toResponse() as ReactRouterUpdateSessionReturn<Options, DefaultUser>
+    }
+}
+
+export const getProviderTokens = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
+    return async (oauth: LiteralUnion<BuiltInOAuthProvider>): Promise<GetProviderTokensAPIReturn> => {
+        return await api.getProviderTokens(oauth)
     }
 }
 
@@ -162,6 +173,22 @@ export const api = <DefaultUser extends User = User>(config: AuthInstance<Defaul
          * }
          */
         updateSession: updateSession<DefaultUser>(config),
+        /**
+         * Retrieves the OAuth provider tokens for the current session on the server-side. It allows access to the
+         * provider's access and refresh tokens, which can be used for making authenticated requests to the provider's API.
+         *
+         * @params options - Options for the API call, including headers to verify `session_token` cookie.
+         * @returns The object returned by the API call {@link GetProviderTokensAPIReturn}
+         * @example
+         * export const loader = async ({ request }) => {
+         *   return await api.getProviderTokens("github", {
+         *     request,
+         *     headers: request.headers
+         *   })
+         * }
+         *
+         */
+        getProviderTokens: getProviderTokens<DefaultUser>(config),
         /**
          * Signs out the current session on the server-side. It implements CSRF Protection by default, for
          * server-side calls it only verifies and validates the CSRF Token, it also provides Double-Submit

--- a/packages/react-router/src/lib/api.ts
+++ b/packages/react-router/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
 import type { AuthInstance, Session, User } from "@aura-stack/react"
 import type {
     BuiltInOAuthProvider,
+    GetProviderTokensAPIOptions,
     GetProviderTokensAPIReturn,
     GetSessionAPIOptions,
     LiteralUnion,
@@ -73,8 +74,11 @@ export const updateSession = <DefaultUser extends User = User>({ api }: AuthInst
 }
 
 export const getProviderTokens = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
-    return async (oauth: LiteralUnion<BuiltInOAuthProvider>): Promise<GetProviderTokensAPIReturn> => {
-        return await api.getProviderTokens(oauth)
+    return async (
+        oauth: LiteralUnion<BuiltInOAuthProvider>,
+        options?: GetProviderTokensAPIOptions
+    ): Promise<GetProviderTokensAPIReturn> => {
+        return await api.getProviderTokens(oauth, options)
     }
 }
 


### PR DESCRIPTION
## Description

This pull request adds support for `api.getProviderTokens()` to the dedicated Next.js and React Router packages.

The implementation was missing from the framework-specific packages when `getProviderTokens()` was introduced in previous PRs. This change brings feature parity across the Aura Auth ecosystem by exposing the API through the framework integrations.

Additionally, this PR fixes a security issue in the provider token retrieval flow. Previously, `getProviderTokens()` did not verify that the requester had an active authenticated session before returning provider credentials. The API now requires a valid active session before access tokens or refresh tokens can be retrieved.

### Key Changes

* Added `api.getProviderTokens()` support to the Next.js package.
* Added `api.getProviderTokens()` support to the React Router package.
* Restored feature parity with the core `@aura-stack/auth` package.
* Added session validation before returning provider tokens.
* Prevented unauthenticated access to provider credentials.

> [!NOTE]
> The framework-specific implementations are built on top of the core APIs provided by `@aura-stack/auth`. For example, the Next.js integration automatically uses the `headers()` function to retrieve request headers, so developers do not need to provide them manually when calling `api.getProviderTokens()`.


@coderabbitai ignore
