### PR TITLE
feat(core): register device metadata

### DIFF
--- a/packages/core/src/@types/adapter.ts
+++ b/packages/core/src/@types/adapter.ts
@@ -91,7 +91,7 @@ export interface DevicesAdapter {
     getDeviceById(id: string): Promise<DeviceEntity | null>
     getDeviceByFingerprint(userId: string, fingerprint: string): Promise<DeviceEntity | null>
     getDevicesByUserId(userId: string): Promise<DeviceEntity[]>
-    updateDevice(id: string, input: Omit<DeviceEntity, "createdAt" | "updatedAt">): Promise<DeviceEntity>
+    updateDevice(id: string, input: Partial<Omit<DeviceEntity, "createdAt" | "updatedAt">>): Promise<DeviceEntity>
     trustDevice(id: string, trusted: boolean): Promise<DeviceEntity>
     deleteDevice(id: string): Promise<void>
 }

--- a/packages/core/src/@types/adapter.ts
+++ b/packages/core/src/@types/adapter.ts
@@ -87,7 +87,7 @@ export interface DevicesAdapter {
     /**
      * Device management methods.
      */
-    createDevice(input: Omit<DeviceEntity, "createdAt" | "updatedAt">): Promise<DeviceEntity>
+    createDevice(input: Omit<DeviceEntity, "id" | "createdAt" | "updatedAt">): Promise<DeviceEntity>
     getDeviceById(id: string): Promise<DeviceEntity | null>
     getDeviceByFingerprint(userId: string, fingerprint: string): Promise<DeviceEntity | null>
     getDevicesByUserId(userId: string): Promise<DeviceEntity[]>

--- a/packages/core/src/@types/session.ts
+++ b/packages/core/src/@types/session.ts
@@ -233,7 +233,7 @@ export interface SessionStrategy<DefaultUser extends User = User> {
      * Create a session after successful authentication.
      * Signs the JWT / writes the DB row / sets cookies.
      */
-    createSession(session: User): Promise<string>
+    createSession(session: User, request: Request): Promise<string>
 
     getProviderTokens(oauth: string, request: Request): Promise<GetProviderTokensStatefulReturn>
 

--- a/packages/core/src/api/signInCredentials.ts
+++ b/packages/core/src/api/signInCredentials.ts
@@ -35,7 +35,7 @@ export const signInCredentials = async ({
         if (!session) {
             throw new AuraAuthError({ code: "AUTH_CREDENTIALS_INVALID" })
         }
-        const sessionToken = await sessionStrategy.createSession(session)
+        const sessionToken = await sessionStrategy.createSession(session, request)
         const csrfToken = await createCSRF(ctx.jose)
         logger?.log("CREDENTIALS_SIGN_IN_SUCCESS")
 

--- a/packages/core/src/api/signUp.ts
+++ b/packages/core/src/api/signUp.ts
@@ -33,7 +33,7 @@ export const signUp = async <Payload extends Record<string, unknown> = Record<st
         if (!user) {
             throw new AuraAuthError({ code: "USER_CREATION_FAILED" })
         }
-        const sessionToken = await sessionStrategy.createSession(user)
+        const sessionToken = await sessionStrategy.createSession(user, request)
         const csrfToken = await createCSRF(ctx.jose)
         logger?.log("SIGN_UP_SUCCESS")
 

--- a/packages/core/src/session/stateful.ts
+++ b/packages/core/src/session/stateful.ts
@@ -45,6 +45,12 @@ export const createStatefulStrategy = <DefaultUser extends User = User>({
     const createDevice = async (userId: string, request: Request) => {
         const { userAgent, browser, platform, deviceType, ip, name } = getDeviceInfo(request)
         const fingerprint = await createFingerprint(request)
+        const device = await config.adapter.getDeviceByFingerprint(userId, fingerprint)
+        if (device) {
+            await config.adapter.updateDevice(device.id, { lastSeenAt: new Date() })
+            return device
+        }
+
         return await config.adapter.createDevice({
             userId,
             userAgent,
@@ -1339,11 +1345,16 @@ export const createStatefulStrategy = <DefaultUser extends User = User>({
                 tokenType: accessToken.token_type,
                 scopes: Array.isArray(accessToken.scope) ? accessToken.scope.join(" ") : accessToken.scope || null,
                 accessTokenExpiresAt: accessToken.expires_in ? new Date(Date.now() + accessToken.expires_in * 1000) : null,
+                refreshTokenExpiresAt: accessToken.refresh_token_expires_in
+                    ? new Date(Date.now() + accessToken.refresh_token_expires_in * 1000)
+                    : null,
             })
         }
 
         const device = await createDevice(userId, request)
-        const tokenHash = await createHash(crypto.randomUUID())
+        const sessionToken = createSecretValue(64)
+        const tokenHash = await createHash(sessionToken)
+
         await config.adapter.createSession({
             id: crypto.randomUUID(),
             userId,

--- a/packages/core/src/session/stateful.ts
+++ b/packages/core/src/session/stateful.ts
@@ -1,6 +1,6 @@
 import { AuraAuthError } from "@/shared/errors.ts"
 import { secureApiHeaders } from "@/shared/headers.ts"
-import { verifyCSRFToken, getErrorName, shouldRefresh, toUnionHeaders } from "@/shared/utils.ts"
+import { verifyCSRFToken, getErrorName, shouldRefresh, toUnionHeaders, getDeviceInfo, createFingerprint } from "@/shared/utils.ts"
 import { handleApiError } from "@/shared/utils/api.ts"
 import { refreshProviderToken } from "@/shared/utils/refresh-tokens.ts"
 import { revokeProviderToken } from "@/shared/utils/revoke-token.ts"
@@ -41,6 +41,25 @@ export const createStatefulStrategy = <DefaultUser extends User = User>({
     oauth,
 }: DatabaseStrategyOptions<DefaultUser>): SessionStrategy<DefaultUser> => {
     const cookieConfig = createCookieManager(cookies)
+
+    const createDevice = async (userId: string, request: Request) => {
+        const { userAgent, browser, platform, deviceType, ip, name } = getDeviceInfo(request)
+        const fingerprint = await createFingerprint(request)
+        return await config.adapter.createDevice({
+            userId,
+            userAgent,
+            browser,
+            platform,
+            type: deviceType,
+            name,
+            lastIp: ip,
+            fingerprint,
+            firstSeenAt: new Date(),
+            lastSeenAt: new Date(),
+            trusted: false,
+            metadata: null,
+        })
+    }
 
     const getSession = async (headers: Headers): Promise<GetStatefulSessionReturn<DefaultUser>> => {
         logger?.log("STATEFUL_GET_SESSION_START", {
@@ -183,7 +202,7 @@ export const createStatefulStrategy = <DefaultUser extends User = User>({
         }
     }
 
-    const createSession = async (session: TypedJWTPayload<DefaultUser>) => {
+    const createSession = async (session: TypedJWTPayload<DefaultUser>, request: Request) => {
         logger?.log("STATEFUL_CREATE_SESSION_START", {
             structuredData: {
                 strategy: "stateful",
@@ -286,10 +305,12 @@ export const createStatefulStrategy = <DefaultUser extends User = User>({
             })
         }
 
+        const device = await createDevice(userId as string, request)
+
         const dbSession = await config.adapter.createSession({
             id: cryptoId,
             userId: userId as string,
-            deviceId: null,
+            deviceId: device.id,
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -1254,35 +1275,40 @@ export const createStatefulStrategy = <DefaultUser extends User = User>({
         if (!userInfo.email) {
             throw new AuraAuthError({ code: "INVALID_USER_INFO" })
         }
-        const user = await config.adapter.getUserByEmail(userInfo.email)
+
         let userId: string
+        const user = await config.adapter.getUserByEmail(userInfo.email)
 
         if (user) {
             userId = user.id
-            const updateData: any = {}
-            if (userInfo.name) updateData.name = userInfo.name
-            if (userInfo.image) updateData.image = userInfo.image
-            await config.adapter.updateUser(userId, updateData)
+            const { sub: _, name, email, image, ...attributes } = userInfo
+            await config.adapter.updateUser(userId, {
+                name,
+                email,
+                image,
+                attributes,
+            })
         } else {
+            const { email, image, name, ...attributes } = userInfo
             const newUser = await config.adapter.createUser({
                 id: crypto.randomUUID(),
-                email: userInfo.email,
-                name: userInfo.name,
-                image: userInfo.image,
+                email: email,
+                name: name,
+                image: image,
                 emailVerifiedAt: new Date(),
                 status: "active",
                 mfaEnabled: false,
                 mfaPreferredMethod: null,
-                attributes: {},
+                attributes: attributes,
             })
             userId = newUser.id
         }
 
-        const existingAccount = await config.adapter.getAccountByProvider(oauthId, userInfo.sub)
         let accountId: string
+        const account = await config.adapter.getAccountByProvider(oauthId, userInfo.sub)
 
-        if (existingAccount) {
-            accountId = existingAccount.id
+        if (account) {
+            accountId = account.id
             await config.adapter.updateOAuthTokens(accountId, {
                 accessToken: accessToken.access_token,
                 refreshToken: accessToken.refresh_token || null,
@@ -1290,6 +1316,9 @@ export const createStatefulStrategy = <DefaultUser extends User = User>({
                 tokenType: accessToken.token_type,
                 scopes: Array.isArray(accessToken.scope) ? accessToken.scope.join(" ") : accessToken.scope || null,
                 accessTokenExpiresAt: accessToken.expires_in ? new Date(Date.now() + accessToken.expires_in * 1000) : null,
+                refreshTokenExpiresAt: accessToken.refresh_token_expires_in
+                    ? new Date(Date.now() + accessToken.refresh_token_expires_in * 1000)
+                    : null,
             })
         } else {
             const newAccount = await config.adapter.createAccount({
@@ -1313,15 +1342,19 @@ export const createStatefulStrategy = <DefaultUser extends User = User>({
             })
         }
 
-        const sessionPayload: any = {
-            sub: userId,
-            email: userInfo.email || "",
-            name: userInfo.name || "",
-            image: userInfo.image || "",
-            attributes: {},
-        }
-
-        const session = await createSession(sessionPayload)
+        const device = await createDevice(userId, request)
+        const tokenHash = await createHash(crypto.randomUUID())
+        await config.adapter.createSession({
+            id: crypto.randomUUID(),
+            userId,
+            deviceId: device.id,
+            authenticatedWith: "oauth",
+            expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+            mfaState: "none",
+            status: "active",
+            tokenHash,
+            metadata: null,
+        })
 
         const csrfToken = await createCSRF(jose as any)
 
@@ -1333,12 +1366,9 @@ export const createStatefulStrategy = <DefaultUser extends User = User>({
         })
 
         const headersBuilder = new HeadersBuilder()
-            .setCookie(cookies().sessionToken.name, session, cookies().sessionToken.attributes)
+            .setHeader("Location", transaction.redirectTo || "/")
+            .setCookie(cookies().sessionToken.name, tokenHash, cookies().sessionToken.attributes)
             .setCookie(cookies().csrfToken.name, csrfToken, cookies().csrfToken.attributes)
-
-        const redirectTo = transaction.redirectTo || "/"
-
-        headersBuilder.setHeader("Location", redirectTo)
 
         return Response.json({ oauth: oauthId }, { status: 302, headers: headersBuilder.toHeaders() })
     }

--- a/packages/core/src/session/stateless.ts
+++ b/packages/core/src/session/stateless.ts
@@ -561,7 +561,7 @@ export const createStatelessStrategy = <DefaultUser extends User = User>({
         }
 
         const userInfo = await getUserInfo(resolvedConfig, accessToken, logger)
-        const session = await ctx.sessionStrategy.createSession(userInfo)
+        const session = await ctx.sessionStrategy.createSession(userInfo, request)
         const csrfToken = await createCSRF(jose)
         const tokenPayload = transformToTokenPayload(accessToken)
         const providerToken = await ctx.jwtManager.createToken(tokenPayload)

--- a/packages/core/src/shared/utils.ts
+++ b/packages/core/src/shared/utils.ts
@@ -1,12 +1,13 @@
 import { getEnv } from "@/shared/env.ts"
 import { getCookie } from "@/cookie.ts"
-import { verifyCSRF } from "@/shared/crypto.ts"
+import { createHash, verifyCSRF } from "@/shared/crypto.ts"
 import { encoder } from "@aura-stack/jose/crypto"
 import { AuraAuthError } from "@/shared/errors.ts"
 import { isRelativeURL, isString, isValidURL } from "@/shared/assert.ts"
 import type { JWTManager, OAuthTokenPayload } from "@/@types/session.ts"
 import type { InternalCookieStoreConfig, InternalLogger, JoseInstance, SchemaRegistryContext } from "@/@types/config.ts"
 import type { OAuthAccessTokenResponseType } from "@/@types/oauth.ts"
+import type { DeviceType } from "@/@types/entities.ts"
 
 export const AURA_AUTH_VERSION = "0.8.1"
 
@@ -251,5 +252,71 @@ export const transformToTokenPayload = (tokens: OAuthAccessTokenResponseType & {
         tokenType: tokens.token_type ?? "Bearer",
         scopes: isString(tokens.scope) ? [tokens.scope] : Array.isArray(tokens.scope) ? tokens.scope : [],
         issuedAt: now,
+    }
+}
+
+export const getBrowser = (userAgent: string) => {
+    if (userAgent.includes("Edg/")) return "Edge"
+    if (userAgent.includes("Firefox/")) return "Firefox"
+    if (userAgent.includes("Chrome/")) return "Chrome"
+    if (userAgent.includes("Safari/")) return "Safari"
+    return "Unknown"
+}
+
+export const getPlatform = (userAgent: string, secChUaPlatform: string | null) => {
+    if (secChUaPlatform) {
+        return secChUaPlatform.replace(/"/g, "").trim()
+    }
+    if (!userAgent) return null
+    if (/windows/i.test(userAgent)) return "Windows"
+    if (/macintosh|mac os x/i.test(userAgent)) return "macOS"
+    if (/android/i.test(userAgent)) return "Android"
+    if (/iphone|ipad|ipod/i.test(userAgent)) return "iOS"
+    if (/linux/i.test(userAgent)) return "Linux"
+    return "Unknown"
+}
+
+export const getDeviceType = (userAgent: string, secChUaMobile: string | null): DeviceType => {
+    if (secChUaMobile === "?1") return "mobile"
+    if (!userAgent) return "unknown"
+    if (/ipad|tablet/i.test(userAgent)) return "tablet"
+    if (/mobile|iphone|android/i.test(userAgent)) return "mobile"
+    if (/tv|smarttv|hbbtv|appletv|googletv/i.test(userAgent)) return "tv"
+    if (/bot|crawler|spider|crawling/i.test(userAgent)) return "bot"
+    return "desktop"
+}
+
+export const getIpAddress = (request: Request): string | null => {
+    return (
+        request.headers.get("x-forwarded-for")?.split(",")[0].trim() ||
+        request.headers.get("cf-connecting-ip") ||
+        request.headers.get("x-real-ip") ||
+        request.headers.get("x-client-ip") ||
+        request.headers.get("ip") ||
+        null
+    )
+}
+
+export const createFingerprint = async (request: Request): Promise<string> => {
+    const ip = getIpAddress(request) || "unknown"
+    const userAgent = request.headers.get("user-agent") || "unknown"
+    return await createHash(`${ip}:${userAgent}`)
+}
+
+export const getDeviceInfo = (request: Request) => {
+    const userAgent: string = request.headers.get("user-agent") || ""
+    const secChUaPlatform = request.headers.get("sec-ch-ua-platform")
+    const secChUaMobile = request.headers.get("sec-ch-ua-mobile")
+    const browser = getBrowser(userAgent)
+    const platform = getPlatform(userAgent, secChUaPlatform)
+    const ip = getIpAddress(request) || "unknown"
+
+    return {
+        ip,
+        browser,
+        platform,
+        userAgent,
+        name: `${browser} on ${platform}`,
+        deviceType: getDeviceType(userAgent, secChUaMobile),
     }
 }

--- a/packages/core/src/shared/utils.ts
+++ b/packages/core/src/shared/utils.ts
@@ -280,8 +280,8 @@ export const getDeviceType = (userAgent: string, secChUaMobile: string | null): 
     if (secChUaMobile === "?1") return "mobile"
     if (!userAgent) return "unknown"
     if (/ipad|tablet/i.test(userAgent)) return "tablet"
-    if (/mobile|iphone|android/i.test(userAgent)) return "mobile"
     if (/tv|smarttv|hbbtv|appletv|googletv/i.test(userAgent)) return "tv"
+    if (/mobile|iphone|android/i.test(userAgent)) return "mobile"
     if (/bot|crawler|spider|crawling/i.test(userAgent)) return "bot"
     return "desktop"
 }

--- a/packages/core/test/actions/callback/stateful.test.ts
+++ b/packages/core/test/actions/callback/stateful.test.ts
@@ -250,6 +250,7 @@ describe("callbackAction (stateful)", () => {
         })
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockResolvedValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const {
             handlers: { GET },
@@ -267,6 +268,7 @@ describe("callbackAction (stateful)", () => {
                 createOAuthAccount: createOAuthAccountMock,
                 createSession: createSessionMock,
                 createDevice: createDeviceMock,
+                getDeviceByFingerprint: getDeviceByFingerprintMock,
             },
             {
                 oauth: [oauthCustomService],
@@ -328,6 +330,7 @@ describe("callbackAction (stateful)", () => {
             accountId: "account-123",
             accessToken: "access_123",
             accessTokenExpiresAt: null,
+            refreshTokenExpiresAt: null,
             refreshToken: null,
             idToken: null,
             tokenType: "Bearer",
@@ -418,6 +421,7 @@ describe("callbackAction (stateful)", () => {
         })
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockResolvedValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const {
             handlers: { GET },
@@ -433,6 +437,7 @@ describe("callbackAction (stateful)", () => {
                 createOAuthAccount: createOAuthAccountMock,
                 createSession: createSessionMock,
                 createDevice: createDeviceMock,
+                getDeviceByFingerprint: getDeviceByFingerprintMock,
             },
             {
                 oauth: [oauthCustomService],

--- a/packages/core/test/actions/callback/stateful.test.ts
+++ b/packages/core/test/actions/callback/stateful.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from "vitest"
 import { AURA_AUTH_VERSION } from "@/shared/utils.ts"
-import { oauthCustomService, sessionEntityWithUser, userEntity, authInstance } from "@test/presets.ts"
+import { oauthCustomService, sessionEntityWithUser, userEntity, authInstance, deviceEntity } from "@test/presets.ts"
 import type { OAuthTransactionEntity } from "@/@types/entities.ts"
 
 describe("callbackAction (stateful)", () => {
@@ -248,6 +248,7 @@ describe("callbackAction (stateful)", () => {
             createdAt: new Date(),
             updatedAt: new Date(),
         })
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockResolvedValue(sessionEntityWithUser)
 
         const {
@@ -265,6 +266,7 @@ describe("callbackAction (stateful)", () => {
                 createAccount: createAccountMock,
                 createOAuthAccount: createOAuthAccountMock,
                 createSession: createSessionMock,
+                createDevice: createDeviceMock,
             },
             {
                 oauth: [oauthCustomService],
@@ -308,7 +310,9 @@ describe("callbackAction (stateful)", () => {
         expect(getUserByEmailMock).toHaveBeenCalledWith("john.doe@example.com")
         expect(updateUserMock).toHaveBeenCalledWith("user-123", {
             name: "John Doe",
+            email: "john.doe@example.com",
             image: "https://example.com/john-doe.jpg",
+            attributes: {},
         })
         expect(createUserMock).not.toHaveBeenCalled()
         expect(getAccountByProviderMock).toHaveBeenCalledWith("oauth-provider", "user_123")
@@ -329,9 +333,7 @@ describe("callbackAction (stateful)", () => {
             tokenType: "Bearer",
             scopes: null,
         })
-
-        expect(getUserByIdMock).toHaveBeenCalledWith("user-123")
-
+        expect(createDeviceMock).toHaveBeenCalled()
         expect(response.status).toBe(302)
         expect(response.headers.get("Location")).toBe("/auth")
     })
@@ -414,6 +416,7 @@ describe("callbackAction (stateful)", () => {
             createdAt: new Date(),
             updatedAt: new Date(),
         })
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockResolvedValue(sessionEntityWithUser)
 
         const {
@@ -429,6 +432,7 @@ describe("callbackAction (stateful)", () => {
                 createAccount: createAccountMock,
                 createOAuthAccount: createOAuthAccountMock,
                 createSession: createSessionMock,
+                createDevice: createDeviceMock,
             },
             {
                 oauth: [oauthCustomService],

--- a/packages/core/test/actions/signIn/signInCredentials/stateful.test.ts
+++ b/packages/core/test/actions/signIn/signInCredentials/stateful.test.ts
@@ -24,6 +24,7 @@ describe("signInCredentials action", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { handlers } = authInstance({
             createUser: createUserMock,
@@ -31,6 +32,7 @@ describe("signInCredentials action", async () => {
             getUserById: getUserByIdMock,
             createSession: createSessionMock,
             createDevice: createDeviceMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
         const response = await handlers.POST(
             new Request("http://localhost:3000/auth/signIn/credentials", {
@@ -135,6 +137,7 @@ describe("signInCredentials action", async () => {
         const createSessionMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { handlers } = authInstance(
             {
@@ -142,6 +145,7 @@ describe("signInCredentials action", async () => {
                 updateUser: updateUserMock,
                 getUserById: getUserByIdMock,
                 createSession: createSessionMock,
+                getDeviceByFingerprint: getDeviceByFingerprintMock,
             },
             {
                 credentials: {
@@ -192,6 +196,7 @@ describe("signInCredentials action", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { handlers } = authInstance({
             createUser: createUserMock,
@@ -199,6 +204,7 @@ describe("signInCredentials action", async () => {
             getUserById: getUserByIdMock,
             createSession: createSessionMock,
             createDevice: createDeviceMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const response = await handlers.POST(
@@ -257,6 +263,7 @@ describe("signInCredentials action", async () => {
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance({
@@ -264,6 +271,7 @@ describe("signInCredentials action", async () => {
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
             createDevice: createDeviceMock,
         })
 
@@ -323,6 +331,7 @@ describe("signInCredentials action", async () => {
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance({
@@ -331,6 +340,7 @@ describe("signInCredentials action", async () => {
             getUserById: getUserByIdMock,
             createSession: createSessionMock,
             createDevice: createDeviceMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const response = await handlers.POST(
@@ -390,6 +400,7 @@ describe("signInCredentials action", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { handlers } = authInstance({
             createUser: createUserMock,
@@ -397,6 +408,7 @@ describe("signInCredentials action", async () => {
             getUserById: getUserByIdMock,
             createSession: createSessionMock,
             createDevice: createDeviceMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const response = await handlers.POST(

--- a/packages/core/test/actions/signIn/signInCredentials/stateful.test.ts
+++ b/packages/core/test/actions/signIn/signInCredentials/stateful.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi } from "vitest"
-import { authInstance, jose, sessionEntityWithUser, userEntity } from "@test/presets.ts"
+import { authInstance, deviceEntity, jose, sessionEntityWithUser, userEntity } from "@test/presets.ts"
 import { createCSRF } from "@/shared/crypto.ts"
 import { createSchemaRegistry } from "@/validator/registry.ts"
 
@@ -22,6 +22,7 @@ describe("signInCredentials action", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance({
@@ -29,6 +30,7 @@ describe("signInCredentials action", async () => {
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
             createSession: createSessionMock,
+            createDevice: createDeviceMock,
         })
         const response = await handlers.POST(
             new Request("http://localhost:3000/auth/signIn/credentials", {
@@ -64,7 +66,7 @@ describe("signInCredentials action", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -188,6 +190,7 @@ describe("signInCredentials action", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance({
@@ -195,6 +198,7 @@ describe("signInCredentials action", async () => {
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
             createSession: createSessionMock,
+            createDevice: createDeviceMock,
         })
 
         const response = await handlers.POST(
@@ -232,7 +236,7 @@ describe("signInCredentials action", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -252,6 +256,7 @@ describe("signInCredentials action", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance({
@@ -259,6 +264,7 @@ describe("signInCredentials action", async () => {
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
             createSession: createSessionMock,
+            createDevice: createDeviceMock,
         })
 
         const response = await handlers.POST(
@@ -296,7 +302,7 @@ describe("signInCredentials action", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -316,6 +322,7 @@ describe("signInCredentials action", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance({
@@ -323,6 +330,7 @@ describe("signInCredentials action", async () => {
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
             createSession: createSessionMock,
+            createDevice: createDeviceMock,
         })
 
         const response = await handlers.POST(
@@ -360,7 +368,7 @@ describe("signInCredentials action", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -381,12 +389,14 @@ describe("signInCredentials action", async () => {
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
 
         const { handlers } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
             createSession: createSessionMock,
+            createDevice: createDeviceMock,
         })
 
         const response = await handlers.POST(
@@ -424,7 +434,7 @@ describe("signInCredentials action", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",

--- a/packages/core/test/actions/signUp/stateful.test.ts
+++ b/packages/core/test/actions/signUp/stateful.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, vi } from "vitest"
 import { z } from "zod/v4"
 import { createCSRF } from "@/shared/crypto.ts"
 import { identitySchema } from "@/identity/zod.ts"
-import { authInstance, jose, sessionEntityWithUser, sessionPayload, userEntity } from "@test/presets.ts"
+import { authInstance, deviceEntity, jose, sessionEntityWithUser, sessionPayload, userEntity } from "@test/presets.ts"
 import { createSchemaRegistry } from "@/validator/registry.ts"
 
 describe("signUp API", async () => {
@@ -24,12 +24,14 @@ describe("signUp API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance({
             createSession: createSessionMock,
             createUser: createUserMock,
             updateUser: updateUserMock,
+            createDevice: createDeviceMock,
             getUserById: getUserByIdMock,
         })
 
@@ -63,7 +65,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -83,12 +85,14 @@ describe("signUp API", async () => {
         const createUserMock = vi.fn()
         const updateUserMock = vi.fn().mockReturnValue(userEntity)
         const getUserByIdMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance({
             createSession: createSessionMock,
             createUser: createUserMock,
             updateUser: updateUserMock,
+            createDevice: createDeviceMock,
             getUserById: getUserByIdMock,
         })
 
@@ -121,7 +125,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -243,6 +247,7 @@ describe("signUp API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance(
@@ -250,6 +255,7 @@ describe("signUp API", async () => {
                 createUser: createUserMock,
                 updateUser: updateUserMock,
                 getUserById: getUserByIdMock,
+                createDevice: createDeviceMock,
                 createSession: createSessionMock,
             },
             {
@@ -301,7 +307,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "1234567890",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -315,6 +321,7 @@ describe("signUp API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance(
@@ -322,6 +329,7 @@ describe("signUp API", async () => {
                 createUser: createUserMock,
                 updateUser: updateUserMock,
                 getUserById: getUserByIdMock,
+                createDevice: createDeviceMock,
                 createSession: createSessionMock,
             },
             {
@@ -380,7 +388,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "1234567890",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -394,12 +402,14 @@ describe("signUp API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
+            createDevice: createDeviceMock,
             createSession: createSessionMock,
         })
 
@@ -430,7 +440,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -444,12 +454,14 @@ describe("signUp API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
+            createDevice: createDeviceMock,
             createSession: createSessionMock,
         })
 
@@ -480,7 +492,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -494,6 +506,7 @@ describe("signUp API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance({
@@ -501,6 +514,7 @@ describe("signUp API", async () => {
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
             createSession: createSessionMock,
+            createDevice: createDeviceMock,
         })
 
         const response = await handlers.POST(
@@ -530,7 +544,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -544,12 +558,14 @@ describe("signUp API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
+            createDevice: createDeviceMock,
             createSession: createSessionMock,
         })
 
@@ -580,7 +596,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -594,6 +610,7 @@ describe("signUp API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { handlers } = authInstance({
@@ -601,6 +618,7 @@ describe("signUp API", async () => {
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
             createSession: createSessionMock,
+            createDevice: createDeviceMock,
         })
 
         const response = await handlers.POST(
@@ -630,7 +648,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",

--- a/packages/core/test/actions/signUp/stateful.test.ts
+++ b/packages/core/test/actions/signUp/stateful.test.ts
@@ -26,6 +26,7 @@ describe("signUp API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { handlers } = authInstance({
             createSession: createSessionMock,
@@ -33,6 +34,7 @@ describe("signUp API", async () => {
             updateUser: updateUserMock,
             createDevice: createDeviceMock,
             getUserById: getUserByIdMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const response = await handlers.POST(
@@ -87,6 +89,7 @@ describe("signUp API", async () => {
         const getUserByIdMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { handlers } = authInstance({
             createSession: createSessionMock,
@@ -94,6 +97,7 @@ describe("signUp API", async () => {
             updateUser: updateUserMock,
             createDevice: createDeviceMock,
             getUserById: getUserByIdMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const response = await handlers.POST(
@@ -249,6 +253,7 @@ describe("signUp API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { handlers } = authInstance(
             {
@@ -257,6 +262,7 @@ describe("signUp API", async () => {
                 getUserById: getUserByIdMock,
                 createDevice: createDeviceMock,
                 createSession: createSessionMock,
+                getDeviceByFingerprint: getDeviceByFingerprintMock,
             },
             {
                 signUp: {
@@ -323,6 +329,7 @@ describe("signUp API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { handlers } = authInstance(
             {
@@ -331,6 +338,7 @@ describe("signUp API", async () => {
                 getUserById: getUserByIdMock,
                 createDevice: createDeviceMock,
                 createSession: createSessionMock,
+                getDeviceByFingerprint: getDeviceByFingerprintMock,
             },
             {
                 identity: {
@@ -404,6 +412,7 @@ describe("signUp API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { handlers } = authInstance({
             createUser: createUserMock,
@@ -411,6 +420,7 @@ describe("signUp API", async () => {
             getUserById: getUserByIdMock,
             createDevice: createDeviceMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const response = await handlers.POST(
@@ -456,6 +466,7 @@ describe("signUp API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { handlers } = authInstance({
             createUser: createUserMock,
@@ -463,6 +474,7 @@ describe("signUp API", async () => {
             getUserById: getUserByIdMock,
             createDevice: createDeviceMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const response = await handlers.POST(
@@ -508,6 +520,7 @@ describe("signUp API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { handlers } = authInstance({
             createUser: createUserMock,
@@ -515,6 +528,7 @@ describe("signUp API", async () => {
             getUserById: getUserByIdMock,
             createSession: createSessionMock,
             createDevice: createDeviceMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const response = await handlers.POST(
@@ -560,6 +574,7 @@ describe("signUp API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { handlers } = authInstance({
             createUser: createUserMock,
@@ -567,6 +582,7 @@ describe("signUp API", async () => {
             getUserById: getUserByIdMock,
             createDevice: createDeviceMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const response = await handlers.POST(
@@ -612,6 +628,7 @@ describe("signUp API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { handlers } = authInstance({
             createUser: createUserMock,
@@ -619,6 +636,7 @@ describe("signUp API", async () => {
             getUserById: getUserByIdMock,
             createSession: createSessionMock,
             createDevice: createDeviceMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const response = await handlers.POST(

--- a/packages/core/test/api/stateful/signInCredentials.test.ts
+++ b/packages/core/test/api/stateful/signInCredentials.test.ts
@@ -24,6 +24,7 @@ describe("signInCredentials API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { api } = authInstance({
             createUser: createUserMock,
@@ -31,6 +32,7 @@ describe("signInCredentials API", async () => {
             getUserById: getUserByIdMock,
             createDevice: createDeviceMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const output = await api.signInCredentials({
@@ -240,6 +242,7 @@ describe("signInCredentials API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { api } = authInstance({
             createUser: createUserMock,
@@ -247,6 +250,7 @@ describe("signInCredentials API", async () => {
             getUserById: getUserByIdMock,
             createDevice: createDeviceMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const output = await api.signInCredentials({
@@ -308,6 +312,7 @@ describe("signInCredentials API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { api } = authInstance({
             createUser: createUserMock,
@@ -315,6 +320,7 @@ describe("signInCredentials API", async () => {
             getUserById: getUserByIdMock,
             createDevice: createDeviceMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const output = await api.signInCredentials({
@@ -376,6 +382,7 @@ describe("signInCredentials API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { api } = authInstance({
             createUser: createUserMock,
@@ -383,6 +390,7 @@ describe("signInCredentials API", async () => {
             getUserById: getUserByIdMock,
             createDevice: createDeviceMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const output = await api.signInCredentials({
@@ -444,6 +452,7 @@ describe("signInCredentials API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { api } = authInstance({
             createUser: createUserMock,
@@ -451,6 +460,7 @@ describe("signInCredentials API", async () => {
             getUserById: getUserByIdMock,
             createDevice: createDeviceMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const output = await api.signInCredentials({

--- a/packages/core/test/api/stateful/signInCredentials.test.ts
+++ b/packages/core/test/api/stateful/signInCredentials.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from "vitest"
 import { createCSRF } from "@/shared/crypto.ts"
-import { authInstance, jose, sessionEntityWithUser, userEntity } from "@test/presets.ts"
+import { authInstance, deviceEntity, jose, sessionEntityWithUser, userEntity } from "@test/presets.ts"
 import { createSchemaRegistry } from "@/validator/registry.ts"
 
 describe("signInCredentials API", async () => {
@@ -22,12 +22,14 @@ describe("signInCredentials API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { api } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
+            createDevice: createDeviceMock,
             createSession: createSessionMock,
         })
 
@@ -63,7 +65,7 @@ describe("signInCredentials API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -236,12 +238,14 @@ describe("signInCredentials API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { api } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
+            createDevice: createDeviceMock,
             createSession: createSessionMock,
         })
 
@@ -280,7 +284,7 @@ describe("signInCredentials API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -302,12 +306,14 @@ describe("signInCredentials API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { api } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
+            createDevice: createDeviceMock,
             createSession: createSessionMock,
         })
 
@@ -346,7 +352,7 @@ describe("signInCredentials API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -368,12 +374,14 @@ describe("signInCredentials API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { api } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
+            createDevice: createDeviceMock,
             createSession: createSessionMock,
         })
 
@@ -412,7 +420,7 @@ describe("signInCredentials API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -434,12 +442,14 @@ describe("signInCredentials API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { api } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
+            createDevice: createDeviceMock,
             createSession: createSessionMock,
         })
 
@@ -478,7 +488,7 @@ describe("signInCredentials API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",

--- a/packages/core/test/api/stateful/signUp.test.ts
+++ b/packages/core/test/api/stateful/signUp.test.ts
@@ -25,6 +25,7 @@ describe("signUp API", async () => {
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { api } = authInstance({
             createUser: createUserMock,
@@ -32,6 +33,7 @@ describe("signUp API", async () => {
             getUserById: getUserByIdMock,
             createDevice: createDeviceMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const output = await api.signUp({
@@ -225,6 +227,7 @@ describe("signUp API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { api } = authInstance({
             createUser: createUserMock,
@@ -232,6 +235,7 @@ describe("signUp API", async () => {
             getUserById: getUserByIdMock,
             createDevice: createDeviceMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const output = await api.signUp({
@@ -288,6 +292,7 @@ describe("signUp API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { api } = authInstance({
             createUser: createUserMock,
@@ -295,6 +300,7 @@ describe("signUp API", async () => {
             getUserById: getUserByIdMock,
             createDevice: createDeviceMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const output = await api.signUp({
@@ -351,6 +357,7 @@ describe("signUp API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { api } = authInstance({
             createUser: createUserMock,
@@ -358,6 +365,7 @@ describe("signUp API", async () => {
             getUserById: getUserByIdMock,
             createDevice: createDeviceMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const output = await api.signUp({
@@ -414,6 +422,7 @@ describe("signUp API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { api } = authInstance({
             createUser: createUserMock,
@@ -421,6 +430,7 @@ describe("signUp API", async () => {
             getUserById: getUserByIdMock,
             createDevice: createDeviceMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const output = await api.signUp({
@@ -477,6 +487,7 @@ describe("signUp API", async () => {
         const createUserMock = vi.fn().mockReturnValue(userEntity)
         const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
+        const getDeviceByFingerprintMock = vi.fn().mockReturnValue(null)
 
         const { api } = authInstance({
             createUser: createUserMock,
@@ -484,6 +495,7 @@ describe("signUp API", async () => {
             getUserById: getUserByIdMock,
             createDevice: createDeviceMock,
             createSession: createSessionMock,
+            getDeviceByFingerprint: getDeviceByFingerprintMock,
         })
 
         const output = await api.signUp({

--- a/packages/core/test/api/stateful/signUp.test.ts
+++ b/packages/core/test/api/stateful/signUp.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi } from "vitest"
 import { createCSRF } from "@/shared/crypto.ts"
 import { createSchemaRegistry } from "@/validator/registry.ts"
-import { authInstance, jose, sessionEntityWithUser, sessionPayload, userEntity } from "@test/presets.ts"
+import { authInstance, deviceEntity, jose, sessionEntityWithUser, sessionPayload, userEntity } from "@test/presets.ts"
 import type { User } from "@/index.ts"
 
 describe("signUp API", async () => {
@@ -23,12 +23,14 @@ describe("signUp API", async () => {
         const updateUserMock = vi.fn()
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
         const getUserByIdMock = vi.fn().mockReturnValue(null)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
 
         const { api } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
+            createDevice: createDeviceMock,
             createSession: createSessionMock,
         })
 
@@ -59,7 +61,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -221,12 +223,14 @@ describe("signUp API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { api } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
+            createDevice: createDeviceMock,
             createSession: createSessionMock,
         })
 
@@ -260,7 +264,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -282,12 +286,14 @@ describe("signUp API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { api } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
+            createDevice: createDeviceMock,
             createSession: createSessionMock,
         })
 
@@ -321,7 +327,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -343,12 +349,14 @@ describe("signUp API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { api } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
+            createDevice: createDeviceMock,
             createSession: createSessionMock,
         })
 
@@ -382,7 +390,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -404,12 +412,14 @@ describe("signUp API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { api } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
+            createDevice: createDeviceMock,
             createSession: createSessionMock,
         })
 
@@ -443,7 +453,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",
@@ -465,12 +475,14 @@ describe("signUp API", async () => {
         const updateUserMock = vi.fn()
         const getUserByIdMock = vi.fn().mockReturnValue(null)
         const createUserMock = vi.fn().mockReturnValue(userEntity)
+        const createDeviceMock = vi.fn().mockResolvedValue(deviceEntity)
         const createSessionMock = vi.fn().mockReturnValue(sessionEntityWithUser)
 
         const { api } = authInstance({
             createUser: createUserMock,
             updateUser: updateUserMock,
             getUserById: getUserByIdMock,
+            createDevice: createDeviceMock,
             createSession: createSessionMock,
         })
 
@@ -504,7 +516,7 @@ describe("signUp API", async () => {
         expect(createSessionMock).toHaveBeenCalledWith({
             id: expect.any(String),
             userId: "user-123",
-            deviceId: null,
+            deviceId: "device-123",
             authenticatedWith: "credentials",
             status: "active",
             mfaState: "none",

--- a/packages/core/test/presets.ts
+++ b/packages/core/test/presets.ts
@@ -4,6 +4,7 @@ import type {
     AccountEntity,
     AuthConfig,
     DatabaseAdapter,
+    DeviceEntity,
     OAuthAccountEntity,
     OAuthProviderCredentials,
     OAuthTokenPayload,
@@ -133,6 +134,23 @@ export const accountEntity: Partial<AccountEntity> = {
     id: "account-123",
     status: "unlinked",
     provider: "oauth-provider",
+}
+
+export const deviceEntity: DeviceEntity = {
+    id: "device-123",
+    userId: userEntity.id,
+    userAgent:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+    browser: "Chrome",
+    platform: "Windows",
+    name: "John's Laptop",
+    type: "desktop",
+    lastIp: "192.168.1.1",
+    fingerprint: "fingerprint-123",
+    firstSeenAt: new Date(),
+    lastSeenAt: new Date(),
+    trusted: false,
+    metadata: null,
 }
 
 const auth = createAuth({

--- a/packages/elysia/test/stateful/index.test.ts
+++ b/packages/elysia/test/stateful/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi } from "vitest"
 import { adapter, app, auth, prismaClient } from "@test/stateful/app"
 import { createCSRF } from "@aura-stack/auth/crypto"
+import { parseSetCookie } from "@aura-stack/auth/cookies"
 
 describe("GET /api/auth/signIn/github", () => {
     test("redirects to GitHub's OAuth page", async () => {
@@ -63,13 +64,16 @@ describe("GET /api/auth/signIn/github", () => {
             redirectTo: null,
             userAgent: null,
         })
-        await app.handle(
+        const request = await app.handle(
             new Request("http://localhost:3000/api/auth/callback/github?code=valid-code&state=state-123", {
                 headers: {
                     "User-Agent": "Mozilla/5.0",
                 },
             })
         )
+        const sessionToken = request.headers.getSetCookie()?.find((cookie) => cookie.startsWith("aura-auth.session_token="))
+        expect(sessionToken).toBeDefined()
+
         expect(mockFetch).toHaveBeenNthCalledWith(1, "https://github.com/login/oauth/access_token", {
             method: "POST",
             headers: {
@@ -94,6 +98,26 @@ describe("GET /api/auth/signIn/github", () => {
                 Authorization: "Bearer access_token_123",
             },
             signal: expect.any(AbortSignal),
+        })
+
+        const parsed = parseSetCookie(sessionToken!)
+        const session = await app.handle(
+            new Request("http://localhost/api/auth/session", {
+                headers: { Cookie: `aura-auth.session_token=${parsed.value}` },
+            })
+        )
+        expect(session.status).toBe(200)
+        expect(await session.json()).toEqual({
+            success: true,
+            session: {
+                user: {
+                    sub: expect.any(String),
+                    name: "John Doe",
+                    email: "john.doe@example.com",
+                    image: "https://john.doe/avatar.png",
+                },
+                expires: expect.any(String),
+            },
         })
     })
 })


### PR DESCRIPTION
## Description

This pull request adds automatic device metadata collection and registration for the Stateful session strategy.

During authentication flows such as credential sign-in, OAuth/OIDC sign-in, and sign-up, the library now captures device information from the incoming request and stores it in the `Device` table. This information can be used to identify trusted devices, audit authentication activity, manage active sessions, and support future security features.

The device metadata is inferred primarily from the request headers, which are normalized and mapped into a consistent structure before being persisted.

### Captured Metadata

The following information is collected when available:

- Platform
- Browser
- User agent
- Device fingerprint
- Client IP address
- Additional device metadata inferred from request headers

### Request Headers

The following headers are used to infer device metadata:

> **Note:** Header values are normalized and mapped into a consistent format to provide more accurate and predictable device information.

- `user-agent`
- `sec-ch-ua-platform`
- `sec-ch-ua-mobile`
- `x-forwarded-for`
- `cf-connecting-ip`
- `x-real-ip`
- `x-client-ip`
- `ip`

## Related PRs
- #240 
- #237 
- #235
- #234
- #231
- #230
- #229
- #228
- #227


@coderabbitai ignore