### PR TITLE
docs(api-reference): add documentation for experimental APIs

### DIFF
--- a/docs/src/content/docs/(core)/api-reference/client/functions/disconnectProvider.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/disconnectProvider.mdx
@@ -1,0 +1,59 @@
+---
+title: disconnectProvider
+description: Disconnect an OAuth provider from the current session, from the client.
+---
+
+The `disconnectProvider` client method disconnects an OAuth provider from the current session, without revoking its access token, from a client-side or browser context.
+
+```ts title="disconnect-provider.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const success = await authClient.disconnectProvider("github")
+```
+
+<Callout>
+  This is a softer alternative to `revokeToken`: it disconnects the provider from the session without revoking the access token
+  itself. See [`revokeToken`](/docs/api-reference/client/functions/revokeToken) for the stronger alternative.
+</Callout>
+
+## Reference
+
+### Parameters
+
+| Parameter  | Type     | Required | Description                                 |
+| ---------- | -------- | -------- | ------------------------------------------- |
+| providerId | `string` | Yes      | The id of the OAuth provider to disconnect. |
+
+### Returns
+
+| Return Type        | Description                                                                          |
+| ------------------ | ------------------------------------------------------------------------------------ |
+| `Promise<boolean>` | Resolves to `true` if the provider was successfully disconnected, `false` otherwise. |
+
+## Behavior
+
+- Cookies are read automatically from the browser context — you don't need to handle them or CSRF tokens manually.
+- The access token itself remains valid until it naturally expires or is separately revoked with `revokeToken`.
+- If disconnection fails (the provider isn't connected to the current session), the method resolves to `false` — this does not throw an error, as "not connected" is an expected outcome.
+
+## Usage
+
+### Disconnect a provider
+
+```ts title="disconnect-provider.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const success = await authClient.disconnectProvider("github")
+```
+
+### Handling failure
+
+```tsx title="handle-failure.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const success = await authClient.disconnectProvider("github")
+
+if (!success) {
+  window.location.assign("/settings/connections")
+}
+```

--- a/docs/src/content/docs/(core)/api-reference/client/functions/getAccessToken.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/getAccessToken.mdx
@@ -1,0 +1,64 @@
+---
+title: getAccessToken
+description: Retrieve the OAuth access token for a connected provider, from the client.
+---
+
+The `getAccessToken` client method retrieves the OAuth access token for a specific connected provider, from a client-side or browser context.
+
+```ts title="get-access-token.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const accessToken = await authClient.getAccessToken("github")
+```
+
+<Callout>
+  This is a simplified version of `getProviderTokens`, which retrieves the full set of OAuth tokens for a provider. See
+  [`getProviderTokens`](/docs/api-reference/client/functions/getProviderTokens) for the advanced alternative.
+</Callout>
+
+## Reference
+
+### Parameters
+
+| Parameter  | Type     | Required | Description                                                    |
+| ---------- | -------- | -------- | -------------------------------------------------------------- |
+| providerId | `string` | Yes      | The id of the OAuth provider to retrieve the access token for. |
+
+### Returns
+
+| Return Type               | Description                                                |
+| ------------------------- | ---------------------------------------------------------- |
+| `Promise<string \| null>` | Resolves to the access token or `null` if retrieval fails. |
+
+## Behavior
+
+- Cookies are read automatically from the browser context — you don't need to handle them or CSRF tokens manually.
+- If retrieval fails (no valid access or refresh token for the provider), the method resolves to `null` — this does not throw an error, as "not connected" is an expected outcome.
+
+## Usage
+
+### Get a provider's access token
+
+```ts title="get-access-token.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const accessToken = await authClient.getAccessToken("github")
+```
+
+### Using the token in a request
+
+```tsx title="protected-fetch.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const accessToken = await authClient.getAccessToken("github")
+
+if (!accessToken) {
+  window.location.assign("/login")
+}
+
+const response = await fetch("/api/some-protected-route", {
+  headers: {
+    Authorization: `Bearer ${accessToken}`,
+  },
+})
+```

--- a/docs/src/content/docs/(core)/api-reference/client/functions/getProviderTokens.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/getProviderTokens.mdx
@@ -1,0 +1,64 @@
+---
+title: getProviderTokens
+description: Retrieve the full set of OAuth tokens for a connected provider, from the client.
+---
+
+The `getProviderTokens` client method retrieves the full set of OAuth tokens (access token, refresh token, and ID token) for a specific connected provider, from a client-side or browser context.
+
+```ts title="get-provider-tokens.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const { success, tokens } = await authClient.getProviderTokens("github")
+```
+
+<Callout>
+  This is the advanced version of `getAccessToken`, which only returns the access token. Use this if you need the full token set.
+  See [`getAccessToken`](/docs/api-reference/client/functions/getAccessToken) for the simpler alternative.
+</Callout>
+
+## Reference
+
+### Parameters
+
+| Parameter  | Type     | Required | Description                                              |
+| ---------- | -------- | -------- | -------------------------------------------------------- |
+| providerId | `string` | Yes      | The id of the OAuth provider to retrieve the tokens for. |
+
+### Returns
+
+| Return Type                     | Description                                              |
+| ------------------------------- | -------------------------------------------------------- |
+| `Promise<ProviderTokensReturn>` | Resolves to an object containing `success` and `tokens`. |
+
+## Behavior
+
+- Cookies are read automatically from the browser context — you don't need to handle them or CSRF tokens manually.
+- Follows the same access-token → refresh-token fallback described in [`api.getProviderTokens`](/docs/api-reference/server/api/getProviderTokens#behavior). If neither is valid, resolves to `success: false` and `tokens: null`.
+
+## Usage
+
+### Get a provider's tokens
+
+```ts title="get-provider-tokens.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const { success, tokens } = await authClient.getProviderTokens("github")
+```
+
+### Using a token in a request
+
+```tsx title="protected-fetch.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const { success, tokens } = await authClient.getProviderTokens("github")
+
+if (!success) {
+  window.location.assign("/login")
+}
+
+const response = await fetch("/api/some-protected-route", {
+  headers: {
+    Authorization: `Bearer ${tokens?.accessToken}`,
+  },
+})
+```

--- a/docs/src/content/docs/(core)/api-reference/client/functions/index.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/index.mdx
@@ -1,0 +1,88 @@
+---
+title: functions
+description: The functions exposed by createAuthClient — sign-in, sign-up, session management, OAuth token management, and sign-out for client-side and browser contexts.
+---
+
+### Signature
+
+```ts lineNumbers
+function createAuthClient<DefaultUser extends User = User, SignUpPayload extends Record<string, any> = Record<string, any>>(
+  options: AuthClientOptions
+): {
+  getSession(): Promise<Session<User> | null>
+  signIn<Options extends SignInOptions>(
+    oauth: LiteralUnion<BuiltInOAuthProvider>,
+    options?: Options | undefined
+  ): Promise<SignInReturn<Options>>
+  signInCredentials<Options extends SignInCredentialsOptions>(options: Options): Promise<SignInCredentialsReturn<Options>>
+  signUp<Options extends SignUpOptions<Record<string, any>>>(options: Options): Promise<SignUpReturn<Options>>
+  updateSession<Options extends UpdateSessionOptions<User>>(options: Options): Promise<UpdateSessionReturn<Options, User>>
+  signOut<Options extends SignOutOptions>(options?: Options): Promise<SignOutReturn<Options>>
+  // OAuth token management
+  getAccessToken(providerId: string): Promise<AccessTokenReturn>
+  getProviderTokens(providerId: string): Promise<ProviderTokensReturn>
+  isProviderConnected(providerId: string): Promise<ProviderConnectedReturn>
+  refreshUserInfo(providerId: string): Promise<RefreshUserInfoReturn<User>>
+  revokeToken(providerId: string): Promise<RevokeTokenReturn>
+  disconnectProvider(providerId: string): Promise<DisconnectProviderReturn>
+}
+```
+
+Unlike `auth.api` on the server, `createAuthClient()` returns a **flat object** — there's no `client.functions` namespace. This page exists purely as a browsable index; every method below is called directly on your `authClient` instance (e.g. `authClient.signIn(...)`).
+
+<Callout type="info">
+  All of these run in a client-side or browser context and read/write cookies automatically — none of them accept `request`,
+  `headers`, or `skipCSRFCheck`. For the equivalent server-side surface, see [`api`](/docs/api-reference/server/api).
+</Callout>
+
+<Cards>
+
+<Card title="signIn" href="/docs/api-reference/client/functions/signIn">
+  Signs in a user with a built-in or custom OAuth provider.
+</Card>
+
+<Card title="signInCredentials" href="/docs/api-reference/client/functions/signInCredentials">
+  Signs in a user with a username/email and password.
+</Card>
+
+<Card title="signUp" href="/docs/api-reference/client/functions/signUp">
+  Registers a new user.
+</Card>
+
+<Card title="getSession" href="/docs/api-reference/client/functions/getSession">
+  Returns the current user's session.
+</Card>
+
+<Card title="updateSession" href="/docs/api-reference/client/functions/updateSession">
+  Updates the current user's session data.
+</Card>
+
+<Card title="isProviderConnected" href="/docs/api-reference/client/functions/isProviderConnected">
+  Verifies whether the current session is connected to a specific OAuth provider.
+</Card>
+
+<Card title="getProviderTokens" href="/docs/api-reference/client/functions/getProviderTokens">
+  Retrieves the full set of tokens for a specific OAuth provider.
+</Card>
+
+<Card title="getAccessToken" href="/docs/api-reference/client/functions/getAccessToken">
+  Retrieves the access token for a specific OAuth provider.
+</Card>
+
+<Card title="refreshUserInfo" href="/docs/api-reference/client/functions/refreshUserInfo">
+  Refreshes the user's profile information from the OAuth provider.
+</Card>
+
+<Card title="disconnectProvider" href="/docs/api-reference/client/functions/disconnectProvider">
+  Disconnects the current session from a specific OAuth provider without revoking its token.
+</Card>
+
+<Card title="revokeToken" href="/docs/api-reference/client/functions/revokeToken">
+  Revokes the access token for a specific OAuth provider.
+</Card>
+
+<Card title="signOut" href="/docs/api-reference/client/functions/signOut">
+  Signs out the current user and invalidates the session.
+</Card>
+
+</Cards>

--- a/docs/src/content/docs/(core)/api-reference/client/functions/index.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/index.mdx
@@ -18,13 +18,12 @@ function createAuthClient<DefaultUser extends User = User, SignUpPayload extends
   signUp<Options extends SignUpOptions<Record<string, any>>>(options: Options): Promise<SignUpReturn<Options>>
   updateSession<Options extends UpdateSessionOptions<User>>(options: Options): Promise<UpdateSessionReturn<Options, User>>
   signOut<Options extends SignOutOptions>(options?: Options): Promise<SignOutReturn<Options>>
-  // OAuth token management
-  getAccessToken(providerId: string): Promise<AccessTokenReturn>
-  getProviderTokens(providerId: string): Promise<ProviderTokensReturn>
-  isProviderConnected(providerId: string): Promise<ProviderConnectedReturn>
-  refreshUserInfo(providerId: string): Promise<RefreshUserInfoReturn<User>>
-  revokeToken(providerId: string): Promise<RevokeTokenReturn>
-  disconnectProvider(providerId: string): Promise<DisconnectProviderReturn>
+  getAccessToken(oauth: LiteralUnion<BuiltInOAuthProvider>): Promise<string | null>
+  getProviderTokens(oauth: LiteralUnion<BuiltInOAuthProvider>): Promise<GetProviderTokensReturn>
+  isProviderConnected(oauth: LiteralUnion<BuiltInOAuthProvider>): Promise<boolean>
+  refreshUserInfo(oauth: LiteralUnion<BuiltInOAuthProvider>): Promise<Session<User> | null>
+  revokeToken(oauth: LiteralUnion<BuiltInOAuthProvider>): Promise<boolean>
+  disconnectProvider(oauth: LiteralUnion<BuiltInOAuthProvider>): Promise<boolean>
 }
 ```
 

--- a/docs/src/content/docs/(core)/api-reference/client/functions/isProviderConnected.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/isProviderConnected.mdx
@@ -1,0 +1,59 @@
+---
+title: isProviderConnected
+description: Check whether the current session has an active connection with a specific OAuth provider, from the client.
+---
+
+The `isProviderConnected` client method checks whether the current session has an active connection with a specific OAuth provider, from a client-side or browser context.
+
+```ts title="is-provider-connected.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const connected = await authClient.isProviderConnected("github")
+```
+
+<Callout>
+  This only checks connection status — it doesn't return token data. If you need the access token, use
+  [`getAccessToken`](/docs/api-reference/client/functions/getAccessToken) instead.
+</Callout>
+
+## Reference
+
+### Parameters
+
+| Parameter  | Type     | Required | Description                                               |
+| ---------- | -------- | -------- | --------------------------------------------------------- |
+| providerId | `string` | Yes      | The id of the OAuth provider to check the connection for. |
+
+### Returns
+
+| Return Type        | Description                                                         |
+| ------------------ | ------------------------------------------------------------------- |
+| `Promise<boolean>` | Resolves to a boolean indicating whether the provider is connected. |
+
+## Behavior
+
+- Cookies are read automatically from the browser context — you don't need to handle them or CSRF tokens manually.
+- On success, the method resolves to `true` or `false`. This does not throw for "not connected" — that's an expected outcome.
+- If the check itself fails (e.g. no valid session), the method resolves to `null` and `success` is `false` — distinct from `connected: false`.
+
+## Usage
+
+### Check a provider's connection status
+
+```ts title="is-provider-connected.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const connected = await authClient.isProviderConnected("github")
+```
+
+### Prompting the user to connect a provider
+
+```tsx title="connect-prompt.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const connected = await authClient.isProviderConnected("github")
+
+if (!connected) {
+  window.location.assign("/settings/connections/github")
+}
+```

--- a/docs/src/content/docs/(core)/api-reference/client/functions/isProviderConnected.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/isProviderConnected.mdx
@@ -34,7 +34,7 @@ const connected = await authClient.isProviderConnected("github")
 
 - Cookies are read automatically from the browser context — you don't need to handle them or CSRF tokens manually.
 - On success, the method resolves to `true` or `false`. This does not throw for "not connected" — that's an expected outcome.
-- If the check itself fails (e.g. no valid session), the method resolves to `null` and `success` is `false` — distinct from `connected: false`.
+- If the check itself fails (e.g. no valid session), the method resolves to `false` rather than throwing an error. This is to avoid exposing session state to the client.
 
 ## Usage
 

--- a/docs/src/content/docs/(core)/api-reference/client/functions/meta.json
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/meta.json
@@ -1,4 +1,17 @@
 {
   "title": "Functions",
-  "pages": ["signIn", "signInCredentials", "signUp", "getSession", "updateSession", "signOut"]
+  "pages": [
+    "signIn",
+    "signInCredentials",
+    "signUp",
+    "getSession",
+    "updateSession",
+    "isProviderConnected",
+    "getProviderTokens",
+    "getAccessToken",
+    "refreshUserInfo",
+    "disconnectProvider",
+    "revokeToken",
+    "signOut"
+  ]
 }

--- a/docs/src/content/docs/(core)/api-reference/client/functions/refreshUserInfo.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/refreshUserInfo.mdx
@@ -1,0 +1,58 @@
+---
+title: refreshUserInfo
+description: Refresh the current user's profile data from a connected provider, from the client.
+---
+
+The `refreshUserInfo` client method refreshes the current user's profile data from a connected provider, without requiring re-authentication, from a client-side or browser context.
+
+```ts title="refresh-user-info.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const userInfo = await authClient.refreshUserInfo("github")
+```
+
+## Reference
+
+### Parameters
+
+| Parameter  | Type     | Required | Description                                             |
+| ---------- | -------- | -------- | ------------------------------------------------------- |
+| providerId | `string` | Yes      | The id of the OAuth provider to refresh user info from. |
+
+### Returns
+
+| Return Type                     | Description                                                       |
+| ------------------------------- | ----------------------------------------------------------------- |
+| `Promise<Session<DefaultUser>>` | Resolves to the refreshed session or `null` if the refresh fails. |
+
+## Behavior
+
+- Cookies are read automatically from the browser context — you don't need to handle them or CSRF tokens manually.
+- Uses the provider's existing access token to fetch fresh profile data and normalizes it into the session's `User` object, matching [`api.refreshUserInfo`](/docs/api-reference/server/api/refreshUserInfo#behavior)'s behavior.
+- If the refresh fails (invalid or expired access token, or the provider request fails), the `session` resolves to `null` or `session.user`
+
+## Usage
+
+### Refresh user info
+
+```ts title="refresh-user-info.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const userInfo = await authClient.refreshUserInfo("github")
+
+console.log("refreshed session:", session)
+```
+
+### Handling failure
+
+```tsx title="handle-failure.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const userInfo = await authClient.refreshUserInfo("github")
+
+if (!userInfo) {
+  window.location.assign("/login")
+}
+
+console.log("refreshed session:", session)
+```

--- a/docs/src/content/docs/(core)/api-reference/client/functions/refreshUserInfo.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/refreshUserInfo.mdx
@@ -21,15 +21,15 @@ const userInfo = await authClient.refreshUserInfo("github")
 
 ### Returns
 
-| Return Type                     | Description                                                       |
-| ------------------------------- | ----------------------------------------------------------------- |
-| `Promise<Session<DefaultUser>>` | Resolves to the refreshed session or `null` if the refresh fails. |
+| Return Type                   | Description |
+| ----------------------------- | ----------- | ------------------------------------------------------------------------------------ |
+| `Promise<Session<DefaultUser> | null>`      | Resolves to the refreshed session object on success or `null` when refreshing fails. |
 
 ## Behavior
 
 - Cookies are read automatically from the browser context — you don't need to handle them or CSRF tokens manually.
 - Uses the provider's existing access token to fetch fresh profile data and normalizes it into the session's `User` object, matching [`api.refreshUserInfo`](/docs/api-reference/server/api/refreshUserInfo#behavior)'s behavior.
-- If the refresh fails (invalid or expired access token, or the provider request fails), the `session` resolves to `null` or `session.user`
+- If the refresh fails (invalid or expired access token, or the provider request fails), the function returns `null`. On success it returns the refreshed session object.
 
 ## Usage
 

--- a/docs/src/content/docs/(core)/api-reference/client/functions/revokeToken.mdx
+++ b/docs/src/content/docs/(core)/api-reference/client/functions/revokeToken.mdx
@@ -1,0 +1,64 @@
+---
+title: revokeToken
+description: Revoke the OAuth access token for a connected provider, from the client.
+---
+
+The `revokeToken` client method revokes the OAuth access token for a specific connected provider, from a client-side or browser context.
+
+<Callout>
+  Token revocation depends on the OAuth provider supporting it. If the provider does not support revocation, this method resolves
+  to `success: false`.
+</Callout>
+
+```ts title="revoke-token.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const success = await authClient.revokeToken("github")
+```
+
+<Callout>
+  This is a stronger alternative to `disconnectProvider`, which disconnects a provider without revoking its token. Use this method
+  when you specifically need the token itself invalidated. See
+  [`disconnectProvider`](/docs/api-reference/client/functions/disconnectProvider) for the softer alternative.
+</Callout>
+
+## Reference
+
+### Parameters
+
+| Parameter  | Type     | Required | Description                                           |
+| ---------- | -------- | -------- | ----------------------------------------------------- |
+| providerId | `string` | Yes      | The id of the OAuth provider to revoke the token for. |
+
+### Returns
+
+| Return Type        | Description                                                                  |
+| ------------------ | ---------------------------------------------------------------------------- |
+| `Promise<boolean>` | Resolves to `true` if the token was successfully revoked, `false` otherwise. |
+
+## Behavior
+
+- Cookies are read automatically from the browser context — you don't need to handle them or CSRF tokens manually.
+- If revocation fails (no active token for the provider, or the provider rejects the request), the method resolves to `false`.
+
+## Usage
+
+### Revoke a provider's access token
+
+```ts title="revoke-token.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const success = await authClient.revokeToken("github")
+```
+
+### Handling failure
+
+```tsx title="handle-failure.ts" lineNumbers
+import { authClient } from "@/lib/auth-client"
+
+const success = await authClient.revokeToken("github")
+
+if (!success) {
+  window.location.assign("/settings/connections")
+}
+```

--- a/docs/src/content/docs/(core)/api-reference/server/api/disconnectProvider.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/disconnectProvider.mdx
@@ -1,0 +1,101 @@
+---
+title: disConnectProvider
+description: Complete API reference for the api.disConnectProvider method, providing type-safe OAuth provider disconnection across all runtimes.
+---
+
+<Callout type="warning">
+  TODO — confirm before publishing: this method's name (`disConnectProvider`, with an internal capital `C`) breaks the
+  `lowerCamelCase` convention every other `api` method follows (`getAccessToken`, `isProviderConnected`, `revokeToken`, etc.).
+  This reads like a naming bug in the library itself rather than a docs issue — worth fixing at the source before v1.0.0, since
+  it's a public symbol name that would need a breaking change to correct later. Left as-is here pending confirmation.
+</Callout>
+
+The `api.disConnectProvider` method is the primary programmatic entry point for disconnecting an OAuth provider from the current session, without revoking its access token. This method runs on the server, so it requires you to pass the `request` or `headers` object from your server-side context.
+
+```ts title="disconnect-provider.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const output = await api.disConnectProvider("github", {
+  request: getRequest(),
+})
+```
+
+<Callout>
+  This method is a softer alternative to `api.revokeToken`: it disconnects the provider from the session without revoking the
+  access token itself. If you need the token invalidated, use `api.revokeToken` instead. See
+  [`api.revokeToken`](/docs/api-reference/server/api/revoke-token) for the stronger alternative.
+</Callout>
+
+## Reference
+
+### Parameters
+
+| Parameter  | Type                           | Required | Description                                 |
+| ---------- | ------------------------------ | -------- | ------------------------------------------- |
+| providerId | `string`                       | Yes      | The id of the OAuth provider to disconnect. |
+| options    | `DisconnectProviderAPIOptions` | Yes      | An object containing request context.       |
+
+### DisconnectProviderAPIOptions
+
+| Option        | Type      | Default   | Description                                               |
+| ------------- | --------- | --------- | --------------------------------------------------------- |
+| request       | `Request` | undefined | The request object from the server-side context.          |
+| headers       | `Headers` | undefined | The headers object from the server-side context.          |
+| skipCSRFCheck | `boolean` | `false`   | Whether to skip CSRF token verification for this request. |
+
+<Callout type="info">
+  At least one of `request` or `headers` is required to construct the incoming URL and validate redirect URLs.
+</Callout>
+
+### Returns
+
+| Return Type                            | Description                                                             |
+| -------------------------------------- | ----------------------------------------------------------------------- |
+| `Promise<DisconnectProviderAPIReturn>` | Resolves to an object containing `success` — see [Behavior](#behavior). |
+
+## Behavior
+
+- This disconnects the provider from the current session's list of connected providers, without calling the provider's revocation endpoint. The access token itself remains valid until it naturally expires (or is separately revoked with `api.revokeToken`).
+- CSRF protection is verified by default. Set `skipCSRFCheck: true` only if you're enforcing CSRF protection at a different layer (e.g. a framework-level middleware) — disabling it here without an equivalent safeguard reintroduces the vulnerability it protects against.
+- If disconnection fails (the provider isn't connected to the current session), `success` is `false`.
+
+## Errors
+
+See the [Errors Reference](/docs/api-reference/errors) for `CsrfError` (missing or mismatched token) and provider-connection errors.
+
+## Usage
+
+### Disconnect a provider
+
+```ts title="disconnect-provider.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success } = await api.disConnectProvider("github", {
+  request: getRequest(),
+})
+```
+
+### Handling failure
+
+```tsx title="handle-failure.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success } = await api.disConnectProvider("github", {
+  request: getRequest(),
+})
+
+if (!success) {
+  redirect("/settings/connections")
+}
+```
+
+### Delegating CSRF protection to a different layer
+
+```ts title="skip-csrf.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success } = await api.disConnectProvider("github", {
+  request: getRequest(),
+  skipCSRFCheck: true, // only if enforced elsewhere — see the warning above
+})
+```

--- a/docs/src/content/docs/(core)/api-reference/server/api/disconnectProvider.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/disconnectProvider.mdx
@@ -1,21 +1,14 @@
 ---
-title: disConnectProvider
-description: Complete API reference for the api.disConnectProvider method, providing type-safe OAuth provider disconnection across all runtimes.
+title: disconnectProvider
+description: Complete API reference for the api.disconnectProvider method, providing type-safe OAuth provider disconnection across all runtimes.
 ---
 
-<Callout type="warning">
-  TODO — confirm before publishing: this method's name (`disConnectProvider`, with an internal capital `C`) breaks the
-  `lowerCamelCase` convention every other `api` method follows (`getAccessToken`, `isProviderConnected`, `revokeToken`, etc.).
-  This reads like a naming bug in the library itself rather than a docs issue — worth fixing at the source before v1.0.0, since
-  it's a public symbol name that would need a breaking change to correct later. Left as-is here pending confirmation.
-</Callout>
-
-The `api.disConnectProvider` method is the primary programmatic entry point for disconnecting an OAuth provider from the current session, without revoking its access token. This method runs on the server, so it requires you to pass the `request` or `headers` object from your server-side context.
+The `api.disconnectProvider` method is the primary programmatic entry point for disconnecting an OAuth provider from the current session, without revoking its access token. This method runs on the server, so it requires you to pass the `request` or `headers` object from your server-side context.
 
 ```ts title="disconnect-provider.ts" lineNumbers
 import { api } from "@/lib/auth"
 
-const output = await api.disConnectProvider("github", {
+const output = await api.disconnectProvider("github", {
   request: getRequest(),
 })
 ```
@@ -59,10 +52,6 @@ const output = await api.disConnectProvider("github", {
 - CSRF protection is verified by default. Set `skipCSRFCheck: true` only if you're enforcing CSRF protection at a different layer (e.g. a framework-level middleware) — disabling it here without an equivalent safeguard reintroduces the vulnerability it protects against.
 - If disconnection fails (the provider isn't connected to the current session), `success` is `false`.
 
-## Errors
-
-See the [Errors Reference](/docs/api-reference/errors) for `CsrfError` (missing or mismatched token) and provider-connection errors.
-
 ## Usage
 
 ### Disconnect a provider
@@ -70,7 +59,7 @@ See the [Errors Reference](/docs/api-reference/errors) for `CsrfError` (missing 
 ```ts title="disconnect-provider.ts" lineNumbers
 import { api } from "@/lib/auth"
 
-const { success } = await api.disConnectProvider("github", {
+const { success } = await api.disconnectProvider("github", {
   request: getRequest(),
 })
 ```
@@ -80,7 +69,7 @@ const { success } = await api.disConnectProvider("github", {
 ```tsx title="handle-failure.ts" lineNumbers
 import { api } from "@/lib/auth"
 
-const { success } = await api.disConnectProvider("github", {
+const { success } = await api.disconnectProvider("github", {
   request: getRequest(),
 })
 
@@ -94,7 +83,7 @@ if (!success) {
 ```ts title="skip-csrf.ts" lineNumbers
 import { api } from "@/lib/auth"
 
-const { success } = await api.disConnectProvider("github", {
+const { success } = await api.disconnectProvider("github", {
   request: getRequest(),
   skipCSRFCheck: true, // only if enforced elsewhere — see the warning above
 })

--- a/docs/src/content/docs/(core)/api-reference/server/api/getAccessToken.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/getAccessToken.mdx
@@ -1,0 +1,100 @@
+---
+title: getAccessToken
+description: Complete API reference for the api.getAccessToken method, providing type-safe OAuth access token retrieval across all runtimes.
+---
+
+The `api.getAccessToken` method is the primary programmatic entry point for retrieving the OAuth access token for a specific provider. This method runs on the server, so it requires you to pass the `request` or `headers` object from your server-side context.
+
+```ts title="get-access-token.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const output = await api.getAccessToken("github", {
+  request: getRequest(),
+})
+```
+
+<Callout>
+  This method is a simplified version of `api.getProviderTokens`, which retrieves the full set of OAuth tokens (access token,
+  refresh token, and ID token) for a provider. Use this method if you only need the access token. See
+  [`api.getProviderTokens`](/docs/api-reference/server/api/get-provider-tokens) for the advanced alternative.
+</Callout>
+
+## Reference
+
+### Parameters
+
+| Parameter  | Type                    | Required | Description                                                    |
+| ---------- | ----------------------- | -------- | -------------------------------------------------------------- |
+| providerId | `string`                | Yes      | The id of the OAuth provider to retrieve the access token for. |
+| options    | `AccessTokenAPIOptions` | Yes      | An object containing request context.                          |
+
+### AccessTokenAPIOptions
+
+| Option        | Type      | Default   | Description                                               |
+| ------------- | --------- | --------- | --------------------------------------------------------- |
+| request       | `Request` | undefined | The request object from the server-side context.          |
+| headers       | `Headers` | undefined | The headers object from the server-side context.          |
+| skipCSRFCheck | `boolean` | `false`   | Whether to skip CSRF token verification for this request. |
+
+<Callout type="info">
+  At least one of `request` or `headers` is required to construct the incoming URL and validate redirect URLs.
+</Callout>
+
+### Returns
+
+| Return Type                     | Description                                                                               |
+| ------------------------------- | ----------------------------------------------------------------------------------------- |
+| `Promise<AccessTokenAPIReturn>` | Resolves to an object containing `success` and `accessToken` — see [Behavior](#behavior). |
+
+## Behavior
+
+- This function internally uses `api.getProviderTokens` to retrieve the access token for the specified provider. See [`api.getProviderTokens`](/docs/api-reference/server/api/get-provider-tokens) for the full retrieval/refresh behavior.
+- CSRF protection is verified by default. Set `skipCSRFCheck: true` only if you're enforcing CSRF protection at a different layer (e.g. a framework-level middleware) — disabling it here without an equivalent safeguard reintroduces the vulnerability it protects against.
+- If retrieval fails (no valid access or refresh token for the provider), `accessToken` resolves to `null` and `success` is `false`.
+
+## Errors
+
+See the [Errors Reference](/docs/api-reference/errors) for `CsrfError` (missing or mismatched token) and provider-connection errors.
+
+## Usage
+
+### Get a provider's access token
+
+```ts title="get-access-token.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success, accessToken } = await api.getAccessToken("github", {
+  request: getRequest(),
+})
+```
+
+### Using the token in a request
+
+```tsx title="protected-fetch.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success, accessToken } = await api.getAccessToken("github", {
+  request: getRequest(),
+})
+
+if (!success) {
+  redirect("/login")
+}
+
+const response = await fetch("/api/some-protected-route", {
+  headers: {
+    Authorization: `Bearer ${accessToken}`,
+  },
+})
+```
+
+### Delegating CSRF protection to a different layer
+
+```ts title="skip-csrf.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success, accessToken } = await api.getAccessToken("github", {
+  request: getRequest(),
+  skipCSRFCheck: true, // only if enforced elsewhere — see the warning above
+})
+```

--- a/docs/src/content/docs/(core)/api-reference/server/api/getAccessToken.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/getAccessToken.mdx
@@ -52,10 +52,6 @@ const output = await api.getAccessToken("github", {
 - CSRF protection is verified by default. Set `skipCSRFCheck: true` only if you're enforcing CSRF protection at a different layer (e.g. a framework-level middleware) — disabling it here without an equivalent safeguard reintroduces the vulnerability it protects against.
 - If retrieval fails (no valid access or refresh token for the provider), `accessToken` resolves to `null` and `success` is `false`.
 
-## Errors
-
-See the [Errors Reference](/docs/api-reference/errors) for `CsrfError` (missing or mismatched token) and provider-connection errors.
-
 ## Usage
 
 ### Get a provider's access token

--- a/docs/src/content/docs/(core)/api-reference/server/api/getProviderTokens.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/getProviderTokens.mdx
@@ -1,0 +1,105 @@
+---
+title: getProviderTokens
+description: Complete API reference for the api.getProviderTokens method, providing type-safe OAuth token retrieval across all runtimes.
+---
+
+The `api.getProviderTokens` method is the primary programmatic entry point for retrieving the full set of OAuth tokens for a specific provider. This method runs on the server, so it requires you to pass the `request` or `headers` object from your server-side context.
+
+```ts title="get-provider-tokens.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const output = await api.getProviderTokens("github", {
+  request: getRequest(),
+})
+```
+
+<Callout>
+  This method is the advanced version of `api.getAccessToken`, which is a simplified version that only returns the access token.
+  Use this method if you need the full set of OAuth tokens (access token, refresh token, and ID token) and want the flexibility to
+  handle them yourself. See [`api.getAccessToken`](/docs/api-reference/server/api/get-access-token) for the simpler alternative.
+</Callout>
+
+## Reference
+
+### Parameters
+
+| Parameter  | Type                          | Required | Description                                              |
+| ---------- | ----------------------------- | -------- | -------------------------------------------------------- |
+| providerId | `string`                      | Yes      | The id of the OAuth provider to retrieve the tokens for. |
+| options    | `GetProviderTokensAPIOptions` | Yes      | An object containing request context.                    |
+
+### GetProviderTokensAPIOptions
+
+| Option        | Type      | Default   | Description                                               |
+| ------------- | --------- | --------- | --------------------------------------------------------- |
+| request       | `Request` | undefined | The request object from the server-side context.          |
+| headers       | `Headers` | undefined | The headers object from the server-side context.          |
+| skipCSRFCheck | `boolean` | `false`   | Whether to skip CSRF token verification for this request. |
+
+<Callout type="info">
+  At least one of `request` or `headers` is required to construct the incoming URL and validate redirect URLs.
+</Callout>
+
+### Returns
+
+| Return Type                           | Description                                                                          |
+| ------------------------------------- | ------------------------------------------------------------------------------------ |
+| `Promise<GetProviderTokensAPIReturn>` | Resolves to an object containing `success` and `tokens` — see [Behavior](#behavior). |
+
+## Behavior
+
+The method resolves the tokens in stages:
+
+1. If the current access token is valid, it retrieves the associated OAuth tokens for the specified provider directly.
+2. If the access token is invalid, it checks whether the refresh token is valid:
+   - If valid, it uses it to retrieve fresh OAuth tokens for the provider.
+   - If invalid, it returns `success: false` and `tokens: null`.
+
+- CSRF protection is verified by default. Set `skipCSRFCheck: true` only if you're enforcing CSRF protection at a different layer (e.g. a framework-level middleware) — disabling it here without an equivalent safeguard reintroduces the vulnerability it protects against.
+
+## Errors
+
+See the [Errors Reference](/docs/api-reference/errors) for `CsrfError` (missing or mismatched token) and provider-connection errors.
+
+## Usage
+
+### Get a provider's tokens
+
+```ts title="get-provider-tokens.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success, tokens } = await api.getProviderTokens("github", {
+  request: getRequest(),
+})
+```
+
+### Using a token in a request
+
+```tsx title="protected-fetch.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success, tokens } = await api.getProviderTokens("github", {
+  request: getRequest(),
+})
+
+if (!success) {
+  redirect("/login")
+}
+
+const response = await fetch("/api/some-protected-route", {
+  headers: {
+    Authorization: `Bearer ${tokens?.accessToken}`,
+  },
+})
+```
+
+### Delegating CSRF protection to a different layer
+
+```ts title="skip-csrf.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success, tokens } = await api.getProviderTokens("github", {
+  request: getRequest(),
+  skipCSRFCheck: true, // only if enforced elsewhere — see the warning above
+})
+```

--- a/docs/src/content/docs/(core)/api-reference/server/api/getProviderTokens.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/getProviderTokens.mdx
@@ -57,10 +57,6 @@ The method resolves the tokens in stages:
 
 - CSRF protection is verified by default. Set `skipCSRFCheck: true` only if you're enforcing CSRF protection at a different layer (e.g. a framework-level middleware) — disabling it here without an equivalent safeguard reintroduces the vulnerability it protects against.
 
-## Errors
-
-See the [Errors Reference](/docs/api-reference/errors) for `CsrfError` (missing or mismatched token) and provider-connection errors.
-
 ## Usage
 
 ### Get a provider's tokens

--- a/docs/src/content/docs/(core)/api-reference/server/api/index.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/index.mdx
@@ -41,6 +41,30 @@ export interface AuthInstance<DefaultUser extends User = User, SignUpSchema exte
   Updates the current user's session data.
 </Card>
 
+<Card title="isProviderConnected" href="/docs/api-reference/server/api/isProviderConnected">
+  Verifies if a user is connected to a specific OAuth provider.
+</Card>
+
+<Card title="getProviderTokens" href="/docs/api-reference/server/api/getProviderTokens">
+  Retrieves the tokens for a specific OAuth provider.
+</Card>
+
+<Card title="getAccessToken" href="/docs/api-reference/server/api/getAccessToken">
+  Retrieves the access token for a specific OAuth provider.
+</Card>
+
+<Card title="refreshUserInfo" href="/docs/api-reference/server/api/refreshUserInfo">
+  Refreshes the user's information from the OAuth provider.
+</Card>
+
+<Card title="disconnectProvider" href="/docs/api-reference/server/api/disconnectProvider">
+  Disconnects the user from a specific OAuth provider.
+</Card>
+
+<Card title="revokeToken" href="/docs/api-reference/server/api/revokeToken">
+  Revokes the token for a specific OAuth provider.
+</Card>
+
 <Card title="signOut" href="/docs/api-reference/server/api/signOut">
   Signs out the current user and invalidates the session.
 </Card>

--- a/docs/src/content/docs/(core)/api-reference/server/api/isProviderConnected.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/isProviderConnected.mdx
@@ -51,10 +51,6 @@ const output = await api.isProviderConnected("github", {
 - CSRF protection is verified by default. Set `skipCSRFCheck: true` only if you're enforcing CSRF protection at a different layer (e.g. a framework-level middleware) — disabling it here without an equivalent safeguard reintroduces the vulnerability it protects against.
 - If the check itself fails (e.g. no valid session), `connected` resolves to `null` and `success` is `false` — distinct from `connected: false`, which means the check succeeded and simply found no connection.
 
-## Errors
-
-See the [Errors Reference](/docs/api-reference/errors) for `CsrfError` (missing or mismatched token) and `SessionError` (no active session).
-
 ## Usage
 
 ### Check a provider's connection status

--- a/docs/src/content/docs/(core)/api-reference/server/api/isProviderConnected.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/isProviderConnected.mdx
@@ -1,0 +1,82 @@
+---
+title: isProviderConnected
+description: Complete API reference for the api.isProviderConnected method, verifying whether the current session has an active connection with a specific OAuth provider.
+---
+
+The `api.isProviderConnected` method checks whether the current session has an active connection with a specific OAuth provider. This method runs on the server, so it requires you to pass the `request` or `headers` object from your server-side context.
+
+```ts title="is-provider-connected.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const output = await api.isProviderConnected("github", {
+  request: getRequest(),
+})
+```
+
+<Callout>
+  This method only checks connection status — it doesn't return any token data. If you need the access token itself, use
+  [`api.getAccessToken`](/docs/api-reference/server/api/get-access-token) instead.
+</Callout>
+
+## Reference
+
+### Parameters
+
+| Parameter  | Type                          | Required | Description                                               |
+| ---------- | ----------------------------- | -------- | --------------------------------------------------------- |
+| providerId | `string`                      | Yes      | The id of the OAuth provider to check the connection for. |
+| options    | `ProviderConnectedAPIOptions` | Yes      | An object containing request context.                     |
+
+### ProviderConnectedAPIOptions
+
+| Option        | Type      | Default   | Description                                               |
+| ------------- | --------- | --------- | --------------------------------------------------------- |
+| request       | `Request` | undefined | The request object from the server-side context.          |
+| headers       | `Headers` | undefined | The headers object from the server-side context.          |
+| skipCSRFCheck | `boolean` | `false`   | Whether to skip CSRF token verification for this request. |
+
+<Callout type="info">
+  At least one of `request` or `headers` is required to construct the incoming URL and validate redirect URLs.
+</Callout>
+
+### Returns
+
+| Return Type                           | Description                                                                             |
+| ------------------------------------- | --------------------------------------------------------------------------------------- |
+| `Promise<ProviderConnectedAPIReturn>` | Resolves to an object containing `success` and `connected` — see [Behavior](#behavior). |
+
+## Behavior
+
+- On success, `connected` resolves to `true` or `false` depending on whether the specified provider is currently connected to the session — it does not throw for the "not connected" case, since that's an expected outcome, not an error.
+- CSRF protection is verified by default. Set `skipCSRFCheck: true` only if you're enforcing CSRF protection at a different layer (e.g. a framework-level middleware) — disabling it here without an equivalent safeguard reintroduces the vulnerability it protects against.
+- If the check itself fails (e.g. no valid session), `connected` resolves to `null` and `success` is `false` — distinct from `connected: false`, which means the check succeeded and simply found no connection.
+
+## Errors
+
+See the [Errors Reference](/docs/api-reference/errors) for `CsrfError` (missing or mismatched token) and `SessionError` (no active session).
+
+## Usage
+
+### Check a provider's connection status
+
+```ts title="is-provider-connected.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success, connected } = await api.isProviderConnected("github", {
+  request: getRequest(),
+})
+```
+
+### Prompting the user to connect a provider
+
+```tsx title="connect-prompt.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success, connected } = await api.isProviderConnected("github", {
+  request: getRequest(),
+})
+
+if (success && !connected) {
+  redirect("/settings/connections/github")
+}
+```

--- a/docs/src/content/docs/(core)/api-reference/server/api/meta.json
+++ b/docs/src/content/docs/(core)/api-reference/server/api/meta.json
@@ -1,4 +1,17 @@
 {
   "title": "api",
-  "pages": ["signIn", "signInCredentials", "signUp", "getSession", "updateSession", "signOut"]
+  "pages": [
+    "signIn",
+    "signInCredentials",
+    "signUp",
+    "getSession",
+    "updateSession",
+    "isProviderConnected",
+    "getProviderTokens",
+    "getAccessToken",
+    "refreshUserInfo",
+    "disconnectProvider",
+    "revokeToken",
+    "signOut"
+  ]
 }

--- a/docs/src/content/docs/(core)/api-reference/server/api/refreshUserInfo.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/refreshUserInfo.mdx
@@ -46,10 +46,6 @@ const output = await api.refreshUserInfo("github", {
 - CSRF protection is verified by default. Set `skipCSRFCheck: true` only if you're enforcing CSRF protection at a different layer (e.g. a framework-level middleware) — disabling it here without an equivalent safeguard reintroduces the vulnerability it protects against.
 - If the refresh fails (invalid or expired access token, or the provider request fails), `session` resolves to `null` and `success` is `false`.
 
-## Errors
-
-See the [Errors Reference](/docs/api-reference/errors) for `CsrfError` (missing or mismatched token) and provider-connection errors.
-
 ## Usage
 
 ### Refresh user info

--- a/docs/src/content/docs/(core)/api-reference/server/api/refreshUserInfo.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/refreshUserInfo.mdx
@@ -1,0 +1,92 @@
+---
+title: refreshUserInfo
+description: Complete API reference for the api.refreshUserInfo method, refreshing the user's profile data without requiring re-authentication.
+---
+
+The `api.refreshUserInfo` method refreshes a user's profile data from the provider without requiring them to re-authenticate. This method runs on the server, so it requires you to pass the `request` or `headers` object from your server-side context.
+
+```ts title="refresh-user-info.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const output = await api.refreshUserInfo("github", {
+  request: getRequest(),
+})
+```
+
+## Reference
+
+### Parameters
+
+| Parameter  | Type                        | Required | Description                                             |
+| ---------- | --------------------------- | -------- | ------------------------------------------------------- |
+| providerId | `string`                    | Yes      | The id of the OAuth provider to refresh user info from. |
+| options    | `RefreshUserInfoAPIOptions` | Yes      | An object containing request context.                   |
+
+### RefreshUserInfoAPIOptions
+
+| Option        | Type      | Default   | Description                                               |
+| ------------- | --------- | --------- | --------------------------------------------------------- |
+| request       | `Request` | undefined | The request object from the server-side context.          |
+| headers       | `Headers` | undefined | The headers object from the server-side context.          |
+| skipCSRFCheck | `boolean` | `false`   | Whether to skip CSRF token verification for this request. |
+
+<Callout type="info">
+  At least one of `request` or `headers` is required to construct the incoming URL and validate redirect URLs.
+</Callout>
+
+### Returns
+
+| Return Type                                      | Description                                                                           |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| `Promise<RefreshUserInfoAPIReturn<DefaultUser>>` | Resolves to an object containing `success` and `session` — see [Behavior](#behavior). |
+
+## Behavior
+
+- The method uses the provider's existing access token to call its `userInfo` endpoint, then normalizes the response through the provider's `profile` function into a `User` object, and returns the updated session.
+- CSRF protection is verified by default. Set `skipCSRFCheck: true` only if you're enforcing CSRF protection at a different layer (e.g. a framework-level middleware) — disabling it here without an equivalent safeguard reintroduces the vulnerability it protects against.
+- If the refresh fails (invalid or expired access token, or the provider request fails), `session` resolves to `null` and `success` is `false`.
+
+## Errors
+
+See the [Errors Reference](/docs/api-reference/errors) for `CsrfError` (missing or mismatched token) and provider-connection errors.
+
+## Usage
+
+### Refresh user info
+
+```ts title="refresh-user-info.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success, session } = await api.refreshUserInfo("github", {
+  request: getRequest(),
+})
+
+console.log("refreshed session:", session)
+```
+
+### Handling failure
+
+```tsx title="handle-failure.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success, session } = await api.refreshUserInfo("github", {
+  request: getRequest(),
+})
+
+if (!success) {
+  redirect("/login")
+}
+
+console.log("refreshed session:", session)
+```
+
+### Delegating CSRF protection to a different layer
+
+```ts title="skip-csrf.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success, session } = await api.refreshUserInfo("github", {
+  request: getRequest(),
+  skipCSRFCheck: true, // only if enforced elsewhere — see the warning above
+})
+```

--- a/docs/src/content/docs/(core)/api-reference/server/api/revokeToken.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/revokeToken.mdx
@@ -1,0 +1,99 @@
+---
+title: revokeToken
+description: Complete API reference for the api.revokeToken method, providing type-safe OAuth access token revocation across all runtimes.
+---
+
+The `api.revokeToken` method is the primary programmatic entry point for revoking the OAuth access token for a specific provider. This method runs on the server, so it requires you to pass the `request` or `headers` object from your server-side context.
+
+<Callout>
+  Token revocation depends on the OAuth provider supporting it. If the provider does not support revocation, this method returns
+  `success: false`.
+</Callout>
+
+```ts title="revoke-token.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const output = await api.revokeToken("github", {
+  request: getRequest(),
+})
+```
+
+<Callout>
+  This method is a stronger alternative to `api.disConnectProvider`, which disconnects a provider from the current session without
+  revoking its access token. Use this method when you specifically need the token itself invalidated. See
+  [`api.disConnectProvider`](/docs/api-reference/server/api/disconnect-provider) for the softer alternative.
+</Callout>
+
+## Reference
+
+### Parameters
+
+| Parameter  | Type                    | Required | Description                                           |
+| ---------- | ----------------------- | -------- | ----------------------------------------------------- |
+| providerId | `string`                | Yes      | The id of the OAuth provider to revoke the token for. |
+| options    | `RevokeTokenAPIOptions` | Yes      | An object containing request context.                 |
+
+### RevokeTokenAPIOptions
+
+| Option        | Type      | Default   | Description                                               |
+| ------------- | --------- | --------- | --------------------------------------------------------- |
+| request       | `Request` | undefined | The request object from the server-side context.          |
+| headers       | `Headers` | undefined | The headers object from the server-side context.          |
+| skipCSRFCheck | `boolean` | `false`   | Whether to skip CSRF token verification for this request. |
+
+<Callout type="info">
+  At least one of `request` or `headers` is required to construct the incoming URL and validate redirect URLs.
+</Callout>
+
+### Returns
+
+| Return Type                     | Description                                                             |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| `Promise<RevokeTokenAPIReturn>` | Resolves to an object containing `success` — see [Behavior](#behavior). |
+
+## Behavior
+
+- Revocation success depends entirely on the provider's `revokeToken` endpoint configuration and whether the provider supports token revocation at all. If it doesn't, this method returns `success: false`.
+- CSRF protection is verified by default. Set `skipCSRFCheck: true` only if you're enforcing CSRF protection at a different layer (e.g. a framework-level middleware) — disabling it here without an equivalent safeguard reintroduces the vulnerability it protects against.
+- If revocation fails (no active token for the provider, or the provider rejects the request), `success` is `false`.
+
+## Errors
+
+See the [Errors Reference](/docs/api-reference/errors) for `CsrfError` (missing or mismatched token) and provider-connection errors.
+
+## Usage
+
+### Revoke a provider's access token
+
+```ts title="revoke-token.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success } = await api.revokeToken("github", {
+  request: getRequest(),
+})
+```
+
+### Handling failure
+
+```tsx title="handle-failure.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success } = await api.revokeToken("github", {
+  request: getRequest(),
+})
+
+if (!success) {
+  redirect("/settings/connections")
+}
+```
+
+### Delegating CSRF protection to a different layer
+
+```ts title="skip-csrf.ts" lineNumbers
+import { api } from "@/lib/auth"
+
+const { success } = await api.revokeToken("github", {
+  request: getRequest(),
+  skipCSRFCheck: true, // only if enforced elsewhere — see the warning above
+})
+```

--- a/docs/src/content/docs/(core)/api-reference/server/api/revokeToken.mdx
+++ b/docs/src/content/docs/(core)/api-reference/server/api/revokeToken.mdx
@@ -19,9 +19,9 @@ const output = await api.revokeToken("github", {
 ```
 
 <Callout>
-  This method is a stronger alternative to `api.disConnectProvider`, which disconnects a provider from the current session without
+  This method is a stronger alternative to `api.disconnectProvider`, which disconnects a provider from the current session without
   revoking its access token. Use this method when you specifically need the token itself invalidated. See
-  [`api.disConnectProvider`](/docs/api-reference/server/api/disconnect-provider) for the softer alternative.
+  [`api.disconnectProvider`](/docs/api-reference/server/api/disconnect-provider) for the softer alternative.
 </Callout>
 
 ## Reference
@@ -56,10 +56,6 @@ const output = await api.revokeToken("github", {
 - Revocation success depends entirely on the provider's `revokeToken` endpoint configuration and whether the provider supports token revocation at all. If it doesn't, this method returns `success: false`.
 - CSRF protection is verified by default. Set `skipCSRFCheck: true` only if you're enforcing CSRF protection at a different layer (e.g. a framework-level middleware) — disabling it here without an equivalent safeguard reintroduces the vulnerability it protects against.
 - If revocation fails (no active token for the provider, or the provider rejects the request), `success` is `false`.
-
-## Errors
-
-See the [Errors Reference](/docs/api-reference/errors) for `CsrfError` (missing or mismatched token) and provider-connection errors.
 
 ## Usage
 

--- a/packages/core/src/api/createApi.ts
+++ b/packages/core/src/api/createApi.ts
@@ -39,6 +39,10 @@ import type {
     RevokeTokenAPIOptions,
     DisconnectProviderAPIOptions,
     ProviderConnectedAPIOptions,
+    RefreshUserInfoAPIReturn,
+    RevokeTokenAPIReturn,
+    ProviderConnectedAPIReturn,
+    DisconnectProviderAPIReturn,
 } from "@/@types/index.ts"
 import type { ZodObject } from "zod"
 import type { SchemaTypes } from "@/identity/index.ts"
@@ -196,7 +200,10 @@ export const createAuthAPI = <DefaultUser extends User = User, SignUpSchema exte
          *    headers: getHeaders()
          * })
          */
-        refreshUserInfo: async (oauth: LiteralUnion<BuiltInOAuthProvider>, options?: RefreshUserInfoAPIOptions) => {
+        refreshUserInfo: async (
+            oauth: LiteralUnion<BuiltInOAuthProvider>,
+            options?: RefreshUserInfoAPIOptions
+        ): Promise<RefreshUserInfoAPIReturn<DefaultUser>> => {
             return refreshUserInfo<DefaultUser>(oauth, { ctx, ...options, skipCSRFCheck: true })
         },
         /**
@@ -212,7 +219,10 @@ export const createAuthAPI = <DefaultUser extends User = User, SignUpSchema exte
          * // Use the returned headers to update the response headers in your server-side logic
          * return new Response(null, { status: 200, headers })
          */
-        revokeToken: async (oauth: LiteralUnion<BuiltInOAuthProvider>, options?: RevokeTokenAPIOptions) => {
+        revokeToken: async (
+            oauth: LiteralUnion<BuiltInOAuthProvider>,
+            options?: RevokeTokenAPIOptions
+        ): Promise<RevokeTokenAPIReturn> => {
             return revokeToken(oauth, { ctx, ...options, disconnect: false, skipCSRFCheck: true })
         },
         /**
@@ -227,7 +237,10 @@ export const createAuthAPI = <DefaultUser extends User = User, SignUpSchema exte
          * // Use the returned headers to update the response headers in your server-side logic
          * return new Response(null, { status: 200, headers })
          */
-        disconnectProvider: async (oauth: LiteralUnion<BuiltInOAuthProvider>, options?: DisconnectProviderAPIOptions) => {
+        disconnectProvider: async (
+            oauth: LiteralUnion<BuiltInOAuthProvider>,
+            options?: DisconnectProviderAPIOptions
+        ): Promise<DisconnectProviderAPIReturn> => {
             return disconnectProvider(oauth, { ctx, ...options, skipCSRFCheck: true })
         },
         /**
@@ -244,7 +257,10 @@ export const createAuthAPI = <DefaultUser extends User = User, SignUpSchema exte
          *    // The session is connected to the GitHub provider
          * }
          */
-        isProviderConnected: async (oauth: LiteralUnion<BuiltInOAuthProvider>, options?: ProviderConnectedAPIOptions) => {
+        isProviderConnected: async (
+            oauth: LiteralUnion<BuiltInOAuthProvider>,
+            options?: ProviderConnectedAPIOptions
+        ): Promise<ProviderConnectedAPIReturn> => {
             return isProviderConnected(oauth, { ctx, ...options })
         },
         /**

--- a/packages/core/src/api/revokeToken.ts
+++ b/packages/core/src/api/revokeToken.ts
@@ -61,7 +61,7 @@ export const revokeToken = async (
         skipCSRFCheck = false,
         disconnect = false,
     }: FunctionAPIContext<RevokeTokenAPIOptions> & { disconnect?: boolean }
-) => {
+): Promise<RevokeTokenAPIReturn> => {
     const { cookies } = ctx
     try {
         ctx.logger?.log("OAUTH_ACCESS_TOKEN_REQUEST_INITIATED", {


### PR DESCRIPTION
## Description

This pull request expands the API Reference documentation by adding comprehensive documentation for the recently introduced experimental APIs available on both the server-side and client-side.

The new documentation covers each API in detail, including its purpose, parameters, return values, execution context, authentication requirements, cookie behavior, CSRF considerations, failure scenarios, and practical usage examples.

### Documented APIs

- `getProviderTokens`
- `getAccessToken`
- `refreshUserInfo`
- `isProviderConnected`
- `disconnectProvider`
- `revokeToken`

### Related PRs
- #223 
- #221 
- #220 
- #219 
- #218
- #212 