### PR TITLE
feat(core): introduce stateful session strategy types

### DIFF
--- a/packages/core/src/@types/adapter.ts
+++ b/packages/core/src/@types/adapter.ts
@@ -1,0 +1,137 @@
+import type {
+    UserEntity,
+    AccountEntity,
+    OAuthAccountEntity,
+    CredentialAccountEntity,
+    SessionEntity,
+    SessionWithUserEntity,
+    DeviceEntity,
+    MFACredentialEntity,
+    MFAMethod,
+    OAuthTransactionEntity,
+    RevokeReason,
+} from "@/@types/entities.ts"
+
+export interface UsersAdapter {
+    /**
+     * User management methods
+     */
+    createUser(input: Partial<Omit<UserEntity, "createdAt" | "updatedAt">>): Promise<UserEntity>
+    getUserById(id: string): Promise<UserEntity | null>
+    getUserByEmail(email: string): Promise<UserEntity | null>
+    updateUser(id: string, input: Partial<Omit<UserEntity, "createdAt" | "updatedAt">>): Promise<UserEntity>
+
+    /**
+     * Soft delete: sets status = "deleted", row is preserved.
+     * Hard delete: removes the row and all owned rows (Accounts, Sessions,
+     * Devices, MfaCredentials). Strategy is set in AdapterConfig, not here.
+     *
+     * Delete an user based on the selected strategy.
+     *   - `"soft"`: The user is marked as deleted, but the row is preserved in the database.
+     *   - `"hard"`: The user and all associated data (Accounts, Sessions, Devices, MfaCredentials) are permanently removed from the database.
+     */
+    deleteUser(id: string): Promise<void>
+}
+
+export interface AccountsAdapter {
+    /**
+     * Account management methods
+     */
+    createAccount(input: Partial<Omit<AccountEntity, "createdAt" | "updatedAt">>): Promise<AccountEntity>
+    getAccountById(id: string): Promise<AccountEntity | null>
+    getAccountByProvider(provider: string, providerUserId: string): Promise<AccountEntity | null>
+    getAccountsByUserId(userId: string): Promise<AccountEntity[]>
+    updateAccountStatus(id: string, status: AccountEntity["status"]): Promise<AccountEntity>
+    unlinkAccount(id: string): Promise<void>
+}
+
+export interface OAuthAccountsAdapter {
+    /**
+     * OAuthAccount management methods
+     */
+    createOAuthAccount(input: Partial<Omit<OAuthAccountEntity, "createdAt" | "updatedAt">>): Promise<OAuthAccountEntity>
+    getOAuthAccount(accountId: string): Promise<OAuthAccountEntity | null>
+    updateOAuthTokens(
+        accountId: string,
+        input: Partial<Omit<OAuthAccountEntity, "createdAt" | "updatedAt">>
+    ): Promise<OAuthAccountEntity>
+}
+
+export interface CredentialAccountsAdapter {
+    /**
+     * CredentialAccounts management methods.
+     */
+    createCredentialAccount(input: Partial<Omit<CredentialAccountEntity, "updatedAt">>): Promise<CredentialAccountEntity>
+    getCredentialAccount(accountId: string): Promise<CredentialAccountEntity | null>
+    updatePasswordHash(accountId: string, passwordHash: string): Promise<CredentialAccountEntity>
+}
+
+export interface SessionsAdapter {
+    /**
+     * Session management methods.
+     */
+    createSession(input: Omit<SessionEntity, "createdAt" | "updatedAt" | "lastActivityAt" | "revokedAt">): Promise<SessionEntity>
+    getSessionByToken(token: string): Promise<SessionWithUserEntity | null>
+    getSessionById(id: string): Promise<SessionEntity | null>
+    listSessions(filter: Pick<SessionEntity, "userId" | "status" | "deviceId">): Promise<SessionEntity[]>
+    updateSession(
+        id: string,
+        input: Omit<SessionEntity, "createdAt" | "updatedAt" | "lastActivityAt" | "revokedAt">
+    ): Promise<SessionEntity>
+    touchSession(id: string, lastActivityAt: Date): Promise<void>
+    revokeSession(id: string, reason: RevokeReason): Promise<void>
+    revokeAllSessions(userId: string, reason: RevokeReason, exceptSessionId?: string): Promise<number>
+}
+
+export interface DevicesAdapter {
+    /**
+     * Device management methods.
+     */
+    createDevice(input: Omit<DeviceEntity, "createdAt" | "updatedAt">): Promise<DeviceEntity>
+    getDeviceById(id: string): Promise<DeviceEntity | null>
+    getDeviceByFingerprint(userId: string, fingerprint: string): Promise<DeviceEntity | null>
+    getDevicesByUserId(userId: string): Promise<DeviceEntity[]>
+    updateDevice(id: string, input: Omit<DeviceEntity, "createdAt" | "updatedAt">): Promise<DeviceEntity>
+    trustDevice(id: string, trusted: boolean): Promise<DeviceEntity>
+    deleteDevice(id: string): Promise<void>
+}
+
+export interface MFACredentialsAdapter {
+    /**
+     * MFACredentials management methods.
+     */
+    createMfaCredential(input: Omit<MFACredentialEntity, "id" | "verifiedAt" | "updatedAt">): Promise<MFACredentialEntity>
+    getMfaCredentialById(id: string): Promise<MFACredentialEntity | null>
+    getMfaCredentialsByUserId(userId: string): Promise<MFACredentialEntity[]>
+    getMfaCredentialsByType(userId: string, type: MFAMethod): Promise<MFACredentialEntity[]>
+    verifyMfaCredential(id: string): Promise<MFACredentialEntity>
+    updateMfaCredential(
+        id: string,
+        input: Omit<MFACredentialEntity, "id" | "verifiedAt" | "updatedAt">
+    ): Promise<MFACredentialEntity>
+    deleteMfaCredential(id: string): Promise<void>
+}
+
+export interface OAuthTransactionsAdapter {
+    /**
+     * OAuthTransaction management methods.
+     */
+    createOAuthTransaction(input: OAuthTransactionEntity): Promise<OAuthTransactionEntity>
+    getOAuthTransactionByState(state: string): Promise<OAuthTransactionEntity | null>
+    consumeOAuthTransaction(state: string): Promise<OAuthTransactionEntity | null>
+    deleteExpiredOAuthTransactions(): Promise<number>
+}
+
+/**
+ * The database adapter interface. Each provider package must implement this.
+ */
+export interface DatabaseAdapter
+    extends
+        UsersAdapter,
+        AccountsAdapter,
+        OAuthAccountsAdapter,
+        CredentialAccountsAdapter,
+        SessionsAdapter,
+        DevicesAdapter,
+        MFACredentialsAdapter,
+        OAuthTransactionsAdapter {}

--- a/packages/core/src/@types/entities.ts
+++ b/packages/core/src/@types/entities.ts
@@ -1,0 +1,160 @@
+export type UserStatus = "active" | "suspended" | "pending_verification" | "deleted"
+
+/**
+ * @todo: add "passkey" and "saml" to AccountType when we implement those providers
+ */
+export type AccountType = "oauth" | "credentials"
+
+export type AccountStatus = "active" | "unlinked" | "suspended"
+
+export type SessionStatus = "active" | "expired" | "revoked"
+
+/**
+ * Tracks MFA progress within a session.
+ *   - "none": MFA not required for this user or session
+ *   - "pending": primary auth passed, MFA challenge not yet completed
+ *   - "completed": MFA challenge passed
+ *   - "skipped": trusted device, MFA step-up bypassed
+ */
+export type MFAState = "none" | "pending" | "completed" | "skipped"
+
+export type MFAMethod = "totp" | "webauthn_passkey" | "webauthn_security_key" | "sms" | "email" | "recovery_code"
+
+export type DeviceType = "desktop" | "mobile" | "tablet" | "unknown"
+
+export type RevokeReason =
+    | "user_logout"
+    | "admin_action"
+    | "password_changed"
+    | "email_changed"
+    | "all_sessions_revoked"
+    | "mfa_disabled"
+    | "account_suspended"
+    | "max_sessions_exceeded"
+
+export interface UserEntity {
+    id: string
+    name: string | null
+    email: string | null
+    image: string | null
+    emailVerifiedAt: Date | null
+    status: UserStatus
+    mfaEnabled: boolean
+    mfaPreferredMethod: MFAMethod | null
+    createdAt: Date
+    updatedAt: Date
+    /**
+     * Used to store the extra user attributes and extended by the `identity.schema`
+     * configuration.
+     */
+    attributes: Record<string, unknown> | null
+}
+
+export interface AccountEntity {
+    id: string
+    userId: string
+    provider: string
+    providerUserId: string
+    type: AccountType
+    status: AccountStatus
+    createdAt: Date
+    updatedAt: Date
+}
+
+export interface OAuthAccountEntity {
+    accountId: string
+    accessToken: string
+    refreshToken: string | null
+    idToken: string | null
+    tokenType: string | null
+    scopes: string | null
+    issuer: string | null
+    accessTokenExpiresAt: Date | null
+    refreshTokenExpiresAt: Date | null
+    updatedAt: Date
+}
+
+export interface CredentialAccountEntity {
+    accountId: string
+    passwordHash: string
+    updatedAt: Date
+}
+
+export interface SessionEntity {
+    id: string
+    userId: string
+    deviceId: string | null
+    authenticatedWith: string
+    status: SessionStatus
+    mfaState: MFAState
+    sessionToken: string
+    expiresAt: Date
+    metadata: Record<string, unknown> | null
+    lastActivityAt: Date
+    revokedAt: Date | null
+    createdAt: Date
+    updatedAt: Date
+}
+
+export type SessionWithUserEntity = SessionEntity & { user: UserEntity }
+
+/**
+ * Tracks physical devices across sessions.
+ */
+export interface DeviceEntity {
+    id: string
+    userId: string
+    /**
+     * User-assigned label for the device, e.g. "Work MacBook" or "iPhone 14 Pro".
+     */
+    name: string | null
+    type: DeviceType
+    /**
+     * Platform name and version, e.g. "macOS 14.1" or "Android 14".
+     */
+    platform: string | null
+    /**
+     * Browser name and version, e.g. "Chrome 120" or "Safari 17".
+     */
+    browser: string | null
+    /**
+     * User-Agent string captured at first sign-in from this device.
+     * @see https://developer.mozilla.org/es/docs/Web/HTTP/Reference/Headers/User-Agent
+     */
+    userAgent: string | null
+    fingerprint: string | null
+    lastIp: string | null
+    trusted: boolean
+    firstSeenAt: Date
+    lastSeenAt: Date
+    metadata: Record<string, unknown> | null
+}
+
+export interface MFACredentialEntity {
+    id: string
+    userId: string
+    type: MFAMethod
+    credentialData: Record<string, unknown>
+    isPrimary: boolean
+    verifiedAt: Date | null
+    createdAt: Date
+    metadata: Record<string, unknown> | null
+}
+
+/**
+ * Stores the OAuth transaction state during an OAuth or OIDC authorization flow.
+ */
+export interface OAuthTransactionEntity {
+    id: string
+    provider: string
+    state: string
+    nonce: string | null
+    codeVerifier: string | null
+    redirectUri: string
+    redirectTo: string | null
+    userAgent: string | null
+    fingerprint: string | null
+    createdAt: Date
+    expiresAt: Date
+    metadata: Record<string, unknown> | null
+}

--- a/packages/core/src/@types/session.ts
+++ b/packages/core/src/@types/session.ts
@@ -12,6 +12,7 @@ import type {
     Prettify,
     Identities,
 } from "@/@types/index.ts"
+import type { DatabaseAdapter } from "@/@types/adapter.ts"
 
 /** Application user type, inferred from the configured identity schema (defaults to the built-in user shape). */
 export type User = Infer<typeof identitySchema>
@@ -156,6 +157,20 @@ export type JWTConfig = Prettify<
     } & JWTConfigBase
 >
 
+export interface SessionStatefulConfig {
+    /**
+     * The session deletion strategy when a user is deleted. Defaults to "soft" (mark as deleted, keep for audit).
+     * - "soft": The user is marked as deleted, but the row is preserved in the database.
+     * - "hard": The user and all associated data (Accounts, Sessions, Devices, MfaCredentials) are permanently removed from the database.
+     */
+    deleteStrategy?: "soft" | "hard"
+    /**
+     * The maximum number of concurrent sessions allowed per user. If exceeded, the oldest session(s) will be revoked.
+     * If not set, there is no limit on concurrent sessions.
+     */
+    maxSessions?: number
+}
+
 /**
  * Stateless JWT strategy.
  * No database required. Tokens are self-contained and cannot be revoked
@@ -173,6 +188,12 @@ export type StatelessStrategyConfig = {
     jwt?: JWTConfig
 }
 
+export type StatefulStrategyConfig = {
+    strategy: "database"
+    adapter: DatabaseAdapter
+    session?: SessionStatefulConfig
+}
+
 /**
  * The session strategy. Determines which fields below are required.
  *
@@ -182,7 +203,7 @@ export type StatelessStrategyConfig = {
  *
  * @default "jwt"
  */
-export type SessionConfig = StatelessStrategyConfig
+export type SessionConfig = StatelessStrategyConfig | StatefulStrategyConfig
 
 /** Result of reading a stateless (JWT) session from a request: session payload and outgoing header mutations. */
 export interface GetStatelessSessionReturn<DefaultUser extends User = User> {


### PR DESCRIPTION
## Description

This pull request introduces the foundational types and interfaces required to support the upcoming **Stateful** session strategy in `@aura-stack/auth`.

The changes include the initial database entities, adapter interfaces, and shared types that will serve as the foundation for persisting users, sessions, OAuth accounts, devices, MFA credentials, and related authentication data.

This PR is purely preparatory and does not introduce any runtime behavior or changes to the existing authentication flows.

### Key Changes

- Added database entity definitions for the Stateful session strategy.
- Added the database adapter interface and related types.
- Added shared types for sessions, users, OAuth accounts, devices, and MFA credentials.
- Established the foundation for future Stateful session support.

> [!NOTE]
> This pull request does **not** implement the Stateful session strategy itself. It only introduces the type definitions and abstractions that will be used by future PRs implementing the runtime behavior.

### Mode

```mermaid
erDiagram
Users ||--o{ Accounts : "has"
Users ||--o{ Sessions : "starts"
Users ||--o{ Devices : "registers"
Users ||--o{ MfaCredentials : "configures"
Accounts ||--|| OAuthAccounts : "oauth"
Accounts ||--|| CredentialAccounts : "credentials"
Devices ||--o{ Sessions : "contains"
Users {
varchar id PK
varchar name
varchar email UK
varchar image
timestamp emailVerifiedAt
varchar status
boolean mfaEnabled
varchar mfaPreferredMethod
json attributes
timestamp createdAt
timestamp updatedAt
}
Accounts {
varchar id PK
varchar userId FK
varchar provider
varchar providerUserId
varchar type
varchar status
timestamp createdAt
timestamp updatedAt
json metadata
}
OAuthAccounts {
varchar accountId PK,FK
text accessToken
text refreshToken
text idToken
text tokenType
text scopes
varchar issuer
timestamp accessTokenExpiresAt
timestamp refreshTokenExpiresAt
timestamp updatedAt
}
CredentialAccounts {
varchar accountId PK,FK
text passwordHash
timestamp updatedAt
}
Sessions {
varchar id PK
varchar userId FK
varchar deviceId FK
varchar authenticatedWith
varchar status
varchar mfaState
text sessionToken UK
timestamp expiresAt
timestamp lastActivityAt
timestamp revokedAt
timestamp createdAt
timestamp updatedAt
json metadata
}
Devices {
varchar id PK
varchar userId FK
varchar name
varchar type
varchar platform
varchar browser
text userAgent
varchar fingerprint
varchar lastIp
boolean trusted
timestamp firstSeenAt
timestamp lastSeenAt
json metadata
}
MfaCredentials {
varchar id PK
varchar userId FK
varchar type
json credentialData
boolean isPrimary
timestamp verifiedAt
timestamp createdAt
json metadata
}
OAuthTransactions {
varchar id PK
varchar provider
varchar state UK
varchar nonce
varchar codeVerifier
text redirectUri
text redirectTo
varchar deviceId
timestamp createdAt
timestamp expiresAt
json metadata
}
```
