### PR TITLE
feat(core): introduce experimental `refreshUserInfo` APIs

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the `refreshUserInfo()` client API to `createAuthClient()`, providing a client-side interface for the `POST /providers/:provider/user/refresh` endpoint. [#218](https://github.com/aura-stack-ts/auth/pull/218)
+
+- Added the experimental `refreshUserInfo()` API for synchronizing the authenticated user's profile with the provider's `userInfo` endpoint. The API refreshes the stored user information without requiring the user to sign in again. [#219](https://github.com/aura-stack-ts/auth/pull/219)
+
 - Added the `getAccessToken()` client API to `createAuthClient()`. The API provides a client-side interface for retrieving the provider access token through the `GET /providers/:provider/tokens` endpoint. It is a convenience wrapper around `getProviderTokens()`. [#218](https://github.com/aura-stack-ts/auth/pull/218)
 
 - Added the experimental `getAccessToken()` API for retrieving the provider `accessToken` after a successful OAuth or OpenID Connect (OIDC) sign-in. This API is a simplified alternative to `getProviderTokens()` when only the access token is required. [#218](https://github.com/aura-stack-ts/auth/pull/218)

--- a/packages/core/src/@types/api.ts
+++ b/packages/core/src/@types/api.ts
@@ -351,3 +351,17 @@ export type AccessTokenData = { success: true; accessToken: string } | { success
  * Programmatic result for `getAccessToken` API with response metadata and `toResponse()`.
  */
 export type AccessTokenAPIReturn = AuthActionAPIReturn<AccessTokenData>
+
+/**
+ * Programmatic options for `refreshUserInfo` API.
+ */
+export type RefreshUserInfoAPIOptions = Pick<APIOptionsWithRequest, "headers" | "request"> & APIOptionsWithSkipCSRFCheck
+
+export type RefreshUserInfoData<DefaultUser extends User = User> =
+    | { success: true; session: Session<DefaultUser> }
+    | { success: false; session: null }
+
+/**
+ * Programmatic result for `refreshUserInfo` API with response metadata and `toResponse()`.
+ */
+export type RefreshUserInfoAPIReturn<DefaultUser extends User = User> = AuthActionAPIReturn<RefreshUserInfoData<DefaultUser>>

--- a/packages/core/src/@types/config.ts
+++ b/packages/core/src/@types/config.ts
@@ -525,6 +525,9 @@ export interface SignUpConfig<Identity extends Identities, SignUpSchema extends 
 
 export type RateLimiterConfig = Partial<
     RaterLimiterBaseConfig<
-        Record<"signIn" | "signInCredentials" | "updateSession" | "signUp" | "getProviderTokens", RateLimiterRule>
+        Record<
+            "signIn" | "signInCredentials" | "updateSession" | "signUp" | "getProviderTokens" | "refreshUserInfo",
+            RateLimiterRule
+        >
     >["rules"]
 >

--- a/packages/core/src/actions/callback/userinfo.ts
+++ b/packages/core/src/actions/callback/userinfo.ts
@@ -83,6 +83,7 @@ const createUserInfoRequest = async (oauthConfig: ProviderConfig, accessToken: s
         if (isAuraAuthError(error)) {
             throw error
         }
+        console.log("Error fetching user info:", error)
         logger?.log("OAUTH_USERINFO_REQUEST_FAILED")
         throw new AuraAuthError({ code: "UNKNOWN_OAUTH_USER_INFO_ERROR", cause: error })
     }

--- a/packages/core/src/actions/callback/userinfo.ts
+++ b/packages/core/src/actions/callback/userinfo.ts
@@ -1,5 +1,5 @@
 import { fetchAsync } from "@/shared/fetch-async.ts"
-import { AURA_AUTH_VERSION } from "@/shared/utils.ts"
+import { AURA_AUTH_VERSION, getErrorName } from "@/shared/utils.ts"
 import { OAuthErrorResponse, OIDCUserInfoSchema } from "@/schemas.ts"
 import type {
     AccessTokenContext,
@@ -83,7 +83,6 @@ const createUserInfoRequest = async (oauthConfig: ProviderConfig, accessToken: s
         if (isAuraAuthError(error)) {
             throw error
         }
-        console.log("Error fetching user info:", error)
         logger?.log("OAUTH_USERINFO_REQUEST_FAILED")
         throw new AuraAuthError({ code: "UNKNOWN_OAUTH_USER_INFO_ERROR", cause: error })
     }
@@ -139,7 +138,7 @@ export const getUserInfo = async (
         if (isAuraAuthError(error)) {
             throw error
         }
-        logger?.log("OAUTH_USERINFO_REQUEST_FAILED")
+        logger?.log("OAUTH_USERINFO_REQUEST_FAILED", { structuredData: { error_type: getErrorName(error) } })
         throw new AuraAuthError({ code: "UNKNOWN_CUSTOM_USER_INFO_ERROR", cause: error })
     }
 }

--- a/packages/core/src/actions/user/refresh.ts
+++ b/packages/core/src/actions/user/refresh.ts
@@ -1,0 +1,34 @@
+import { z } from "zod/v4"
+import { refreshUserInfo } from "@/api/refreshUserInfo.ts"
+import { createEndpoint, createEndpointConfig } from "@aura-stack/router"
+import type { OAuthProviderRecord } from "@/@types/oauth.ts"
+
+export const refreshConfig = (oauth: OAuthProviderRecord) => {
+    return createEndpointConfig({
+        schemas: {
+            params: z.object({
+                oauth: z.enum(
+                    Object.keys(oauth) as (keyof OAuthProviderRecord)[],
+                    "The OAuth provider is not supported or invalid."
+                ),
+            }),
+        },
+    })
+}
+
+export const refreshAction = (oauth: OAuthProviderRecord) => {
+    return createEndpoint(
+        "POST",
+        "/providers/:oauth/user/refresh",
+        async (ctx) => {
+            const { toResponse } = await refreshUserInfo(ctx.params.oauth, {
+                ctx: ctx.context,
+                headers: ctx.request.headers,
+                request: ctx.request,
+                skipCSRFCheck: false,
+            })
+            return toResponse()
+        },
+        refreshConfig(oauth)
+    )
+}

--- a/packages/core/src/api/createApi.ts
+++ b/packages/core/src/api/createApi.ts
@@ -31,9 +31,11 @@ import type {
     GetProviderTokensAPIReturn,
     AccessTokenAPIOptions,
     AccessTokenAPIReturn,
+    RefreshUserInfoAPIOptions,
 } from "@/@types/index.ts"
 import type { ZodObject } from "zod"
 import type { SchemaTypes } from "@/identity/index.ts"
+import { refreshUserInfo } from "./refreshUserInfo.ts"
 
 type InferSignUp<T> = Wrap<RemoveIndexSignature<InferSchema<T>>>
 
@@ -176,6 +178,20 @@ export const createAuthAPI = <DefaultUser extends User = User, SignUpSchema exte
             options?: AccessTokenAPIOptions
         ): Promise<AccessTokenAPIReturn> => {
             return getAccessToken(oauth, { ctx, ...options, skipCSRFCheck: true })
+        },
+        /**
+         * Refreshes the user profile data from the OAuth provider on the server-side. It makes a request to the
+         * `userInfo` endpoint of the specified OAuth provider.
+         *
+         * @param oauth - The OAuth provider for which to refresh the user profile data (e.g., "github", "gitlab", "bitbucket").
+         * @param options - Options for the API call, including headers and request object.
+         * @example
+         * const { success, session } = await api.refreshUserInfo("github", {
+         *    headers: getHeaders()
+         * })
+         */
+        refreshUserInfo: async (oauth: LiteralUnion<BuiltInOAuthProvider>, options?: RefreshUserInfoAPIOptions) => {
+            return refreshUserInfo<DefaultUser>(oauth, { ctx, ...options })
         },
         /**
          * Signs out the current session on the server-side. It implements CSRF Protection by default, for

--- a/packages/core/src/api/createApi.ts
+++ b/packages/core/src/api/createApi.ts
@@ -191,7 +191,7 @@ export const createAuthAPI = <DefaultUser extends User = User, SignUpSchema exte
          * })
          */
         refreshUserInfo: async (oauth: LiteralUnion<BuiltInOAuthProvider>, options?: RefreshUserInfoAPIOptions) => {
-            return refreshUserInfo<DefaultUser>(oauth, { ctx, ...options })
+            return refreshUserInfo<DefaultUser>(oauth, { ctx, ...options, skipCSRFCheck: true })
         },
         /**
          * Signs out the current session on the server-side. It implements CSRF Protection by default, for

--- a/packages/core/src/api/refreshUserInfo.ts
+++ b/packages/core/src/api/refreshUserInfo.ts
@@ -1,0 +1,140 @@
+import { HeadersBuilder } from "@aura-stack/router"
+import { secureApiHeaders } from "@/shared/headers.ts"
+import { getProviderTokens } from "./getProviderTokens.ts"
+import { getUserInfo } from "@/actions/callback/userinfo.ts"
+import { AuraAuthError, isAuraAuthError } from "@/shared/errors.ts"
+import { verifyCSRFToken, verifySessionToken, toUnionHeaders } from "@/shared/utils.ts"
+import { verifyRateLimit } from "@/router/rate-limiter.ts"
+import { getBaseURL, getOriginURL } from "@/actions/signIn/authorization.ts"
+import type { LiteralUnion } from "@/@types/utility.ts"
+import type { Session, User } from "@/@types/session.ts"
+import type { BuiltInOAuthProvider } from "@/oauth/index.ts"
+import type { FunctionAPIContext, RefreshUserInfoAPIOptions, RefreshUserInfoAPIReturn } from "@/@types/api.ts"
+
+export const refreshUserInfo = async <DefaultUser extends User = User>(
+    oauth: LiteralUnion<BuiltInOAuthProvider>,
+    { ctx, headers: headersInit, request: requestInit, skipCSRFCheck = false }: FunctionAPIContext<RefreshUserInfoAPIOptions>
+): Promise<RefreshUserInfoAPIReturn<DefaultUser>> => {
+    const { cookies } = ctx
+    try {
+        ctx.logger?.log("OAUTH_USERINFO_REQUEST_INITIATED", {
+            structuredData: { provider: oauth, skipCSRFCheck },
+        })
+
+        const provider = ctx.oauth[oauth]
+        if (!provider) {
+            ctx.logger?.log("INVALID_OAUTH_CONFIGURATION", {
+                structuredData: { provider: oauth },
+            })
+            throw new AuraAuthError({ code: "UNSUPPORTED_OAUTH_CONFIGURATION" })
+        }
+        const headers = new Headers(headersInit ?? requestInit?.headers)
+        let request = requestInit
+        if (!request) {
+            const origin = await getBaseURL({ ctx, headers })
+            const url = `${origin}${ctx.basePath}/session`
+            request = new Request(url, { headers })
+        }
+        await getOriginURL(request, ctx)
+
+        const rateLimit = await verifyRateLimit(ctx, request, "refreshUserInfo")
+        if (rateLimit) {
+            ctx.logger?.log("INVALID_REQUEST", {
+                structuredData: { provider: oauth },
+            })
+            return rateLimit as RefreshUserInfoAPIReturn<DefaultUser>
+        }
+
+        await verifySessionToken({
+            headers,
+            cookies,
+            jwt: ctx.jwtManager,
+            logger: ctx.logger,
+        })
+        await verifyCSRFToken({
+            headers,
+            cookies,
+            jose: ctx.jose,
+            logger: ctx.logger,
+            skipCSRFCheck,
+        })
+
+        const { success, tokens } = await getProviderTokens(oauth, {
+            ctx,
+            request: requestInit,
+            headers: headersInit,
+            skipCSRFCheck,
+        })
+        if (!success) {
+            ctx.logger?.log("OAUTH_ACCESS_TOKEN_ERROR", {
+                structuredData: { provider: oauth },
+            })
+            throw new AuraAuthError({ code: "INVALID_ACCESS_TOKEN_RETRIVING_REFRESH_USER_INFO" })
+        }
+
+        const userInfo = await getUserInfo(
+            provider,
+            {
+                access_token: tokens.accessToken,
+                expires_in: tokens?.expiresAt,
+                refresh_token: tokens?.refreshToken,
+                id_token: tokens?.idToken,
+                scope: tokens?.scopes?.join(" "),
+                token_type: tokens?.tokenType,
+            },
+            ctx.logger
+        )
+
+        ctx.logger?.log("OAUTH_USERINFO_SUCCESS", {
+            structuredData: { provider: oauth, userId: userInfo.sub },
+        })
+
+        const sessionToken = await ctx.sessionStrategy.createSession(userInfo)
+        const newHeaders = new HeadersBuilder(headers)
+            .setCookie(cookies.sessionToken.name, sessionToken, cookies.sessionToken.attributes)
+            .toHeaders()
+
+        const mergedHeaders = toUnionHeaders(newHeaders, headers)
+
+        const decodedSession = await ctx.jwtManager.verifyToken(sessionToken)
+        return {
+            success: true,
+            headers: mergedHeaders,
+            session: decodedSession as unknown as Session<DefaultUser>,
+            toResponse: () => {
+                return Response.json(
+                    {
+                        success: true,
+                        session: decodedSession,
+                    },
+                    { headers: mergedHeaders, status: 200 }
+                )
+            },
+        }
+    } catch (error) {
+        let code = "UNKNOWN_REFRESH_USER_INFO_ERROR"
+        let message = "Failed to refresh user information from the OAuth provider"
+        let statusCode = 400
+        if (isAuraAuthError(error)) {
+            code = error.code
+            message = error.userMessage
+            statusCode = error.statusCode
+        }
+        const newHeaders = new Headers(secureApiHeaders)
+        return {
+            success: false,
+            headers: newHeaders,
+            error: { code, message },
+            session: null,
+            toResponse: () => {
+                return Response.json(
+                    {
+                        success: false,
+                        session: null,
+                    },
+                    { headers: newHeaders, status: statusCode }
+                )
+            },
+        }
+    }
+}

--- a/packages/core/src/api/refreshUserInfo.ts
+++ b/packages/core/src/api/refreshUserInfo.ts
@@ -3,11 +3,11 @@ import { secureApiHeaders } from "@/shared/headers.ts"
 import { getProviderTokens } from "./getProviderTokens.ts"
 import { getUserInfo } from "@/actions/callback/userinfo.ts"
 import { AuraAuthError, isAuraAuthError } from "@/shared/errors.ts"
-import { verifyCSRFToken, verifySessionToken, toUnionHeaders } from "@/shared/utils.ts"
+import { verifyCSRFToken, verifySessionToken, toUnionHeaders, createStandardSession } from "@/shared/utils.ts"
 import { verifyRateLimit } from "@/router/rate-limiter.ts"
 import { getBaseURL, getOriginURL } from "@/actions/signIn/authorization.ts"
 import type { LiteralUnion } from "@/@types/utility.ts"
-import type { Session, User } from "@/@types/session.ts"
+import type { User } from "@/@types/session.ts"
 import type { BuiltInOAuthProvider } from "@/oauth/index.ts"
 import type { FunctionAPIContext, RefreshUserInfoAPIOptions, RefreshUserInfoAPIReturn } from "@/@types/api.ts"
 
@@ -100,16 +100,21 @@ export const refreshUserInfo = async <DefaultUser extends User = User>(
 
         const mergedHeaders = toUnionHeaders(newHeaders, headers)
 
-        const decodedSession = await ctx.jwtManager.verifyToken(sessionToken)
+        const session = await createStandardSession({
+            sessionToken,
+            jwt: ctx.jwtManager,
+            identity: ctx.identity,
+            newHeaders: mergedHeaders,
+        })
         return {
             success: true,
             headers: mergedHeaders,
-            session: decodedSession as unknown as Session<DefaultUser>,
+            session,
             toResponse: () => {
                 return Response.json(
                     {
+                        session,
                         success: true,
-                        session: decodedSession,
                     },
                     { headers: mergedHeaders, status: 200 }
                 )

--- a/packages/core/src/api/refreshUserInfo.ts
+++ b/packages/core/src/api/refreshUserInfo.ts
@@ -73,7 +73,7 @@ export const refreshUserInfo = async <DefaultUser extends User = User>(
         }
 
         const expiresIn = tokens?.expiresAt
-            ? Math.max(0, Math.floor(((tokens.expiresAt as number) - Date.now()) / 1000))
+            ? Math.max(0, Math.floor(tokens.expiresAt - Math.floor(Date.now() / 1000)))
             : undefined
 
         const userInfo = await getUserInfo(
@@ -104,7 +104,6 @@ export const refreshUserInfo = async <DefaultUser extends User = User>(
             sessionToken,
             jwt: ctx.jwtManager,
             identity: ctx.identity,
-            newHeaders: mergedHeaders,
         })
         return {
             success: true,

--- a/packages/core/src/api/refreshUserInfo.ts
+++ b/packages/core/src/api/refreshUserInfo.ts
@@ -69,14 +69,18 @@ export const refreshUserInfo = async <DefaultUser extends User = User>(
             ctx.logger?.log("OAUTH_ACCESS_TOKEN_ERROR", {
                 structuredData: { provider: oauth },
             })
-            throw new AuraAuthError({ code: "INVALID_ACCESS_TOKEN_RETRIVING_REFRESH_USER_INFO" })
+            throw new AuraAuthError({ code: "INVALID_ACCESS_TOKEN_RETRIEVING_REFRESH_USER_INFO" })
         }
+
+        const expiresIn = tokens?.expiresAt
+            ? Math.max(0, Math.floor(((tokens.expiresAt as number) - Date.now()) / 1000))
+            : undefined
 
         const userInfo = await getUserInfo(
             provider,
             {
                 access_token: tokens.accessToken,
-                expires_in: tokens?.expiresAt,
+                expires_in: expiresIn,
                 refresh_token: tokens?.refreshToken,
                 id_token: tokens?.idToken,
                 scope: tokens?.scopes?.join(" "),

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -339,7 +339,7 @@ export const createAuthClient = <
      * const updatedSession = await authClient.refreshUserInfo("google")
      * // Expected:
      * {
-     *   id: "user_id",
+     *   sub: "user_id",
      *   name: "John Doe",
      *   email: "john.doe@example.com",
      *   image: "https://example.com/avatar.jpg",

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -194,7 +194,7 @@ export const createAuthClient = <
                     "X-CSRF-Token": csrfToken,
                 },
             })
-            const json = await response.json()
+            const json: any = await response.json()
             if (options?.redirect === true && typeof window !== "undefined" && json?.redirectURL) {
                 window.location.assign(json.redirectURL)
             }
@@ -327,6 +327,45 @@ export const createAuthClient = <
     }
 
     /**
+     * Refreshes the user information from making a request to the user info endpoint of the specified
+     * OAuth provider. This is useful for keeping the session data up-to-date without requiring the user
+     * to re-authenticate,
+     *
+     * @param oauth - The OAuth provider identifier (e.g., "google", "github").
+     * @returns the updated session object if successful, or null if the refresh fails or the user is not authenticated.
+     * @example
+     * const authClient = createAuthClient({ ... })
+     *
+     * const updatedSession = await authClient.refreshUserInfo("google")
+     * // Expected:
+     * {
+     *   id: "user_id",
+     *   name: "John Doe",
+     *   email: "john.doe@example.com",
+     *   image: "https://example.com/avatar.jpg",
+     * }
+     */
+    const refreshUserInfo = async (oauth: LiteralUnion<BuiltInOAuthProvider>): Promise<Session<DefaultUser> | null> => {
+        try {
+            const csrfToken = await getCSRFToken()
+            if (!csrfToken) {
+                throw new AuraAuthError({ code: "CSRF_TOKEN_MISSING" })
+            }
+            const response = await client.post("/providers/:oauth/user/refresh", {
+                params: { oauth },
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                },
+            })
+            const json = await response.json()
+            return json.session as Session<DefaultUser> | null
+        } catch (error) {
+            console.error("Error refreshing user info:", error)
+            return null
+        }
+    }
+
+    /**
      * Signs out the current user, ending their session and optionally redirecting them to a specified URL.
      *
      * @param options Sign-out options, including redirect behavior and target URL after sign-out.
@@ -375,6 +414,7 @@ export const createAuthClient = <
         updateSession,
         getProviderTokens,
         getAccessToken,
+        refreshUserInfo,
         signOut,
     }
 }

--- a/packages/core/src/createAuth.ts
+++ b/packages/core/src/createAuth.ts
@@ -25,6 +25,7 @@ import type {
     EditableShape,
     ZodIdentitySchema,
 } from "@/@types/index.ts"
+import { refreshAction } from "./actions/user/refresh.ts"
 
 const createInternalConfig = <Identity extends Identities, SignUpSchema extends SchemaTypes>(
     config?: AuthConfig<Identity, SignUpSchema>
@@ -59,6 +60,7 @@ export const createAuthInstance = <Identity extends Identities, SignUpSchema ext
             updateSessionAction(config.context.identity as SchemaRegistryContext),
             signUpAction<Identity, SignUpSchema>(config.context.signUp as SignUpConfig<Identity, SignUpSchema>),
             tokensAction(config.context.oauth),
+            refreshAction(config.context.oauth),
         ],
         config
     )

--- a/packages/core/src/router/rate-limiter.ts
+++ b/packages/core/src/router/rate-limiter.ts
@@ -61,6 +61,8 @@ export const createRateLimiterInstance = (config?: RateLimiterConfig) => {
 
 const defaultValues = (action: keyof RateLimiterConfig) => {
     switch (action) {
+        case "getProviderTokens":
+            return { tokens: null }
         case "refreshUserInfo":
             return { session: null }
         case "signIn":

--- a/packages/core/src/router/rate-limiter.ts
+++ b/packages/core/src/router/rate-limiter.ts
@@ -67,6 +67,8 @@ const defaultValues = (action: keyof RateLimiterConfig) => {
             return { session: null }
         case "signIn":
             return { redirect: false, signInURL: null }
+        case "updateSession":
+            return { session: null, redirect: false, redirectURL: null }
         default:
             return {
                 redirect: false,

--- a/packages/core/src/router/rate-limiter.ts
+++ b/packages/core/src/router/rate-limiter.ts
@@ -48,8 +48,29 @@ export const createRateLimiterInstance = (config?: RateLimiterConfig) => {
                 keyGenerator: (request) => getLimitKey(request, "getProviderTokens"),
                 ...config?.getProviderTokens,
             } as RateLimiterRule,
+            refreshUserInfo: {
+                algorithm: "sliding-window",
+                limit: 10,
+                windowMs: 15 * 60 * 1000,
+                keyGenerator: (request) => getLimitKey(request, "refreshUserInfo"),
+                ...config?.refreshUserInfo,
+            } as RateLimiterRule,
         },
     })
+}
+
+const defaultValues = (action: keyof RateLimiterConfig) => {
+    switch (action) {
+        case "refreshUserInfo":
+            return { session: null }
+        case "signIn":
+            return { redirect: false, signInURL: null }
+        default:
+            return {
+                redirect: false,
+                redirectURL: null,
+            }
+    }
 }
 
 /**
@@ -59,13 +80,11 @@ export const verifyRateLimit = async (ctx: RouterGlobalContext, request: Request
     const rateLimit = await ctx.rateLimiters[action].check(request)
     if (!rateLimit.ok) {
         const toResponse = rateLimit.toResponse()
-        let redirectField = action === "signIn" ? "signInURL" : "redirectURL"
-        let tokensField = action === "getProviderTokens" ? "tokens" : "redirect"
+        const values = defaultValues(action)
 
         return {
+            ...values,
             success: false,
-            [tokensField]: tokensField === "tokens" ? null : false,
-            [redirectField]: null,
             error: { code: "RATE_LIMIT_EXCEEDED", message: "Too many requests." },
             headers: toResponse.headers,
             toResponse: () => toResponse,

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -116,7 +116,7 @@ export const AuraErrorCode = {
     /**
      * User Info Refresh Errors
      */
-    INVALID_ACCESS_TOKEN_RETRIVING_REFRESH_USER_INFO: "INVALID_ACCESS_TOKEN_RETRIVING_REFRESH_USER_INFO",
+    INVALID_ACCESS_TOKEN_RETRIEVING_REFRESH_USER_INFO: "INVALID_ACCESS_TOKEN_RETRIEVING_REFRESH_USER_INFO",
     INVALID_REFRESH_USER_INFO_RESPONSE: "INVALID_REFRESH_USER_INFO_RESPONSE",
     INVALID_REFRESH_USER_INFO_NETWORK: "INVALID_REFRESH_USER_INFO_NETWORK",
 } as const
@@ -832,7 +832,7 @@ export const ERROR_CATALOG: Record<AuraErrorCode, CatalogEntry> = {
             "The remote identity provider rejected the refresh token exchange request. The response 'ok' field resolved to false. This typically indicates that the refresh token has expired, been reused, or has been explicitly revoked by the end-user.",
         userMessage: "Your secure session renewal failed. Please sign in again to continue.",
     },
-    INVALID_ACCESS_TOKEN_RETRIVING_REFRESH_USER_INFO: {
+    INVALID_ACCESS_TOKEN_RETRIEVING_REFRESH_USER_INFO: {
         type: "VALIDATION",
         statusCode: 401,
         name: "AuthError",
@@ -845,7 +845,7 @@ export const ERROR_CATALOG: Record<AuraErrorCode, CatalogEntry> = {
         statusCode: 502,
         name: "AuthError",
         message:
-            "The outbound HTTP request to the provider user info profile endpoint returned a non-2xx status code during a synchronization sync block. The response 'ok' field resolved to false.",
+            "The outbound HTTP request to the provider user info profile endpoint returned a non-2xx status code during a profile synchronization request. The response 'ok' field resolved to false.",
         userMessage: "The identity provider rejected the request to update profile details.",
     },
     INVALID_REFRESH_USER_INFO_NETWORK: {

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -112,6 +112,13 @@ export const AuraErrorCode = {
     OIDC_JWKS_INVALID_RESPONSE: "OIDC_JWKS_INVALID_RESPONSE",
     OIDC_JWKS_INVALID_SCHEMA: "OIDC_JWKS_INVALID_SCHEMA",
     OIDC_INVALID_ISSUER_PARAMS: "OIDC_INVALID_ISSUER_PARAMS",
+
+    /**
+     * User Info Refresh Errors
+     */
+    INVALID_ACCESS_TOKEN_RETRIVING_REFRESH_USER_INFO: "INVALID_ACCESS_TOKEN_RETRIVING_REFRESH_USER_INFO",
+    INVALID_REFRESH_USER_INFO_RESPONSE: "INVALID_REFRESH_USER_INFO_RESPONSE",
+    INVALID_REFRESH_USER_INFO_NETWORK: "INVALID_REFRESH_USER_INFO_NETWORK",
 } as const
 
 export type AuraErrorCode = (typeof AuraErrorCode)[keyof typeof AuraErrorCode]
@@ -824,6 +831,30 @@ export const ERROR_CATALOG: Record<AuraErrorCode, CatalogEntry> = {
         message:
             "The remote identity provider rejected the refresh token exchange request. The response 'ok' field resolved to false. This typically indicates that the refresh token has expired, been reused, or has been explicitly revoked by the end-user.",
         userMessage: "Your secure session renewal failed. Please sign in again to continue.",
+    },
+    INVALID_ACCESS_TOKEN_RETRIVING_REFRESH_USER_INFO: {
+        type: "VALIDATION",
+        statusCode: 401,
+        name: "AuthError",
+        message:
+            "The profile refresh sequence was aborted because a valid access token could not be extracted or resolved from the current session context inside the refreshUserInfo function.",
+        userMessage: "Failed to sync profile data. Your active session access token is missing or invalid.",
+    },
+    INVALID_REFRESH_USER_INFO_RESPONSE: {
+        type: "PROTOCOL",
+        statusCode: 502,
+        name: "AuthError",
+        message:
+            "The outbound HTTP request to the provider user info profile endpoint returned a non-2xx status code during a synchronization sync block. The response 'ok' field resolved to false.",
+        userMessage: "The identity provider rejected the request to update profile details.",
+    },
+    INVALID_REFRESH_USER_INFO_NETWORK: {
+        type: "NETWORK",
+        statusCode: 504,
+        name: "AuthError",
+        message:
+            "A raw connection timeout, network failure, or socket hang-up occurred while trying to retrieve updated user info metadata from the remote identity platform.",
+        userMessage: "A network transport failure prevented fetching updated profile data from the provider.",
     },
 }
 

--- a/packages/core/src/shared/utils.ts
+++ b/packages/core/src/shared/utils.ts
@@ -217,17 +217,15 @@ export const createStandardSession = async ({
     sessionToken,
     jwt,
     identity,
-    newHeaders,
 }: {
     sessionToken: string
     jwt: JWTManager
     identity: SchemaRegistryContext
-    newHeaders?: Headers
 }) => {
     const claims = await jwt.verifyToken(sessionToken)
     const parsedClaims = identity.skipValidation ? claims : await identity.schemaRegistry.parseWithJWT(claims)
     const { exp: _exp, iat: _iat, mexp: _mexp, ...defaultPayload } = parsedClaims
     const userClaims = await identity.schemaRegistry.parse(defaultPayload)
-    if (!userClaims.sub) return { session: null, headers: newHeaders }
+    if (!userClaims.sub) return null
     return userClaims
 }

--- a/packages/core/src/shared/utils.ts
+++ b/packages/core/src/shared/utils.ts
@@ -5,7 +5,7 @@ import { encoder } from "@aura-stack/jose/crypto"
 import { AuraAuthError } from "@/shared/errors.ts"
 import { isRelativeURL, isValidURL } from "@/shared/assert.ts"
 import type { JWTManager, OAuthTokenPayload } from "@/@types/session.ts"
-import type { CookieStoreConfig, InternalLogger, JoseInstance } from "@/@types/config.ts"
+import type { CookieStoreConfig, InternalLogger, JoseInstance, SchemaRegistryContext } from "@/@types/config.ts"
 
 export const AURA_AUTH_VERSION = "0.7.2"
 
@@ -211,4 +211,23 @@ export const merge = (origin: Record<string, unknown>, source: Record<string, un
         }
     }
     return { ...origin, ...source }
+}
+
+export const createStandardSession = async ({
+    sessionToken,
+    jwt,
+    identity,
+    newHeaders,
+}: {
+    sessionToken: string
+    jwt: JWTManager
+    identity: SchemaRegistryContext
+    newHeaders?: Headers
+}) => {
+    const claims = await jwt.verifyToken(sessionToken)
+    const parsedClaims = identity.skipValidation ? claims : await identity.schemaRegistry.parseWithJWT(claims)
+    const { exp: _exp, iat: _iat, mexp: _mexp, ...defaultPayload } = parsedClaims
+    const userClaims = await identity.schemaRegistry.parse(defaultPayload)
+    if (!userClaims.sub) return { session: null, headers: newHeaders }
+    return userClaims
 }

--- a/packages/core/src/shared/utils.ts
+++ b/packages/core/src/shared/utils.ts
@@ -203,3 +203,12 @@ export const shouldRefresh = (payload: OAuthTokenPayload, refreshWindow: number)
     if (payload.expiresAt - now <= refreshWindow) return true
     return false
 }
+
+export const merge = (origin: Record<string, unknown>, source: Record<string, unknown>) => {
+    for (const key in source) {
+        if (source[key] instanceof Object && key in origin) {
+            Object.assign(source[key], merge(origin[key] as Record<string, unknown>, source[key] as Record<string, unknown>))
+        }
+    }
+    return { ...origin, ...source }
+}

--- a/packages/core/test/actions/user/refresh.test.ts
+++ b/packages/core/test/actions/user/refresh.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest"
-import { api, jose, oauthCustomService, oauthTokens, sessionPayload } from "@test/presets.ts"
+import { jose, oauthCustomService, oauthTokens, POST, sessionPayload } from "@test/presets.ts"
 import { createCSRF } from "@/shared/crypto.ts"
 import { createAuth } from "@/createAuth.ts"
 import { AURA_AUTH_VERSION } from "@/shared/utils.ts"
@@ -36,83 +36,82 @@ vi.mock("@aura-stack/rate-limiter", async () => {
     }
 })
 
-describe("refreshUserInfo", () => {
+describe("refreshUserInfo action", () => {
     test("unsupported oauth provider", async () => {
-        const output = await api.refreshUserInfo("unsupported")
-        expect(output).toEqual({
-            success: false,
-            session: null,
-            error: {
-                code: "UNSUPPORTED_OAUTH_CONFIGURATION",
-                message: "The targeted OAuth provider has not been configured in the initialization parameters.",
-            },
-            headers: expect.any(Headers),
-            toResponse: expect.any(Function),
+        const response = await POST(new Request("https://example.com/auth/unsupported/user/refresh", { method: "POST" }))
+        expect(await response.json()).toEqual({
+            code: "NOT_FOUND",
+            type: "ROUTER_FLOW",
+            message: "The requested route address cannot be found or is unavailable on this application endpoint server context.",
         })
     })
 
     test("invalid operation when the session token is missing", async () => {
-        vi.stubEnv("BASE_URL", "https://example.com")
-
-        const output = await api.refreshUserInfo("oauth-provider", { headers: new Headers() })
-        expect(output).toEqual({
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", { method: "POST" })
+        )
+        expect(await response.json()).toEqual({
             success: false,
             session: null,
-            error: {
-                code: "SESSION_NOT_FOUND",
-                message: "The session token is not found. There is no active session.",
-            },
-            headers: expect.any(Headers),
-            toResponse: expect.any(Function),
         })
     })
 
     test("throws error when CSRF token is missing", async () => {
-        vi.stubEnv("BASE_URL", "http://localhost:3000")
         const sessionToken = await jose.encodeJWT(sessionPayload)
 
-        const output = await api.refreshUserInfo("oauth-provider", {
-            headers: {
-                Cookie: `aura-auth.session_token=${sessionToken}`,
-            },
-        })
-        expect(output).toEqual({
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    Cookie: `aura-auth.session_token=${sessionToken}`,
+                },
+            })
+        )
+        expect(await response.json()).toEqual({
             success: false,
             session: null,
-            error: {
-                code: "CSRF_TOKEN_MISSING",
-                message: "The CSRF token is missing. Please refresh and try again.",
-            },
-            headers: expect.any(Headers),
-            toResponse: expect.any(Function),
+        })
+    })
+
+    test("throws error when CSRF token is invalid", async () => {
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}`,
+                    "X-CSRF-Token": "invalid-token",
+                },
+            })
+        )
+        expect(await response.json()).toEqual({
+            success: false,
+            session: null,
         })
     })
 
     test("throws error when provider token does not exist", async () => {
-        vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
         const sessionToken = await jose.encodeJWT(sessionPayload)
 
-        const output = await api.refreshUserInfo("oauth-provider", {
-            headers: {
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}`,
-            },
-        })
-        expect(output).toEqual({
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.session_token=${sessionToken}`,
+                },
+            })
+        )
+        expect(await response.json()).toEqual({
             success: false,
             session: null,
-            error: {
-                code: "INVALID_ACCESS_TOKEN_RETRIEVING_REFRESH_USER_INFO",
-                message: "Failed to sync profile data. Your active session access token is missing or invalid.",
-            },
-            headers: expect.any(Headers),
-            toResponse: expect.any(Function),
         })
     })
 
     test("successfully refreshes user info", async () => {
-        vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
         const sessionToken = await jose.encodeJWT(sessionPayload)
 
@@ -131,14 +130,17 @@ describe("refreshUserInfo", () => {
         })
         vi.stubGlobal("fetch", mockFetch)
 
-        const output = await api.refreshUserInfo("oauth-provider", {
-            headers: {
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
-            },
-        })
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.session_token=${sessionToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                },
+            })
+        )
 
-        expect(output).toEqual({
+        expect(await response.json()).toEqual({
             success: true,
             session: {
                 sub: "1234567890",
@@ -146,9 +148,8 @@ describe("refreshUserInfo", () => {
                 name: "John Doe",
                 image: "https://example.com/image.jpg",
             },
-            headers: expect.any(Headers),
-            toResponse: expect.any(Function),
         })
+        expect(response.status).toBe(200)
         expect(mockFetch).toHaveBeenCalledWith("https://example.com/oauth/userinfo", {
             method: "GET",
             headers: {
@@ -161,7 +162,6 @@ describe("refreshUserInfo", () => {
     })
 
     test("handles getUserInfo network error gracefully", async () => {
-        vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
         const sessionToken = await jose.encodeJWT(sessionPayload)
 
@@ -170,27 +170,23 @@ describe("refreshUserInfo", () => {
         const mockFetch = vi.fn().mockRejectedValueOnce(new Error("Network connection lost"))
         vi.stubGlobal("fetch", mockFetch)
 
-        const output = await api.refreshUserInfo("oauth-provider", {
-            headers: {
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
-            },
-        })
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.session_token=${sessionToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                },
+            })
+        )
 
-        expect(output).toEqual({
+        expect(await response.json()).toEqual({
             success: false,
             session: null,
-            error: {
-                code: "UNKNOWN_OAUTH_USER_INFO_ERROR",
-                message: "Failed to communicate clean state down to the user configuration data provider.",
-            },
-            headers: expect.any(Headers),
-            toResponse: expect.any(Function),
         })
     })
 
     test("handles getUserInfo invalid response from provider", async () => {
-        vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
         const sessionToken = await jose.encodeJWT(sessionPayload)
 
@@ -202,27 +198,23 @@ describe("refreshUserInfo", () => {
         })
         vi.stubGlobal("fetch", mockFetch)
 
-        const output = await api.refreshUserInfo("oauth-provider", {
-            headers: {
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
-            },
-        })
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.session_token=${sessionToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                },
+            })
+        )
 
-        expect(output).toEqual({
+        expect(await response.json()).toEqual({
             success: false,
             session: null,
-            error: {
-                code: "INVALID_OAUTH_USER_INFO_RESPONSE",
-                message: "The resource userInfo target server returned an error code response.",
-            },
-            headers: expect.any(Headers),
-            toResponse: expect.any(Function),
         })
     })
 
     test("handles getUserInfo OAuth error response", async () => {
-        vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
         const sessionToken = await jose.encodeJWT(sessionPayload)
 
@@ -238,27 +230,23 @@ describe("refreshUserInfo", () => {
         })
         vi.stubGlobal("fetch", mockFetch)
 
-        const output = await api.refreshUserInfo("oauth-provider", {
-            headers: {
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
-            },
-        })
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.session_token=${sessionToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                },
+            })
+        )
 
-        expect(output).toEqual({
+        expect(await response.json()).toEqual({
             success: false,
             session: null,
-            error: {
-                code: "INVALID_OAUTH_USER_INFO_RES_FORMAT",
-                message: "The returned user info profile structure payload is corrupted or unexpected.",
-            },
-            headers: expect.any(Headers),
-            toResponse: expect.any(Function),
         })
     })
 
     test("handles getUserInfo missing required user fields", async () => {
-        vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
         const sessionToken = await jose.encodeJWT(sessionPayload)
 
@@ -273,30 +261,15 @@ describe("refreshUserInfo", () => {
         })
         vi.stubGlobal("fetch", mockFetch)
 
-        const output = await api.refreshUserInfo("oauth-provider", {
-            headers: {
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
-            },
-        })
-
-        expect(output).toEqual({
-            success: false,
-            session: null,
-            error: {
-                code: "UNKNOWN_OAUTH_USER_INFO_ERROR",
-                message: "Failed to communicate clean state down to the user configuration data provider.",
-            },
-            headers: expect.any(Headers),
-            toResponse: expect.any(Function),
-        })
-    })
-
-    test("toResponse returns correct response on failure", async () => {
-        const output = await api.refreshUserInfo("unsupported")
-
-        const response = output.toResponse()
-        expect(response.status).toBe(400)
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.session_token=${sessionToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                },
+            })
+        )
 
         expect(await response.json()).toEqual({
             success: false,
@@ -305,7 +278,6 @@ describe("refreshUserInfo", () => {
     })
 
     test("handles getProviderTokens failure", async () => {
-        vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
         const sessionToken = await jose.encodeJWT(sessionPayload)
 
@@ -315,24 +287,21 @@ describe("refreshUserInfo", () => {
         } as unknown as Record<string, unknown>)
 
         const { refreshToken: _, ...spread } = oauthCustomService
-        const { api } = createAuth({ oauth: [spread] })
+        const { handlers } = createAuth({ oauth: [spread] })
 
-        const output = await api.refreshUserInfo("oauth-provider", {
-            headers: {
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
-            },
-        })
+        const response = await handlers.POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.session_token=${sessionToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                },
+            })
+        )
 
-        expect(output).toEqual({
+        expect(await response.json()).toEqual({
             success: false,
             session: null,
-            error: {
-                code: "INVALID_ACCESS_TOKEN_RETRIEVING_REFRESH_USER_INFO",
-                message: "Failed to sync profile data. Your active session access token is missing or invalid.",
-            },
-            headers: expect.any(Headers),
-            toResponse: expect.any(Function),
         })
     })
 
@@ -364,20 +333,29 @@ describe("refreshUserInfo", () => {
         })
         vi.stubGlobal("fetch", mockFetch)
 
-        const output = await api.refreshUserInfo("oauth-provider", {
-            headers: {
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.session_token=${sessionToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                },
+            })
+        )
+
+        expect(await response.json()).toEqual({
+            success: true,
+            session: {
+                sub: "1234567890",
+                email: "john@example.com",
+                name: "John Doe",
+                image: "https://example.com/image.jpg",
             },
         })
-
-        expect(output.success).toBe(true)
-        expect(output.session).not.toBeNull()
         expect(mockFetch).toHaveBeenCalledTimes(2)
     })
 
     test("handles invalid user info response with missing content type", async () => {
-        vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
         const sessionToken = await jose.encodeJWT(sessionPayload)
 
@@ -395,52 +373,43 @@ describe("refreshUserInfo", () => {
         })
         vi.stubGlobal("fetch", mockFetch)
 
-        const output = await api.refreshUserInfo("oauth-provider", {
-            headers: {
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
-            },
-        })
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                },
+            })
+        )
 
-        expect(output).toEqual({
+        expect(await response.json()).toEqual({
             success: false,
             session: null,
-            error: {
-                code: "OAUTH_INVALID_CONTENT_TYPE",
-                message:
-                    "The identity provider returned an unreadable response format. Please try again or check the provider status.",
-            },
-            headers: expect.any(Headers),
-            toResponse: expect.any(Function),
         })
     })
 
     test("handles session token verification failure", async () => {
-        vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
         const invalidSessionToken = "invalid.session.token"
 
-        const output = await api.refreshUserInfo("oauth-provider", {
-            headers: {
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${invalidSessionToken}`,
-            },
-        })
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${invalidSessionToken}`,
+                },
+            })
+        )
 
-        expect(output).toEqual({
+        expect(await response.json()).toEqual({
             success: false,
             session: null,
-            error: {
-                code: "SESSION_INVALID",
-                message: "The session is not valid. Its signature or decryption parameters failed.",
-            },
-            headers: expect.any(Headers),
-            toResponse: expect.any(Function),
         })
     })
 
     test("updates session cookie with new session token", async () => {
-        vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
         const sessionToken = await jose.encodeJWT(sessionPayload)
 
@@ -459,44 +428,49 @@ describe("refreshUserInfo", () => {
         })
         vi.stubGlobal("fetch", mockFetch)
 
-        const output = await api.refreshUserInfo("oauth-provider", {
-            headers: {
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.session_token=${sessionToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                },
+            })
+        )
+
+        expect(await response.json()).toEqual({
+            success: true,
+            session: {
+                sub: "1234567890",
+                email: "john@example.com",
+                name: "John Doe",
+                image: "https://example.com/image.jpg",
             },
         })
-
-        expect(output.success).toBe(true)
-        const setCookieHeader = output.headers.get("set-cookie")
-        expect(setCookieHeader).toContain("aura-auth.session_token=")
+        expect(response.headers.get("set-cookie")).toContain("aura-auth.session_token=")
     })
 
     test("handles malformed provider tokens cookie", async () => {
-        vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
         const sessionToken = await jose.encodeJWT(sessionPayload)
 
-        const output = await api.refreshUserInfo("oauth-provider", {
-            headers: {
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=malformed-token`,
-            },
-        })
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=malformed-token`,
+                },
+            })
+        )
 
-        expect(output).toEqual({
+        expect(await response.json()).toEqual({
             success: false,
             session: null,
-            error: {
-                code: "INVALID_ACCESS_TOKEN_RETRIEVING_REFRESH_USER_INFO",
-                message: "Failed to sync profile data. Your active session access token is missing or invalid.",
-            },
-            headers: expect.any(Headers),
-            toResponse: expect.any(Function),
         })
     })
 
     test("successfully refreshes with custom profile function", async () => {
-        vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
         const sessionToken = await jose.encodeJWT(sessionPayload)
 
@@ -517,28 +491,28 @@ describe("refreshUserInfo", () => {
         })
         vi.stubGlobal("fetch", mockFetch)
 
-        const output = await api.refreshUserInfo("oauth-profile", {
-            headers: {
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-profile=${encodedTokens}`,
-            },
-        })
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-profile/user/refresh", {
+                method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.session_token=${sessionToken}; __Secure-aura-auth.access_token.oauth-profile=${encodedTokens}`,
+                },
+            })
+        )
 
-        expect(output).toEqual({
+        expect(await response.json()).toEqual({
             success: true,
-            session: {
+            session: expect.objectContaining({
                 sub: "1234567890",
                 email: "john@example.com",
                 name: "John Doe",
                 image: "https://example.com/image.jpg",
-            },
-            headers: expect.any(Headers),
-            toResponse: expect.any(Function),
+            }),
         })
     })
 
     test("toResponse returns correct response on success", async () => {
-        vi.stubEnv("BASE_URL", "https://example.com")
         const csrfToken = await createCSRF(jose)
         const sessionToken = await jose.encodeJWT(sessionPayload)
 
@@ -557,15 +531,15 @@ describe("refreshUserInfo", () => {
         })
         vi.stubGlobal("fetch", mockFetch)
 
-        const output = await api.refreshUserInfo("oauth-provider", {
-            headers: {
-                "X-CSRF-Token": csrfToken,
-                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
-            },
-        })
-
-        const response = output.toResponse()
-        expect(response.status).toBe(200)
+        const response = await POST(
+            new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
+                method: "POST",
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    Cookie: `__Host-aura-auth.csrf_token=${csrfToken}; __Secure-aura-auth.session_token=${sessionToken}; __Secure-aura-auth.access_token.oauth-provider=${encodedTokens}`,
+                },
+            })
+        )
 
         expect(await response.json()).toEqual({
             success: true,

--- a/packages/core/test/api/refreshUserInfo.test.ts
+++ b/packages/core/test/api/refreshUserInfo.test.ts
@@ -10,6 +10,7 @@ beforeEach(() => {
 
 afterEach(() => {
     vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
 })
 
 vi.mock("@aura-stack/rate-limiter", async () => {
@@ -125,7 +126,7 @@ describe("refreshUserInfo", () => {
             success: false,
             session: null,
             error: {
-                code: "INVALID_ACCESS_TOKEN_RETRIVING_REFRESH_USER_INFO",
+                code: "INVALID_ACCESS_TOKEN_RETRIEVING_REFRESH_USER_INFO",
                 message: "Failed to sync profile data. Your active session access token is missing or invalid.",
             },
             headers: expect.any(Headers),
@@ -252,6 +253,7 @@ describe("refreshUserInfo", () => {
 
         const mockFetch = vi.fn().mockResolvedValueOnce({
             ok: true,
+            headers: new Headers({ "Content-Type": "application/json" }),
             json: async () => ({
                 error: "invalid_token",
                 error_description: "The access token expired",
@@ -270,8 +272,8 @@ describe("refreshUserInfo", () => {
             success: false,
             session: null,
             error: {
-                code: "UNKNOWN_OAUTH_USER_INFO_ERROR",
-                message: "Failed to communicate clean state down to the user configuration data provider.",
+                code: "INVALID_OAUTH_USER_INFO_RES_FORMAT",
+                message: "The returned user info profile structure payload is corrupted or unexpected.",
             },
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
@@ -350,7 +352,7 @@ describe("refreshUserInfo", () => {
             success: false,
             session: null,
             error: {
-                code: "INVALID_ACCESS_TOKEN_RETRIVING_REFRESH_USER_INFO",
+                code: "INVALID_ACCESS_TOKEN_RETRIEVING_REFRESH_USER_INFO",
                 message: "Failed to sync profile data. Your active session access token is missing or invalid.",
             },
             headers: expect.any(Headers),
@@ -509,7 +511,7 @@ describe("refreshUserInfo", () => {
             success: false,
             session: null,
             error: {
-                code: "INVALID_ACCESS_TOKEN_RETRIVING_REFRESH_USER_INFO",
+                code: "INVALID_ACCESS_TOKEN_RETRIEVING_REFRESH_USER_INFO",
                 message: "Failed to sync profile data. Your active session access token is missing or invalid.",
             },
             headers: expect.any(Headers),

--- a/packages/core/test/api/refreshUserInfo.test.ts
+++ b/packages/core/test/api/refreshUserInfo.test.ts
@@ -1,0 +1,600 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest"
+import { api, jose, oauthCustomService, oauthTokens, sessionPayload } from "@test/presets.ts"
+import { createCSRF } from "@/shared/crypto.ts"
+import { createAuth } from "@/createAuth.ts"
+import { AURA_AUTH_VERSION } from "@/shared/utils.ts"
+
+beforeEach(() => {
+    vi.stubEnv("BASE_URL", undefined)
+})
+
+afterEach(() => {
+    vi.unstubAllEnvs()
+})
+
+vi.mock("@aura-stack/rate-limiter", async () => {
+    const actual = await vi.importActual<typeof import("@aura-stack/rate-limiter")>("@aura-stack/rate-limiter")
+    return {
+        ...actual,
+        createRateLimiter: (...args: Parameters<typeof actual.createRateLimiter>) => {
+            const limiters = actual.createRateLimiter(...args)
+
+            for (const limiter of Object.values(limiters)) {
+                limiter.check = vi.fn().mockResolvedValue({
+                    ok: true,
+                    limit: Number.MAX_SAFE_INTEGER,
+                    remaining: Number.MAX_SAFE_INTEGER,
+                    resetAt: Date.now() + 60000,
+                    retryAfter: 0,
+                    toResponse: () => new Response(),
+                })
+            }
+
+            return limiters
+        },
+    }
+})
+
+describe("refreshUserInfo", () => {
+    test("unsupported oauth provider", async () => {
+        const output = await api.refreshUserInfo("unsupported")
+        expect(output).toEqual({
+            success: false,
+            session: null,
+            error: {
+                code: "UNSUPPORTED_OAUTH_CONFIGURATION",
+                message: "The targeted OAuth provider has not been configured in the initialization parameters.",
+            },
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+    })
+
+    test("invalid operation when the session token is missing", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+
+        const output = await api.refreshUserInfo("oauth-provider", { headers: new Headers() })
+        expect(output).toEqual({
+            success: false,
+            session: null,
+            error: {
+                code: "SESSION_NOT_FOUND",
+                message: "The session token is not found. There is no active session.",
+            },
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+    })
+
+    test("throws error when CSRF token is missing", async () => {
+        vi.stubEnv("BASE_URL", "http://localhost:3000")
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: {
+                Cookie: `aura-auth.session_token=${sessionToken}`,
+            },
+        })
+        expect(output).toEqual({
+            success: false,
+            session: null,
+            error: {
+                code: "CSRF_TOKEN_MISSING",
+                message: "The CSRF token is missing. Please refresh and try again.",
+            },
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+    })
+
+    test("throws error when CSRF token is invalid", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: new Headers({
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}`,
+                "X-CSRF-Token": "invalid-token",
+            }),
+        })
+        expect(output).toEqual({
+            success: false,
+            session: null,
+            error: {
+                code: "CSRF_TOKEN_MISMATCH",
+                message: "CSRF token verification failed. Please refresh and try again.",
+            },
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+    })
+
+    test("throws error when provider token does not exist", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}`,
+            },
+        })
+        expect(output).toEqual({
+            success: false,
+            session: null,
+            error: {
+                code: "INVALID_ACCESS_TOKEN_RETRIVING_REFRESH_USER_INFO",
+                message: "Failed to sync profile data. Your active session access token is missing or invalid.",
+            },
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+    })
+
+    test("successfully refreshes user info", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const encodedTokens = await jose.encodeJWT(oauthTokens as unknown as Record<string, unknown>)
+
+        const mockFetch = vi.fn()
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            headers: new Headers({ "Content-Type": "application/json" }),
+            json: async () => ({
+                id: "1234567890",
+                email: "john@example.com",
+                name: "John Doe",
+                image: "https://example.com/image.jpg",
+            }),
+        })
+        vi.stubGlobal("fetch", mockFetch)
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+            },
+        })
+
+        expect(output.success).toBe(true)
+        expect(output.session).not.toBeNull()
+        expect(output.session).toMatchObject({
+            sub: "1234567890",
+            email: "john@example.com",
+            name: "John Doe",
+            image: "https://example.com/image.jpg",
+        })
+        expect(output.headers).toBeInstanceOf(Headers)
+        expect(output.toResponse).toBeInstanceOf(Function)
+
+        expect(mockFetch).toHaveBeenCalledWith("https://example.com/oauth/userinfo", {
+            method: "GET",
+            headers: {
+                "User-Agent": `Aura Auth/${AURA_AUTH_VERSION}`,
+                Accept: "application/json",
+                Authorization: `Bearer ${oauthTokens.accessToken}`,
+            },
+            signal: expect.any(AbortSignal),
+        })
+    })
+
+    test("handles getUserInfo network error gracefully", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const encodedTokens = await jose.encodeJWT(oauthTokens as unknown as Record<string, unknown>)
+
+        const mockFetch = vi.fn().mockRejectedValueOnce(new Error("Network connection lost"))
+        vi.stubGlobal("fetch", mockFetch)
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+            },
+        })
+
+        expect(output).toEqual({
+            success: false,
+            session: null,
+            error: {
+                code: "UNKNOWN_OAUTH_USER_INFO_ERROR",
+                message: "Failed to communicate clean state down to the user configuration data provider.",
+            },
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+    })
+
+    test("handles getUserInfo invalid response from provider", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const encodedTokens = await jose.encodeJWT(oauthTokens as unknown as Record<string, unknown>)
+
+        const mockFetch = vi.fn().mockResolvedValueOnce({
+            ok: false,
+            status: 401,
+        })
+        vi.stubGlobal("fetch", mockFetch)
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+            },
+        })
+
+        expect(output).toEqual({
+            success: false,
+            session: null,
+            error: {
+                code: "INVALID_OAUTH_USER_INFO_RESPONSE",
+                message: "The resource userInfo target server returned an error code response.",
+            },
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+    })
+
+    test("handles getUserInfo OAuth error response", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const encodedTokens = await jose.encodeJWT(oauthTokens as unknown as Record<string, unknown>)
+
+        const mockFetch = vi.fn().mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                error: "invalid_token",
+                error_description: "The access token expired",
+            }),
+        })
+        vi.stubGlobal("fetch", mockFetch)
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+            },
+        })
+
+        expect(output).toEqual({
+            success: false,
+            session: null,
+            error: {
+                code: "UNKNOWN_OAUTH_USER_INFO_ERROR",
+                message: "Failed to communicate clean state down to the user configuration data provider.",
+            },
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+    })
+
+    test("handles getUserInfo missing required user fields", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const encodedTokens = await jose.encodeJWT(oauthTokens as unknown as Record<string, unknown>)
+
+        const mockFetch = vi.fn().mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                email: "john@example.com",
+                name: "John Doe",
+            }),
+        })
+        vi.stubGlobal("fetch", mockFetch)
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+            },
+        })
+
+        expect(output).toEqual({
+            success: false,
+            session: null,
+            error: {
+                code: "UNKNOWN_OAUTH_USER_INFO_ERROR",
+                message: "Failed to communicate clean state down to the user configuration data provider.",
+            },
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+    })
+
+    test("toResponse returns correct response on failure", async () => {
+        const output = await api.refreshUserInfo("unsupported")
+
+        const response = output.toResponse()
+        expect(response.status).toBe(400)
+
+        const responseBody = await response.json()
+        expect(responseBody).toEqual({
+            success: false,
+            session: null,
+        })
+    })
+
+    test("handles getProviderTokens failure", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const encodedTokens = await jose.encodeJWT({
+            ...oauthTokens,
+            expiresAt: Math.floor(Date.now() / 1000) - 3600,
+        } as unknown as Record<string, unknown>)
+
+        const { refreshToken: _, ...spread } = oauthCustomService
+        const { api } = createAuth({ oauth: [spread] })
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+            },
+        })
+
+        expect(output).toEqual({
+            success: false,
+            session: null,
+            error: {
+                code: "INVALID_ACCESS_TOKEN_RETRIVING_REFRESH_USER_INFO",
+                message: "Failed to sync profile data. Your active session access token is missing or invalid.",
+            },
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+    })
+
+    test("handles expired access token with successful refresh", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const encodedTokens = await jose.encodeJWT({
+            ...oauthTokens,
+            expiresAt: Math.floor(Date.now() / 1000) - 3600,
+        } as unknown as Record<string, unknown>)
+
+        const mockFetch = vi.fn()
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            headers: new Headers({ "Content-Type": "application/json" }),
+            json: async () => oauthTokens,
+        })
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            headers: new Headers({ "Content-Type": "application/json" }),
+            json: async () => ({
+                id: "1234567890",
+                email: "john@example.com",
+                name: "John Doe",
+                image: "https://example.com/image.jpg",
+            }),
+        })
+        vi.stubGlobal("fetch", mockFetch)
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+            },
+        })
+
+        expect(output.success).toBe(true)
+        expect(output.session).not.toBeNull()
+        expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    test("handles invalid user info response with missing content type", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const encodedTokens = await jose.encodeJWT(oauthTokens as unknown as Record<string, unknown>)
+
+        const mockFetch = vi.fn().mockResolvedValueOnce({
+            ok: true,
+            headers: {
+                get: (name: string) => (name === "content-type" ? "text/html" : null),
+            },
+            json: async () => ({
+                id: "1234567890",
+                email: "john@example.com",
+            }),
+        })
+        vi.stubGlobal("fetch", mockFetch)
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+            },
+        })
+
+        expect(output).toEqual({
+            success: false,
+            session: null,
+            error: {
+                code: "OAUTH_INVALID_CONTENT_TYPE",
+                message:
+                    "The identity provider returned an unreadable response format. Please try again or check the provider status.",
+            },
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+    })
+
+    test("handles session token verification failure", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const invalidSessionToken = "invalid.session.token"
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${invalidSessionToken}`,
+            },
+        })
+
+        expect(output).toEqual({
+            success: false,
+            session: null,
+            error: {
+                code: "SESSION_INVALID",
+                message: "The session is not valid. Its signature or decryption parameters failed.",
+            },
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+    })
+
+    test("updates session cookie with new session token", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const encodedTokens = await jose.encodeJWT(oauthTokens as unknown as Record<string, unknown>)
+
+        const mockFetch = vi.fn()
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            headers: new Headers({ "Content-Type": "application/json" }),
+            json: async () => ({
+                id: "1234567890",
+                email: "john@example.com",
+                name: "John Doe",
+                image: "https://example.com/image.jpg",
+            }),
+        })
+        vi.stubGlobal("fetch", mockFetch)
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+            },
+        })
+
+        expect(output.success).toBe(true)
+        const setCookieHeader = output.headers.get("set-cookie")
+        expect(setCookieHeader).toContain("aura-auth.session_token=")
+    })
+
+    test("handles malformed provider tokens cookie", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=malformed-token`,
+            },
+        })
+
+        expect(output).toEqual({
+            success: false,
+            session: null,
+            error: {
+                code: "INVALID_ACCESS_TOKEN_RETRIVING_REFRESH_USER_INFO",
+                message: "Failed to sync profile data. Your active session access token is missing or invalid.",
+            },
+            headers: expect.any(Headers),
+            toResponse: expect.any(Function),
+        })
+    })
+
+    test("successfully refreshes with custom profile function", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const encodedTokens = await jose.encodeJWT(oauthTokens as unknown as Record<string, unknown>)
+
+        const mockFetch = vi.fn()
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            headers: new Headers({ "Content-Type": "application/json" }),
+            json: async () => ({
+                id: "1234567890",
+                email: "john@example.com",
+                name: "John Doe",
+                image: "https://example.com/image.jpg",
+                nickname: "johnny",
+                email_verified: true,
+            }),
+        })
+        vi.stubGlobal("fetch", mockFetch)
+
+        const output = await api.refreshUserInfo("oauth-profile", {
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-profile=${encodedTokens}`,
+            },
+        })
+
+        expect(output.success).toBe(true)
+        expect(output.session).not.toBeNull()
+        expect(output.session).toMatchObject({
+            sub: "1234567890",
+            email: "john@example.com",
+            name: "John Doe",
+            image: "https://example.com/image.jpg",
+        })
+    })
+
+    test("toResponse returns correct response on success", async () => {
+        vi.stubEnv("BASE_URL", "https://example.com")
+        const csrfToken = await createCSRF(jose)
+        const sessionToken = await jose.encodeJWT(sessionPayload)
+
+        const encodedTokens = await jose.encodeJWT(oauthTokens as unknown as Record<string, unknown>)
+
+        const mockFetch = vi.fn()
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            headers: new Headers({ "Content-Type": "application/json" }),
+            json: async () => ({
+                id: "1234567890",
+                email: "john@example.com",
+                name: "John Doe",
+                image: "https://example.com/image.jpg",
+            }),
+        })
+        vi.stubGlobal("fetch", mockFetch)
+
+        const output = await api.refreshUserInfo("oauth-provider", {
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                Cookie: `aura-auth.csrf_token=${csrfToken}; aura-auth.session_token=${sessionToken}; aura-auth.access_token.oauth-provider=${encodedTokens}`,
+            },
+        })
+
+        const response = output.toResponse()
+        expect(response.status).toBe(200)
+
+        const responseBody = await response.json()
+        expect(responseBody).toEqual({
+            success: true,
+            session: expect.objectContaining({
+                sub: "1234567890",
+                email: "john@example.com",
+                name: "John Doe",
+                image: "https://example.com/image.jpg",
+            }),
+        })
+    })
+})


### PR DESCRIPTION
## Description

This pull request introduces the experimental `refreshUserInfo()` API for both server-side and client-side applications.

The new API allows applications to refresh a user's profile information and update the current session without requiring the user to sign in again. It fetches the latest user information from the OAuth or OpenID Connect (OIDC) provider's configured `userInfo` endpoint, reconstructs the user profile using the provider's `profile` mapping function, and updates the session with the refreshed data.

On the server, the functionality is exposed through `auth.api.refreshUserInfo()`. On the client, `createAuthClient().refreshUserInfo()` communicates with the `POST /providers/:provider/user/refresh` endpoint to perform the same operation.

## Usage

### Server-side

```ts id="k9m3vb"
import { createAuth } from "@aura-stack/auth"

export const auth = createAuth({
  oauth: ["google"],
})

const { success, session } = await auth.api.refreshUserInfo("google")
```

### Client-side

```ts
import { createAuthClient } from "@aura-stack/auth/client"

export const authClient = createAuthClient({})

const session = await authClient.refreshUserInfo("google")
```

> [!NOTE]
> `refreshUserInfo()` requires the configured provider to expose a `userInfo` endpoint. Providers that do not implement user information retrieval cannot support this feature.


@coderabbitai ignore