### PR TITLE
fix(security)!: mitigate session token hashing vulnerability

### DIFF
--- a/packages/core/src/session/stateful/createSession.ts
+++ b/packages/core/src/session/stateful/createSession.ts
@@ -44,14 +44,14 @@ export const createSession = <DefaultUser extends User>({ ctx, cookies, cookieMa
             throw new AuraAuthError({ code: "INVALID_USER_INFO" })
         }
 
-        const secretValue = createSecretValue(64)
+        const sessionToken = createSecretValue(64)
         logger?.log("STATEFUL_TOKEN_GENERATED", {
             structuredData: {
-                token_length: secretValue.length,
+                token_length: sessionToken.length,
             },
         })
 
-        const tokenHash = await createHash(secretValue)
+        const tokenHash = await createHash(sessionToken)
         logger?.log("STATEFUL_TOKEN_HASHED", {
             structuredData: {
                 hash_length: tokenHash.length,
@@ -142,6 +142,6 @@ export const createSession = <DefaultUser extends User>({ ctx, cookies, cookieMa
             },
         })
 
-        return secretValue
+        return sessionToken
     }
 }

--- a/packages/core/src/session/stateful/destroySession.ts
+++ b/packages/core/src/session/stateful/destroySession.ts
@@ -1,5 +1,6 @@
 import { getErrorName, verifyCSRFToken } from "@/shared/utils.ts"
 import type { InternalStatefulContext } from "@/@types/index.ts"
+import { createHash } from "@/shared/crypto.ts"
 
 export const destroySession = ({ ctx, cookies, cookieManager }: InternalStatefulContext) => {
     const { logger, sessionConfig, jose } = ctx
@@ -30,7 +31,8 @@ export const destroySession = ({ ctx, cookies, cookieManager }: InternalStateful
             })
 
             if (sessionToken) {
-                const sessionByToken = await sessionConfig.adapter.getSessionByToken(sessionToken)
+                const tokenHash = await createHash(sessionToken)
+                const sessionByToken = await sessionConfig.adapter.getSessionByToken(tokenHash)
                 logger?.log("STATEFUL_SESSION_DB_LOOKUP", {
                     structuredData: {
                         session_found: Boolean(sessionByToken),

--- a/packages/core/src/session/stateful/getProviderTokens.ts
+++ b/packages/core/src/session/stateful/getProviderTokens.ts
@@ -3,6 +3,7 @@ import { handleApiError } from "@/shared/utils/api.ts"
 import { getErrorName, shouldRefresh } from "@/shared/utils.ts"
 import { refreshProviderToken } from "@/shared/utils/refresh-tokens.ts"
 import type { GetProviderTokensStatefulReturn, InternalStatefulContext } from "@/@types/index.ts"
+import { createHash } from "@/shared/crypto.ts"
 
 export const getProviderTokens = ({ ctx, cookieManager }: InternalStatefulContext) => {
     const { oauth, logger, sessionConfig } = ctx
@@ -37,7 +38,8 @@ export const getProviderTokens = ({ ctx, cookieManager }: InternalStatefulContex
                 return { success: false, error: { code, message }, tokens: null, headers: cookieManager.clear(), statusCode }
             }
 
-            const sessionByToken = await sessionConfig.adapter.getSessionByToken(sessionToken)
+            const tokenHash = await createHash(sessionToken)
+            const sessionByToken = await sessionConfig.adapter.getSessionByToken(tokenHash)
             if (!sessionByToken || !sessionByToken.user) {
                 logger?.log("STATEFUL_GET_PROVIDER_TOKENS_SESSION_INVALID", {
                     structuredData: {

--- a/packages/core/src/session/stateful/getSession.ts
+++ b/packages/core/src/session/stateful/getSession.ts
@@ -1,4 +1,5 @@
 import { getErrorName } from "@/shared/utils.ts"
+import { createHash } from "@/shared/crypto.ts"
 import { AuraAuthError } from "@/shared/errors.ts"
 import { secureApiHeaders } from "@/shared/headers.ts"
 import type { GetStatefulSessionReturn, User, InternalStatefulContext } from "@/@types/index.ts"
@@ -36,7 +37,8 @@ export const getSession = <DefaultUser extends User>({ ctx, cookieManager }: Int
                 }
             }
 
-            const session = await sessionConfig.adapter.getSessionByToken(sessionToken)
+            const tokenHash = await createHash(sessionToken)
+            const session = await sessionConfig.adapter.getSessionByToken(tokenHash)
             logger?.log("STATEFUL_SESSION_DB_LOOKUP", {
                 structuredData: {
                     session_found: Boolean(session),

--- a/packages/core/src/session/stateful/isProviderConnected.ts
+++ b/packages/core/src/session/stateful/isProviderConnected.ts
@@ -1,5 +1,6 @@
 import { getErrorName } from "@/shared/utils.ts"
 import type { InternalStatefulContext } from "@/@types/index.ts"
+import { createHash } from "@/shared/crypto.ts"
 
 export const isProviderConnected = ({ ctx, cookieManager }: InternalStatefulContext) => {
     const { logger, sessionConfig } = ctx
@@ -23,7 +24,8 @@ export const isProviderConnected = ({ ctx, cookieManager }: InternalStatefulCont
                 return false
             }
 
-            const sessionByToken = await sessionConfig.adapter.getSessionByToken(sessionToken)
+            const tokenHash = await createHash(sessionToken)
+            const sessionByToken = await sessionConfig.adapter.getSessionByToken(tokenHash)
             if (!sessionByToken || !sessionByToken.user) {
                 logger?.log("AUTH_SESSION_INVALID", {
                     structuredData: {

--- a/packages/core/src/session/stateful/oauthCallback.ts
+++ b/packages/core/src/session/stateful/oauthCallback.ts
@@ -239,7 +239,7 @@ export const oauthCallback = ({ ctx, cookies, cookieManager }: InternalStatefulC
 
         const headersBuilder = new HeadersBuilder()
             .setHeader("Location", transaction.redirectTo || "/")
-            .setCookie(cookies().sessionToken.name, tokenHash, cookies().sessionToken.attributes)
+            .setCookie(cookies().sessionToken.name, sessionToken, cookies().sessionToken.attributes)
             .setCookie(cookies().csrfToken.name, csrfToken, cookies().csrfToken.attributes)
 
         return Response.json({ oauth: oauthId }, { status: 302, headers: headersBuilder.toHeaders() })

--- a/packages/core/src/session/stateful/refreshSession.ts
+++ b/packages/core/src/session/stateful/refreshSession.ts
@@ -1,6 +1,7 @@
 import { getErrorName, verifyCSRFToken } from "@/shared/utils.ts"
 import type { DeepPartial } from "@/@types/utility.ts"
 import type { InternalStatefulContext, Session, User } from "@/@types/index.ts"
+import { createHash } from "@/shared/crypto.ts"
 
 export const refreshSession = <DefaultUser extends User>({ ctx, cookies, cookieManager }: InternalStatefulContext) => {
     const { logger, sessionConfig, jose } = ctx
@@ -68,7 +69,8 @@ export const refreshSession = <DefaultUser extends User>({ ctx, cookies, cookieM
                 return { session: null, headers: cookieManager.clear() }
             }
 
-            const sessionByToken = await sessionConfig.adapter.getSessionByToken(sessionToken)
+            const tokenHash = await createHash(sessionToken)
+            const sessionByToken = await sessionConfig.adapter.getSessionByToken(tokenHash)
             logger?.log("STATEFUL_SESSION_DB_LOOKUP", {
                 structuredData: {
                     session_found: Boolean(sessionByToken),

--- a/packages/core/src/session/stateful/revokeToken.ts
+++ b/packages/core/src/session/stateful/revokeToken.ts
@@ -5,6 +5,7 @@ import { secureApiHeaders } from "@/shared/headers.ts"
 import { revokeProviderToken } from "@/shared/utils/revoke-token.ts"
 import { getErrorName, toUnionHeaders } from "@/shared/utils.ts"
 import type { InternalStatefulContext } from "@/@types/index.ts"
+import { createHash } from "@/shared/crypto.ts"
 
 export const revokeToken = ({ ctx, cookieManager }: InternalStatefulContext) => {
     const { oauth, logger, sessionConfig, cookies } = ctx
@@ -29,7 +30,8 @@ export const revokeToken = ({ ctx, cookieManager }: InternalStatefulContext) => 
                 throw new AuraAuthError({ code: "SESSION_NOT_FOUND" })
             }
 
-            const sessionByToken = await sessionConfig.adapter.getSessionByToken(sessionToken)
+            const tokenHash = await createHash(sessionToken)
+            const sessionByToken = await sessionConfig.adapter.getSessionByToken(tokenHash)
             if (!sessionByToken || !sessionByToken.user) {
                 logger?.log("AUTH_SESSION_INVALID", {
                     structuredData: {

--- a/packages/core/src/session/stateful/signInCredentials.ts
+++ b/packages/core/src/session/stateful/signInCredentials.ts
@@ -40,14 +40,14 @@ export const signInCredentials = ({ ctx, cookies, cookieManager }: InternalState
 
         const device = await createDevice(user.id, request)
 
-        const secretValue = createSecretValue(64)
+        const sessionToken = createSecretValue(64)
         logger?.log("STATEFUL_TOKEN_GENERATED", {
             structuredData: {
-                token_length: secretValue.length,
+                token_length: sessionToken.length,
             },
         })
 
-        const tokenHash = await createHash(secretValue)
+        const tokenHash = await createHash(sessionToken)
         logger?.log("STATEFUL_TOKEN_HASHED", {
             structuredData: {
                 hash_length: tokenHash.length,
@@ -91,6 +91,6 @@ export const signInCredentials = ({ ctx, cookies, cookieManager }: InternalState
             },
         })
 
-        return tokenHash
+        return sessionToken
     }
 }

--- a/packages/core/src/session/stateful/signUp.ts
+++ b/packages/core/src/session/stateful/signUp.ts
@@ -88,14 +88,14 @@ export const signUp = ({ ctx, cookies, cookieManager }: InternalStatefulContext)
         }
 
         const device = await createDevice(user.id, request)
-        const secretValue = createSecretValue(64)
+        const sessionToken = createSecretValue(64)
         logger?.log("STATEFUL_TOKEN_GENERATED", {
             structuredData: {
-                token_length: secretValue.length,
+                token_length: sessionToken.length,
             },
         })
 
-        const tokenHash = await createHash(secretValue)
+        const tokenHash = await createHash(sessionToken)
         logger?.log("STATEFUL_TOKEN_HASHED", {
             structuredData: {
                 hash_length: tokenHash.length,
@@ -139,6 +139,6 @@ export const signUp = ({ ctx, cookies, cookieManager }: InternalStatefulContext)
             },
         })
 
-        return secretValue
+        return sessionToken
     }
 }

--- a/packages/core/src/shared/utils/api.ts
+++ b/packages/core/src/shared/utils/api.ts
@@ -19,6 +19,7 @@ import type {
 } from "@/@types/index.ts"
 import { isStatelessStrategy } from "../assert.ts"
 import { createCookieManager } from "@/session/cookie-manager.ts"
+import { createHash } from "../crypto.ts"
 
 export const createValidation = (ctx: RouterGlobalContext, headersInit?: HeadersInit) => {
     const headers = new Headers(headersInit)
@@ -56,7 +57,8 @@ export const createValidation = (ctx: RouterGlobalContext, headersInit?: Headers
                     })
                 } else {
                     const { sessionToken } = createCookieManager(() => ctx.cookies).getCookie(new Headers(headersInit))
-                    const session = await ctx.sessionConfig.adapter.getSessionByToken(sessionToken)
+                    const tokenHash = await createHash(sessionToken)
+                    const session = await ctx.sessionConfig.adapter.getSessionByToken(tokenHash)
                     if (!session) {
                         throw new AuraAuthError({ code: "SESSION_NOT_FOUND" })
                     }

--- a/packages/core/src/shared/utils/api.ts
+++ b/packages/core/src/shared/utils/api.ts
@@ -57,6 +57,9 @@ export const createValidation = (ctx: RouterGlobalContext, headersInit?: Headers
                     })
                 } else {
                     const { sessionToken } = createCookieManager(() => ctx.cookies).getCookie(new Headers(headersInit))
+                    if (!sessionToken) {
+                        throw new AuraAuthError({ code: "SESSION_NOT_FOUND" })
+                    }
                     const tokenHash = await createHash(sessionToken)
                     const session = await ctx.sessionConfig.adapter.getSessionByToken(tokenHash)
                     if (!session) {

--- a/packages/core/test/actions/providers/connected/stateful.test.ts
+++ b/packages/core/test/actions/providers/connected/stateful.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi } from "vitest"
-import { createCSRF } from "@/shared/crypto.ts"
+import { createCSRF, createHash } from "@/shared/crypto.ts"
 import { accountEntity, authInstance, jose, oauthTokens, sessionEntityWithUser, sessionPayload } from "@test/presets.ts"
 
 describe("connectedAction", () => {
@@ -73,6 +73,7 @@ describe("connectedAction", () => {
         })
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const response = await GET(
             new Request("https://example.com/auth/providers/oauth-provider", {
@@ -88,7 +89,7 @@ describe("connectedAction", () => {
             connected: false,
         })
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).not.toHaveBeenCalled()
     })
 
@@ -107,6 +108,7 @@ describe("connectedAction", () => {
         })
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const response = await GET(
             new Request("https://example.com/auth/providers/oauth-provider", {
@@ -123,7 +125,7 @@ describe("connectedAction", () => {
             connected: true,
         })
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith(sessionEntityWithUser.userId)
     })
 

--- a/packages/core/test/actions/providers/connected/stateful.test.ts
+++ b/packages/core/test/actions/providers/connected/stateful.test.ts
@@ -89,7 +89,9 @@ describe("connectedAction", () => {
             connected: false,
         })
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenCalledTimes(2)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, tokenHash)
         expect(getAccountsByUserIdMock).not.toHaveBeenCalled()
     })
 

--- a/packages/core/test/actions/providers/tokens/revoke/stateful.test.ts
+++ b/packages/core/test/actions/providers/tokens/revoke/stateful.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi } from "vitest"
-import { createCSRF } from "@/shared/crypto.ts"
+import { createCSRF, createHash } from "@/shared/crypto.ts"
 import {
     accountEntity,
     authInstance,
@@ -162,7 +162,8 @@ describe("Revoke Action", () => {
         expect(response.status).toBe(401)
         expect(await response.json()).toEqual({ success: false })
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateAccountStatusMock).not.toHaveBeenCalled()
     })
@@ -186,6 +187,7 @@ describe("Revoke Action", () => {
         )
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const response = await POST(
             new Request("https://example.com/auth/providers/oauth-provider/tokens/revoke", {
@@ -199,7 +201,7 @@ describe("Revoke Action", () => {
         expect(response.status).toBe(401)
         expect(await response.json()).toEqual({ success: false })
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateAccountStatusMock).not.toHaveBeenCalled()
     })
@@ -220,6 +222,7 @@ describe("Revoke Action", () => {
         })
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const mockFetch = vi.fn()
         mockFetch.mockResolvedValueOnce({
@@ -255,7 +258,7 @@ describe("Revoke Action", () => {
             body: expect.any(URLSearchParams),
             signal: expect.any(AbortSignal),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).toHaveBeenCalledWith("account-123", "unlinked")
@@ -277,6 +280,7 @@ describe("Revoke Action", () => {
         })
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const mockFetch = vi.fn()
         mockFetch.mockResolvedValueOnce({
@@ -297,7 +301,7 @@ describe("Revoke Action", () => {
 
         expect(response.status).toBe(200)
         expect(await response.json()).toEqual({ success: true })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).toHaveBeenCalledWith("account-123", "unlinked")
@@ -319,6 +323,7 @@ describe("Revoke Action", () => {
         })
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const encodedTokens = await jose.encodeJWT(oauthTokens as unknown as Record<string, unknown>)
 
@@ -336,7 +341,7 @@ describe("Revoke Action", () => {
         )
 
         expect(await response.json()).toEqual({ success: false })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).not.toHaveBeenCalled()
@@ -377,7 +382,8 @@ describe("Revoke Action", () => {
 
         expect(await response.json()).toEqual({ success: false })
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).not.toHaveBeenCalled()
@@ -398,6 +404,7 @@ describe("Revoke Action", () => {
         })
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
         const mockFetch = vi.fn().mockResolvedValueOnce({
             ok: true,
             status: 201,
@@ -416,7 +423,7 @@ describe("Revoke Action", () => {
 
         expect(await response.json()).toEqual({ success: false })
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).not.toHaveBeenCalled()
@@ -437,6 +444,7 @@ describe("Revoke Action", () => {
         })
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const response = await POST(
             new Request("https://example.com/auth/providers/oauth-provider/tokens/revoke", {
@@ -450,7 +458,7 @@ describe("Revoke Action", () => {
 
         expect(await response.json()).toEqual({ success: false })
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).not.toHaveBeenCalled()
@@ -473,6 +481,7 @@ describe("Revoke Action", () => {
         })
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const response = await POST(
             new Request("https://example.com/auth/providers/oauth-provider/tokens/revoke", {
@@ -486,7 +495,7 @@ describe("Revoke Action", () => {
 
         expect(await response.json()).toEqual({ success: false })
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateAccountStatusMock).not.toHaveBeenCalled()
     })
@@ -515,6 +524,7 @@ describe("Revoke Action", () => {
         )
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const mockFetch = vi.fn()
         mockFetch.mockResolvedValueOnce({
@@ -536,7 +546,7 @@ describe("Revoke Action", () => {
         expect(await response.json()).toEqual({ success: true })
         expect(mockFetch).toHaveBeenCalledWith("https://custom.example.com/revoke", expect.any(Object))
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).toHaveBeenCalledWith("account-123", "unlinked")
@@ -574,6 +584,7 @@ describe("Revoke Action", () => {
         )
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const mockFetch = vi.fn()
         mockFetch.mockResolvedValueOnce({
@@ -596,7 +607,7 @@ describe("Revoke Action", () => {
         expect(await response.json()).toEqual({
             success: true,
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).toHaveBeenCalledWith("account-123", "unlinked")

--- a/packages/core/test/actions/providers/tokens/tokens/stateful.test.ts
+++ b/packages/core/test/actions/providers/tokens/tokens/stateful.test.ts
@@ -3,7 +3,7 @@ import { accountEntity, authInstance, jose, oauthCustomService, sessionEntityWit
 import { createAuth } from "@/createAuth.ts"
 import { createBasicAuthHeader } from "@/shared/utils.ts"
 import type { OAuthProviderConfig } from "@/@types/oauth.ts"
-import { createCSRF } from "@/shared/crypto.ts"
+import { createCSRF, createHash } from "@/shared/crypto.ts"
 import type { DatabaseAdapter } from "@/@types/adapter.ts"
 
 describe("tokensAction (Stateful)", async () => {
@@ -93,7 +93,8 @@ describe("tokensAction (Stateful)", async () => {
             success: false,
             tokens: null,
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
     })
@@ -131,7 +132,8 @@ describe("tokensAction (Stateful)", async () => {
             success: false,
             tokens: null,
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
@@ -187,7 +189,8 @@ describe("tokensAction (Stateful)", async () => {
                 scopes: ["scope1", "scope2"],
             }),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
@@ -248,7 +251,8 @@ describe("tokensAction (Stateful)", async () => {
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
     })
 
     test("refreshToken successfully refreshes tokens", async () => {

--- a/packages/core/test/actions/providers/user/refresh/stateful.test.ts
+++ b/packages/core/test/actions/providers/user/refresh/stateful.test.ts
@@ -9,7 +9,7 @@ import {
     sessionEntityWithUser,
     userEntity,
 } from "@test/presets.ts"
-import { createCSRF } from "@/shared/crypto.ts"
+import { createCSRF, createHash } from "@/shared/crypto.ts"
 import { AURA_AUTH_VERSION } from "@/shared/utils.ts"
 import { createSchemaRegistry } from "@/validator/registry.ts"
 
@@ -217,7 +217,8 @@ describe("refreshUserInfo action", () => {
         expect(spyParse).not.toHaveBeenCalled()
         expect(spyParseAsPartial).not.toHaveBeenCalled()
 
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, "valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, tokenHash)
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(revokeSessionMock).not.toHaveBeenCalled()
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
@@ -257,6 +258,7 @@ describe("refreshUserInfo action", () => {
         })
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const mockFetch = vi.fn()
         mockFetch.mockResolvedValueOnce({
@@ -304,14 +306,14 @@ describe("refreshUserInfo action", () => {
             signal: expect.any(AbortSignal),
         })
 
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, "valid-token-hash")
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, "valid-token-hash")
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, "valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, "valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
 
         const { attributes, ...spreadUser } = userEntity
@@ -381,6 +383,7 @@ describe("refreshUserInfo action", () => {
         })
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const mockFetch = vi.fn().mockResolvedValueOnce({
             ok: false,
@@ -406,7 +409,7 @@ describe("refreshUserInfo action", () => {
         expect(spyParse).not.toHaveBeenCalled()
         expect(spyParseAsPartial).not.toHaveBeenCalled()
 
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, "valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, tokenHash)
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(revokeSessionMock).not.toHaveBeenCalled()
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
@@ -444,6 +447,7 @@ describe("refreshUserInfo action", () => {
         })
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const mockFetch = vi.fn().mockResolvedValueOnce({
             ok: true,
@@ -473,7 +477,7 @@ describe("refreshUserInfo action", () => {
         expect(spyParse).not.toHaveBeenCalled()
         expect(spyParseAsPartial).not.toHaveBeenCalled()
 
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, "valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, tokenHash)
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(revokeSessionMock).not.toHaveBeenCalled()
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
@@ -511,6 +515,7 @@ describe("refreshUserInfo action", () => {
         })
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const mockFetch = vi.fn().mockResolvedValueOnce({
             ok: true,
@@ -540,7 +545,7 @@ describe("refreshUserInfo action", () => {
         expect(spyParse).not.toHaveBeenCalled()
         expect(spyParseAsPartial).not.toHaveBeenCalled()
 
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, "valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, tokenHash)
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(revokeSessionMock).not.toHaveBeenCalled()
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
@@ -588,6 +593,7 @@ describe("refreshUserInfo action", () => {
         )
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const response = await POST(
             new Request("https://example.com/auth/providers/oauth-provider/user/refresh", {
@@ -607,7 +613,7 @@ describe("refreshUserInfo action", () => {
         expect(spyParse).not.toHaveBeenCalled()
         expect(spyParseAsPartial).not.toHaveBeenCalled()
 
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, "valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(revokeSessionMock).not.toHaveBeenCalled()
@@ -655,6 +661,7 @@ describe("refreshUserInfo action", () => {
         })
 
         const csrfToken = await createCSRF(jose)
+        const tokenHash = await createHash("valid-token-hash")
 
         const mockFetch = vi.fn()
         mockFetch.mockResolvedValueOnce({
@@ -698,9 +705,9 @@ describe("refreshUserInfo action", () => {
         })
         expect(mockFetch).toHaveBeenCalledTimes(2)
 
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, "valid-token-hash")
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, "valid-token-hash")
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, "valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
@@ -714,7 +721,7 @@ describe("refreshUserInfo action", () => {
             accessTokenExpiresAt: expect.any(Date),
             refreshTokenExpiresAt: expect.any(Date),
         })
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, "valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
 
         const { attributes, ...spreadUser } = userEntity
@@ -899,14 +906,15 @@ describe("refreshUserInfo action", () => {
             },
         })
 
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, "valid-token-hash")
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, "valid-token-hash")
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, "valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, "valid-token-hash")
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
 
         const { attributes, ...spreadUser } = userEntity

--- a/packages/core/test/actions/session/session/stateful.test.ts
+++ b/packages/core/test/actions/session/session/stateful.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi } from "vitest"
 import { authInstance, jose, sessionEntityWithUser, sessionPayload, userEntity } from "@test/presets.ts"
 import { createSchemaRegistry } from "@/validator/registry.ts"
+import { createHash } from "@/shared/crypto.ts"
 
 describe("sessionAction", () => {
     const { encodeJWT } = jose
@@ -92,7 +93,8 @@ describe("sessionAction", () => {
             },
         })
 
-        expect(sessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const hash = await createHash("valid-token-hash")
+        expect(sessionByTokenMock).toHaveBeenCalledWith(hash)
         expect(sessionByTokenMock).toHaveReturnedWith(Promise.resolve(sessionEntityWithUser))
         expect(revokeSessionMock).not.toHaveBeenCalled()
         const { attributes, ...spreadUser } = userEntity
@@ -133,7 +135,8 @@ describe("sessionAction", () => {
             },
         })
 
-        expect(sessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const hash = await createHash("valid-token-hash")
+        expect(sessionByTokenMock).toHaveBeenCalledWith(hash)
         expect(sessionByTokenMock).toHaveReturnedWith(Promise.resolve(sessionEntityWithUser))
         expect(revokeSessionMock).not.toHaveBeenCalled()
         const { attributes, ...spreadUser } = userEntity
@@ -167,7 +170,8 @@ describe("sessionAction", () => {
         expect(request.status).toBe(401)
         expect(await request.json()).toEqual({ success: false, session: null })
 
-        expect(sessionByTokenMock).toHaveBeenCalledWith("expired-token-hash")
+        const hash = await createHash("expired-token-hash")
+        expect(sessionByTokenMock).toHaveBeenCalledWith(hash)
         expect(revokeSessionMock).toHaveBeenCalledWith("session-123", "user_logout")
         expect(spy).not.toHaveBeenCalled()
     })

--- a/packages/core/test/api/stateful/getAccessToken.test.ts
+++ b/packages/core/test/api/stateful/getAccessToken.test.ts
@@ -7,7 +7,7 @@ import {
     oauthCustomService,
     sessionEntityWithUser,
 } from "@test/presets.ts"
-import { createCSRF } from "@/shared/crypto.ts"
+import { createCSRF, createHash } from "@/shared/crypto.ts"
 import { createAuth } from "@/createAuth.ts"
 import { createBasicAuthHeader } from "@/shared/utils.ts"
 import type { OAuthProviderConfig } from "@/@types/oauth.ts"
@@ -104,7 +104,8 @@ describe("getAccessToken API (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
     })
@@ -143,7 +144,8 @@ describe("getAccessToken API (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
@@ -179,7 +181,8 @@ describe("getAccessToken API (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()

--- a/packages/core/test/api/stateful/getProviderTokens.test.ts
+++ b/packages/core/test/api/stateful/getProviderTokens.test.ts
@@ -7,7 +7,7 @@ import {
     oauthCustomService,
     sessionEntityWithUser,
 } from "@test/presets.ts"
-import { createCSRF } from "@/shared/crypto.ts"
+import { createCSRF, createHash } from "@/shared/crypto.ts"
 import { createAuth } from "@/createAuth.ts"
 import { createBasicAuthHeader } from "@/shared/utils.ts"
 import type { OAuthProviderConfig } from "@/@types/oauth.ts"
@@ -104,7 +104,8 @@ describe("getProviderTokens API (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
     })
@@ -143,7 +144,8 @@ describe("getProviderTokens API (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
@@ -185,7 +187,8 @@ describe("getProviderTokens API (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
@@ -237,7 +240,8 @@ describe("getProviderTokens API (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()

--- a/packages/core/test/api/stateful/getSession.test.ts
+++ b/packages/core/test/api/stateful/getSession.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, vi } from "vitest"
 import { getSetCookie } from "@/cookie.ts"
 import { authInstance, sessionEntityWithUser, userEntity } from "@test/presets.ts"
 import { createSchemaRegistry } from "@/validator/registry.ts"
+import { createHash } from "@/shared/crypto.ts"
 
 describe("getSession", () => {
     test("getSession with no session token", async () => {
@@ -58,7 +59,8 @@ describe("getSession", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(mock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(mock).toHaveBeenCalledWith(tokenHash)
         const { attributes: _, ...spreadPayload } = userEntity
         expect(spy).toHaveBeenCalledWith({ sub: userEntity.id, ...spreadPayload })
         expect(getSetCookie(output.headers, "aura-auth.session_token")).toBe("valid-token-hash")
@@ -95,7 +97,8 @@ describe("getSession", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(sessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(sessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(revokeSessionMock).toHaveBeenCalledWith("session-123", "user_logout")
         expect(spy).not.toHaveBeenCalled()
         expect(getSetCookie(output.headers, "aura-auth.csrf_token")).toBe("")
@@ -136,7 +139,8 @@ describe("getSession", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(mock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(mock).toHaveBeenCalledWith(tokenHash)
         const { attributes: _, ...spreadPayload } = userEntity
         expect(spy).toHaveBeenCalledWith({
             ...spreadPayload,
@@ -188,7 +192,8 @@ describe("getSession", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(mock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(mock).toHaveBeenCalledWith(tokenHash)
         const { attributes: _, ...spreadPayload } = userEntity
         expect(spy).toHaveBeenCalledWith({
             ...spreadPayload,

--- a/packages/core/test/api/stateful/isProviderConnected.test.ts
+++ b/packages/core/test/api/stateful/isProviderConnected.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from "vitest"
 import { authInstance, jose, sessionEntityWithUser } from "@test/presets.ts"
-import { createCSRF } from "@/shared/crypto.ts"
+import { createCSRF, createHash } from "@/shared/crypto.ts"
 
 describe("isProviderConnected (Stateful)", () => {
     test("throws error when provider is not configured", async () => {
@@ -45,7 +45,8 @@ describe("isProviderConnected (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).not.toHaveBeenCalled()
     })
 
@@ -80,7 +81,8 @@ describe("isProviderConnected (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).not.toHaveBeenCalled()
     })
 
@@ -114,7 +116,8 @@ describe("isProviderConnected (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).not.toHaveBeenCalled()
     })
 
@@ -144,7 +147,8 @@ describe("isProviderConnected (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith(sessionEntityWithUser.userId)
     })
 
@@ -185,7 +189,8 @@ describe("isProviderConnected (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith(sessionEntityWithUser.userId)
     })
 
@@ -226,7 +231,8 @@ describe("isProviderConnected (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith(sessionEntityWithUser.userId)
     })
 
@@ -267,7 +273,8 @@ describe("isProviderConnected (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith(sessionEntityWithUser.userId)
     })
 

--- a/packages/core/test/api/stateful/refreshUserInfo.test.ts
+++ b/packages/core/test/api/stateful/refreshUserInfo.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from "vitest"
 import { accountEntity, authInstance, jose, oauthAccountEntity, sessionEntityWithUser, userEntity } from "@test/presets.ts"
-import { createCSRF } from "@/shared/crypto.ts"
+import { createCSRF, createHash } from "@/shared/crypto.ts"
 import { createSchemaRegistry } from "@/validator/registry.ts"
 
 describe("refreshUserInfo API (Stateful)", () => {
@@ -128,7 +128,8 @@ describe("refreshUserInfo API (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
         expect(getUserByIdMock).not.toHaveBeenCalled()
@@ -175,7 +176,8 @@ describe("refreshUserInfo API (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
         expect(getUserByIdMock).not.toHaveBeenCalled()
@@ -226,7 +228,8 @@ describe("refreshUserInfo API (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
@@ -307,14 +310,15 @@ describe("refreshUserInfo API (Stateful)", () => {
         /**
          * @todo Optimize the session token verification across multiple calls.
          */
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, sessionToken)
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, sessionToken)
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
 
         const { attributes, ...spreadUser } = userEntity
@@ -660,9 +664,10 @@ describe("refreshUserInfo API (Stateful)", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, sessionToken)
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, sessionToken)
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
@@ -676,7 +681,7 @@ describe("refreshUserInfo API (Stateful)", () => {
             accessTokenExpiresAt: expect.any(Date),
             refreshTokenExpiresAt: expect.any(Date),
         })
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
 
         const { attributes, ...spreadUser } = userEntity
@@ -773,7 +778,8 @@ describe("refreshUserInfo API (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
     })
@@ -893,14 +899,15 @@ describe("refreshUserInfo API (Stateful)", () => {
             },
         })
 
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, sessionToken)
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, sessionToken)
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
 
         const { attributes, ...spreadUser } = userEntity
@@ -1000,7 +1007,8 @@ describe("refreshUserInfo API (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
     })
@@ -1073,14 +1081,15 @@ describe("refreshUserInfo API (Stateful)", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, sessionToken)
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, sessionToken)
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
 
         const { attributes, ...spreadUser } = userEntity
@@ -1236,14 +1245,15 @@ describe("refreshUserInfo API (Stateful)", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, sessionToken)
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, sessionToken)
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(1, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(2, tokenHash)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(3, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateOAuthTokensMock).not.toHaveBeenCalled()
-        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenNthCalledWith(4, tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
 
         const { attributes, ...spreadUser } = userEntity

--- a/packages/core/test/api/stateful/revokeToken.test.ts
+++ b/packages/core/test/api/stateful/revokeToken.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi } from "vitest"
-import { createCSRF } from "@/shared/crypto.ts"
+import { createCSRF, createHash } from "@/shared/crypto.ts"
 import {
     accountEntity,
     authInstance,
@@ -154,7 +154,8 @@ describe("revokeToken (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateAccountStatusMock).not.toHaveBeenCalled()
     })
@@ -192,7 +193,8 @@ describe("revokeToken (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateAccountStatusMock).not.toHaveBeenCalled()
@@ -239,7 +241,8 @@ describe("revokeToken (Stateful)", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).toHaveBeenCalledWith("account-123", "unlinked")
@@ -306,7 +309,8 @@ describe("revokeToken (Stateful)", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).toHaveBeenCalledWith("account-123", "unlinked")
@@ -361,7 +365,8 @@ describe("revokeToken (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).not.toHaveBeenCalled()
@@ -418,7 +423,8 @@ describe("revokeToken (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).not.toHaveBeenCalled()
@@ -475,7 +481,8 @@ describe("revokeToken (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).not.toHaveBeenCalled()
@@ -535,7 +542,8 @@ describe("revokeToken (Stateful)", () => {
             success: true,
         })
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).toHaveBeenCalledWith("account-123", "unlinked")
@@ -602,7 +610,8 @@ describe("revokeToken (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(revokeSessionMock).toHaveBeenCalledWith(expiredSession.id, "user_logout")
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateAccountStatusMock).not.toHaveBeenCalled()
@@ -647,7 +656,8 @@ describe("revokeToken (Stateful)", () => {
             headers: expect.any(Headers),
             toResponse: expect.any(Function),
         })
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getOAuthAccountMock).not.toHaveBeenCalled()
         expect(updateAccountStatusMock).not.toHaveBeenCalled()
     })
@@ -853,7 +863,8 @@ describe("revokeToken (Stateful)", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).toHaveBeenCalledWith("account-123", "unlinked")
@@ -967,7 +978,8 @@ describe("revokeToken (Stateful)", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(getSessionByTokenMock).toHaveBeenCalledWith(sessionToken)
+        const tokenHash = await createHash(sessionToken)
+        expect(getSessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(getAccountsByUserIdMock).toHaveBeenCalledWith("user-123")
         expect(getOAuthAccountMock).toHaveBeenCalledWith("account-123")
         expect(updateAccountStatusMock).toHaveBeenCalledWith("account-123", "unlinked")

--- a/packages/core/test/api/stateful/signOut.test.ts
+++ b/packages/core/test/api/stateful/signOut.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from "vitest"
-import { createCSRF } from "@/shared/crypto.ts"
+import { createCSRF, createHash } from "@/shared/crypto.ts"
 import { authInstance, jose, sessionEntityWithUser } from "@test/presets.ts"
 
 describe("signOut API", async () => {
@@ -57,7 +57,8 @@ describe("signOut API", async () => {
             toResponse: expect.any(Function),
         })
 
-        expect(sessionTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(sessionTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(revokeSessionMock).toHaveBeenCalledWith("session-123", "user_logout")
     })
 
@@ -86,7 +87,8 @@ describe("signOut API", async () => {
             toResponse: expect.any(Function),
         })
 
-        expect(sessionTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(sessionTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(revokeSessionMock).toHaveBeenCalledWith("session-123", "user_logout")
     })
 
@@ -116,7 +118,8 @@ describe("signOut API", async () => {
             toResponse: expect.any(Function),
         })
 
-        expect(sessionTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(sessionTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(revokeSessionMock).toHaveBeenCalledWith("session-123", "user_logout")
     })
 
@@ -146,7 +149,8 @@ describe("signOut API", async () => {
             toResponse: expect.any(Function),
         })
 
-        expect(sessionTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(sessionTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(revokeSessionMock).toHaveBeenCalledWith("session-123", "user_logout")
     })
 })

--- a/packages/core/test/api/stateful/updateSession.test.ts
+++ b/packages/core/test/api/stateful/updateSession.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from "vitest"
 import { z } from "zod/v4"
-import { createCSRF } from "@/shared/crypto.ts"
+import { createCSRF, createHash } from "@/shared/crypto.ts"
 import { createSchemaRegistry } from "@/validator/registry.ts"
 import { identitySchema as UserIdentity } from "@/identity/zod.ts"
 import { authInstance, jose, sessionEntityWithUser, userEntity } from "@test/presets.ts"
@@ -102,7 +102,8 @@ describe("updateSession API", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(sessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(sessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
         const { attributes, ...spreadUser } = userEntity
         expect(spyParse).toHaveBeenNthCalledWith(1, {
@@ -186,7 +187,8 @@ describe("updateSession API", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(sessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(sessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
         const { attributes, ...spreadUser } = userEntity
         expect(spyParse).toHaveBeenNthCalledWith(1, {
@@ -298,7 +300,8 @@ describe("updateSession API", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(sessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(sessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
 
         const { attributes, ...spreadUser } = userEntityWithAttributes
@@ -392,7 +395,8 @@ describe("updateSession API", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(sessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(sessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
         const { attributes, ...spreadUser } = userEntity
         expect(spyParse).toHaveBeenNthCalledWith(1, {
@@ -477,7 +481,8 @@ describe("updateSession API", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(sessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(sessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
         const { attributes, ...spreadUser } = userEntity
         expect(spyParse).toHaveBeenNthCalledWith(1, {
@@ -566,7 +571,8 @@ describe("updateSession API", () => {
             toResponse: expect.any(Function),
         })
 
-        expect(sessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(sessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
         const { attributes, ...spreadUser } = userEntity
         expect(spyParse).toHaveBeenNthCalledWith(1, {
@@ -667,7 +673,8 @@ describe("updateSession API", () => {
         })
         expect(updated.headers.get("Set-Cookie")).toContain("aura-auth.session_token=")
 
-        expect(sessionByTokenMock).toHaveBeenCalledWith("valid-token-hash")
+        const tokenHash = await createHash("valid-token-hash")
+        expect(sessionByTokenMock).toHaveBeenCalledWith(tokenHash)
         expect(revokeSessionMock).not.toHaveBeenCalled()
         const { attributes, ...spreadUser } = userEntity
         expect(spyParse).toHaveBeenNthCalledWith(1, {

--- a/packages/elysia/test/stateful/index.test.ts
+++ b/packages/elysia/test/stateful/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from "vitest"
 import { adapter, app, auth, prismaClient } from "@test/stateful/app"
-import { createCSRF } from "@aura-stack/auth/crypto"
+import { createCSRF, createHash } from "@aura-stack/auth/crypto"
 import { parseSetCookie } from "@aura-stack/auth/cookies"
 
 describe("GET /api/auth/signIn/github", () => {
@@ -144,7 +144,7 @@ describe("GET /api/auth/signIn/github", () => {
                 "Content-Type": "application/json",
             }),
             json: async () => ({
-                id: "user-123",
+                id: "user-1234",
                 name: "John Doe",
                 login: "johndoe",
                 email: "john.doe@example.com",
@@ -174,6 +174,7 @@ describe("GET /api/auth/signIn/github", () => {
             email: "john.doe@example.com",
         })
 
+        const tokenHash = await createHash("valid-token-hash")
         await adapter.createSession({
             id: "session-123",
             userId: user.id,
@@ -183,7 +184,7 @@ describe("GET /api/auth/signIn/github", () => {
             metadata: null,
             mfaState: "none",
             status: "active",
-            tokenHash: "valid-token-hash",
+            tokenHash,
         })
 
         const account = await adapter.createAccount({
@@ -207,8 +208,6 @@ describe("GET /api/auth/signIn/github", () => {
                 },
             })
         )
-        const sessionToken = request.headers.getSetCookie()?.find((cookie) => cookie.startsWith("aura-auth.session_token="))
-        expect(sessionToken).toBeDefined()
 
         expect(mockFetch).toHaveBeenNthCalledWith(1, "https://github.com/login/oauth/access_token", {
             method: "POST",
@@ -235,6 +234,9 @@ describe("GET /api/auth/signIn/github", () => {
             },
             signal: expect.any(AbortSignal),
         })
+
+        const sessionToken = request.headers.getSetCookie()?.find((cookie) => cookie.startsWith("aura-auth.session_token="))
+        expect(sessionToken).toBeDefined()
 
         const parsed = parseSetCookie(sessionToken!)
         const session = await app.handle(
@@ -299,11 +301,12 @@ describe("GET /api/auth/session", () => {
             email: "john@example.com",
             image: "https://jhon.doe/avatar.png",
         })
+        const tokenHash = await createHash("token-hash-123")
         const session = await adapter.createSession({
             id: "session-123",
             userId: user.id,
             authenticatedWith: "credentials",
-            tokenHash: "token-hash-123",
+            tokenHash,
             expiresAt: new Date(Date.now() + 3600000),
             status: "active",
             mfaState: "none",
@@ -424,11 +427,12 @@ describe("POST /api/auth/signOut", () => {
             email: "signout@example.com",
             status: "active",
         })
+        const tokenHash = await createHash("token-hash-to-revoke")
         const session = await adapter.createSession({
             id: "session-signout-123",
             userId: user.id,
             authenticatedWith: "credentials",
-            tokenHash: "token-hash-to-revoke",
+            tokenHash,
             expiresAt: new Date(Date.now() + 3600000),
             status: "active",
             mfaState: "none",
@@ -622,11 +626,12 @@ describe("POST /api/auth/updateSession", () => {
             name: "Update Session User",
             email: "updatesession@example.com",
         })
+        const tokenHash = await createHash("token-hash-update")
         await adapter.createSession({
             id: "session-update-123",
             userId: user.id,
             authenticatedWith: "credentials",
-            tokenHash: "token-hash-update",
+            tokenHash,
             expiresAt: new Date(Date.now() + 3600000),
             status: "active",
             mfaState: "none",
@@ -731,11 +736,12 @@ describe("GET /api/auth/getProviderTokens", () => {
             name: "No Provider User",
             email: "noprovider@example.com",
         })
+        const tokenHash = await createHash("token-hash-noprovider")
         await adapter.createSession({
             id: "session-noprovider",
             userId: user.id,
             authenticatedWith: "credentials",
-            tokenHash: "token-hash-noprovider",
+            tokenHash,
             expiresAt: new Date(Date.now() + 3600000),
             status: "active",
             mfaState: "none",
@@ -771,11 +777,12 @@ describe("GET /api/auth/isProviderConnected", () => {
             name: "Not Connected User",
             email: "notconnected@example.com",
         })
+        const tokenHash = await createHash("token-hash-notconnected")
         await adapter.createSession({
             id: "session-notconnected",
             userId: user.id,
             authenticatedWith: "credentials",
-            tokenHash: "token-hash-notconnected",
+            tokenHash,
             expiresAt: new Date(Date.now() + 3600000),
             status: "active",
             mfaState: "none",
@@ -1077,11 +1084,13 @@ describe("Multiple concurrent sessions", () => {
             email: "multisession@example.com",
         })
 
+        const tokenHash1 = await createHash("token-hash-multi-1")
+        const tokenHash2 = await createHash("token-hash-multi-2")
         await adapter.createSession({
             id: "session-multi-1",
             userId: user.id,
             authenticatedWith: "credentials",
-            tokenHash: "token-hash-multi-1",
+            tokenHash: tokenHash1,
             expiresAt: new Date(Date.now() + 3600000),
             status: "active",
             mfaState: "none",
@@ -1093,7 +1102,7 @@ describe("Multiple concurrent sessions", () => {
             id: "session-multi-2",
             userId: user.id,
             authenticatedWith: "credentials",
-            tokenHash: "token-hash-multi-2",
+            tokenHash: tokenHash2,
             expiresAt: new Date(Date.now() + 3600000),
             status: "active",
             mfaState: "none",


### PR DESCRIPTION
## Description

This pull request fixes a security vulnerability in the Stateful session strategy related to session token handling.

Previously, the internal session creation flow returned the hashed session token instead of the original randomly generated secret. As a result, the value stored in the database was also used as the authentication credential. If an attacker obtained a copy of the database, they could reuse the stored token hash directly to authenticate requests and hijack active sessions.

This PR changes the session token model to follow a more secure **split secret / hash** design:

- A cryptographically secure random session token is generated.
- The raw session token is returned to the client as a secure, HTTP-only cookie.
- Only the cryptographic hash of the session token is persisted in the database.
- During authentication, the incoming session token is hashed and compared against the stored hash.

Because the database never stores the raw session token, a database compromise no longer exposes reusable session credentials.

### Key Changes

- Fixed the session token hashing vulnerability in the Stateful session strategy.
- Generated a cryptographically secure random session token for each session.
- Stored only the hash of the session token in the database.
- Returned the raw session token exclusively to the client as a secure cookie.
- Updated session validation to hash the incoming token before performing the database lookup.
- Improved the overall security of database-backed session management.

### Security Benefits

- Prevents reuse of database values as authentication credentials.
- Mitigates session hijacking following a database compromise.
- Separates client secrets from persisted database records.
- Aligns the Stateful session implementation with industry best practices for session token storage.

### Previously

```text
Database leak
        ↓
Stored session token
        ↓
Attacker copies the token
        ↓
Authenticated
```

### Now

```text
Database leak
        ↓
SHA-256(sessionToken)
        ↓
Attacker cannot reconstruct the original session token
        ↓
Active sessions remain protected
```

> [!NOTE]
> This change is internal and fully backward-compatible from the API perspective. Applications do not need to modify their authentication flows, as the token hashing and verification process is handled transparently by the Stateful session strategy.


@coderabbitai ignore