### PR TITLE
chore(release): bump package versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,9 @@ worker-configuration.d.ts
 # Packages
 packages/**/_core
 packages/**/oauth
+packages/**/identity
 
 !packages/core/src/oauth/
 !packages/core/src/oauth/**
+!packages/core/src/identity/
+!packages/core/src/identity/**

--- a/packages/elysia/CHANGELOG.md
+++ b/packages/elysia/CHANGELOG.md
@@ -8,9 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.2.2] - 2026-07-07
+
 ### Fixed
 
-- Fixed type inference for the `signUp.schema` configuration. Sign-up schema types are now inferred correctly throughout the authentication fl
+- Fixed type inference for the `signUp.schema` configuration. Sign-up schema types are now inferred correctly throughout the authentication flow. [#216](https://github.com/aura-stack-ts/auth/pull/216)
 
 ---
 

--- a/packages/elysia/deno.json
+++ b/packages/elysia/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/elysia",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -43,7 +43,7 @@
     "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.1"
   },
   "publish": {
-    "include": ["src/**/*.ts", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"],
+    "include": ["src/**/*.ts", "src/_core", "src/oauth", "src/identity", "README.md", "CHANGELOG.md"],
     "exclude": ["dist", "node_modules"]
   }
 }

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/elysia",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "description": "Authentication integration for Elysia applications. Provides middleware, route handlers and session verification powered by Aura Auth.",

--- a/packages/express/CHANGELOG.md
+++ b/packages/express/CHANGELOG.md
@@ -8,9 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.2.2] - 2026-07-07
+
 ### Fixed
 
-- Fixed type inference for the `signUp.schema` configuration. Sign-up schema types are now inferred correctly throughout the authentication fl
+- Fixed type inference for the `signUp.schema` configuration. Sign-up schema types are now inferred correctly throughout the authentication flow. [#216](https://github.com/aura-stack-ts/auth/pull/216)
 
 ---
 

--- a/packages/express/deno.json
+++ b/packages/express/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/express",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -43,7 +43,7 @@
     "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.1"
   },
   "publish": {
-    "include": ["src/**/*.ts", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]
+    "include": ["src/**/*.ts", "src/_core", "src/oauth", "src/identity", "README.md", "CHANGELOG.md"]
   },
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/express",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "description": "Authentication integration for Express applications. Provides middleware, route handlers and session verification powered by Aura Auth.",

--- a/packages/hono/CHANGELOG.md
+++ b/packages/hono/CHANGELOG.md
@@ -8,9 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.2.2] - 2026-07-07
+
 ### Fixed
 
-- Fixed type inference for the `signUp.schema` configuration. Sign-up schema types are now inferred correctly throughout the authentication fl
+- Fixed type inference for the `signUp.schema` configuration. Sign-up schema types are now inferred correctly throughout the authentication flow. [#216](https://github.com/aura-stack-ts/auth/pull/216)
 
 ---
 

--- a/packages/hono/deno.json
+++ b/packages/hono/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/hono",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -43,7 +43,7 @@
     "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.1"
   },
   "publish": {
-    "include": ["src/**/*.ts", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]
+    "include": ["src/**/*.ts", "src/_core", "src/oauth", "src/identity", "README.md", "CHANGELOG.md"]
   },
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/hono",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "description": "Authentication integration for Hono applications. Provides middleware, route handlers and session verification powered by Aura Auth.",

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.2.2] - 2026-07-07
+
 ### Added
 
 - Added the `api.getProviderTokens()` API with built-in support for automatically forwarding request headers via the `headers()` function from `next/headers`, simplifying server-side usage in Next.js applications. [#215](https://github.com/aura-stack-ts/auth/pull/215)
@@ -16,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- Fixed type inference for the `signUp.schema` configuration. Sign-up schema types are now inferred correctly throughout the authentication fl
+- Fixed type inference for the `signUp.schema` configuration. Sign-up schema types are now inferred correctly throughout the authentication flow. [#216](https://github.com/aura-stack-ts/auth/pull/216)
 
 ---
 

--- a/packages/next/deno.json
+++ b/packages/next/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/next",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",
@@ -47,7 +47,7 @@
     "@aura-stack/react": "npm:@aura-stack/react@^0.2.1"
   },
   "publish": {
-    "include": ["src/**/*.ts", "src/**/*.tsx", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]
+    "include": ["src/**/*.ts", "src/**/*.tsx", "src/_core", "src/oauth", "src/identity", "README.md", "CHANGELOG.md"]
   },
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/next",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "description": "Authentication integration for Next.js applications. Supports App Router, Server Components, Route Handlers and client-side authentication powered by Aura Auth.",

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.2.2] - 2026-07-04
+
 ### Added
 
 - Added the `api.getProviderTokens()` API to retrieve provider `accessToken` and `refreshToken` values after a successful OAuth or OpenID Connect (OIDC) sign-in. [#215](https://github.com/aura-stack-ts/auth/pull/215)
@@ -16,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- Fixed type inference for the `signUp.schema` configuration. Sign-up schema types are now inferred correctly throughout the authentication fl
+- Fixed type inference for the `signUp.schema` configuration. Sign-up schema types are now inferred correctly throughout the authentication flow. [#216](https://github.com/aura-stack-ts/auth/pull/216)
 
 ---
 

--- a/packages/react-router/deno.json
+++ b/packages/react-router/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/react-router",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.ts"
@@ -46,7 +46,7 @@
     "@aura-stack/react": "npm:@aura-stack/react@^0.2.1"
   },
   "publish": {
-    "include": ["src/**/*.ts", "src/**/*.tsx", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]
+    "include": ["src/**/*.ts", "src/**/*.tsx", "src/_core", "src/oauth", "src/identity", "README.md", "CHANGELOG.md"]
   },
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/react-router",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "description": "Authentication integration for React Router applications with server-side rendering, route protection, session management and OAuth flows powered by Aura Auth.",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.2.2] - 2026-07-07
+
 ### Added
 
 - Added the `useProviderTokens()` hook for retrieving the `accessToken` and `refreshToken` issued after a successful OAuth or OpenID Connect (OIDC) sign-in. The hook communicates with the `GET /providers/:oauth/tokens` endpoint and exposes `getProviderTokens()` and `isPending` for managing token retrieval. [#214](https://github.com/aura-stack-ts/auth/pull/214)

--- a/packages/react/deno.json
+++ b/packages/react/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/react",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch src/index.tsx"
@@ -47,7 +47,7 @@
     "@aura-stack/auth": "npm:@aura-stack/auth@^0.8.1"
   },
   "publish": {
-    "include": ["src/**/*.ts", "src/**/*.tsx", "src/_core", "src/oauth", "README.md", "CHANGELOG.md"]
+    "include": ["src/**/*.ts", "src/**/*.tsx", "src/_core", "src/oauth", "src/identity", "README.md", "CHANGELOG.md"]
   },
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aura-stack/react",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "description": "React authentication utilities including providers, hooks and OAuth flows for client-side and hybrid applications powered by Aura Auth.",


### PR DESCRIPTION
## Description

This pull request publishes new releases of the packages to both npm and JSR registries:

- `@aura-stack/elysia@0.2.2`
- `@aura-stack/express@0.2.2`
- `@aura-stack/hono@0.2.2`
- `@aura-stack/react@0.2.2`
- `@aura-stack/react-router@0.2.2`
- `@aura-stack/next@0.2.2`  


### NPM

- https://www.npmjs.com/package/@aura-stack/elysia
- https://www.npmjs.com/package/@aura-stack/express
- https://www.npmjs.com/package/@aura-stack/hono
- https://www.npmjs.com/package/@aura-stack/react
- https://www.npmjs.com/package/@aura-stack/react-router
- https://www.npmjs.com/package/@aura-stack/next

### JSR
- https://jsr.io/@aura-stack/elysia
- https://jsr.io/@aura-stack/express
- https://jsr.io/@aura-stack/hono
- https://jsr.io/@aura-stack/react
- https://jsr.io/@aura-stack/react-router
- https://jsr.io/@aura-stack/next


@coderabbitai ignore

@coderabbitai ignore