### PR TITLE
feat: add remaining APIs to Next.js and React Router

### DIFF
--- a/packages/next/src/@types/api.ts
+++ b/packages/next/src/@types/api.ts
@@ -14,6 +14,18 @@ import type {
     UpdateSessionAPIOptions,
     UpdateSessionAPIReturn,
     User,
+    SignUpAPIOptions,
+    SignUpAPIReturn,
+    RefreshUserInfoAPIOptions,
+    RevokeTokenAPIOptions,
+    RevokeTokenAPIReturn,
+    DisconnectProviderAPIOptions,
+    ProviderConnectedAPIOptions,
+    LiteralUnion,
+    BuiltInOAuthProvider,
+    DisconnectProviderAPIReturn,
+    ProviderConnectedAPIReturn,
+    RefreshUserInfoAPIReturn,
 } from "@aura-stack/react/types"
 
 /**
@@ -61,3 +73,45 @@ export type NextUpdateSessionReturn<
 export type NextSignOutReturn<Options extends SignOutAPIOptions> = Options extends { redirectTo: string }
     ? never
     : SignOutAPIReturn
+
+/**
+ * Return type for the Next.js server `api.signUp` helper.
+ * Same `never` rule as {@link NextSignInReturn} when a server redirect is triggered via options.
+ */
+export type NextSignUpReturn<Options extends SignUpAPIOptions> = Options extends { redirect: true }
+    ? never
+    : Options extends { redirectTo: string }
+      ? never
+      : SignUpAPIReturn
+
+export interface NextAPI<DefaultUser extends User = User> {
+    getSession: (options?: any) => Promise<any>
+    signIn: <Options extends SignInAPIOptions>(
+        provider: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Options
+    ) => Promise<NextSignInReturn<Options>>
+    signInCredentials: <Options extends SignInCredentialsAPIOptions>(options: Options) => Promise<NextSignInCredentials<Options>>
+    updateSession: <Options extends NextUpdateSessionOptions<DefaultUser>>(
+        options: Options
+    ) => Promise<NextUpdateSessionReturn<Options, DefaultUser>>
+    getProviderTokens: (oauth: LiteralUnion<BuiltInOAuthProvider>, options?: any) => Promise<any>
+    getAccessToken: (oauth: LiteralUnion<BuiltInOAuthProvider>, options?: any) => Promise<any>
+    signOut: <Options extends SignOutAPIOptions>(options?: Partial<Options>) => Promise<NextSignOutReturn<Options>>
+    signUp: <Options extends SignUpAPIOptions>(options: Options) => Promise<NextSignUpReturn<Options>>
+    refreshUserInfo: <Options extends RefreshUserInfoAPIOptions>(
+        oauth: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Options
+    ) => Promise<RefreshUserInfoAPIReturn>
+    revokeToken: <Options extends RevokeTokenAPIOptions>(
+        oauth: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Options
+    ) => Promise<RevokeTokenAPIReturn>
+    disconnectProvider: <Options extends DisconnectProviderAPIOptions>(
+        oauth: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Options
+    ) => Promise<DisconnectProviderAPIReturn>
+    isProviderConnected: <Options extends ProviderConnectedAPIOptions>(
+        oauth: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Options
+    ) => Promise<ProviderConnectedAPIReturn>
+}

--- a/packages/next/src/lib/api.ts
+++ b/packages/next/src/lib/api.ts
@@ -347,7 +347,7 @@ export const api = <DefaultUser extends User = User>(config: AuthInstance<Defaul
         refreshUserInfo: refreshUserInfo<DefaultUser>(config),
         /**
          * Revokes the OAuth provider token on the server-side. It invalidates the access token for the specified
-         * provider, effectively disconnecting the user from that provider.
+         * provider.
          *
          * @param oauth - The OAuth provider to revoke the token for (e.g., "github", "gitlab", "bitbucket").
          * @param options - Optional parameters for the revoke operation, including headers.

--- a/packages/next/src/lib/api.ts
+++ b/packages/next/src/lib/api.ts
@@ -8,6 +8,8 @@ import type {
     NextSignOutReturn,
     NextUpdateSessionOptions,
     NextUpdateSessionReturn,
+    NextAPI,
+    NextSignUpReturn,
 } from "@/@types/api"
 import type {
     GetSessionAPIOptions,
@@ -18,6 +20,11 @@ import type {
     SignInCredentialsAPIOptions,
     GetProviderTokensAPIOptions,
     AccessTokenAPIOptions,
+    SignUpAPIOptions,
+    RefreshUserInfoAPIOptions,
+    RevokeTokenAPIOptions,
+    DisconnectProviderAPIOptions,
+    ProviderConnectedAPIOptions,
 } from "@aura-stack/react/types"
 
 /**
@@ -127,6 +134,63 @@ export const signOut = <DefaultUser extends User = User>({ api }: AuthInstance<D
             return redirect(out.redirectURL)
         }
         return out as NextSignOutReturn<Options>
+    }
+}
+
+export const signUp = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
+    return async <Options extends SignUpAPIOptions>(options: Options): Promise<NextSignUpReturn<Options>> => {
+        const signUp = await api.signUp({
+            headers: await headers(),
+            ...options,
+            redirect: !!options.redirect,
+        })
+        await setCookies(signUp.headers)
+        if (signUp.success && signUp.redirectURL) {
+            return redirect(signUp.redirectURL)
+        }
+        return signUp as NextSignUpReturn<Options>
+    }
+}
+
+export const refreshUserInfo = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
+    return async <Options extends RefreshUserInfoAPIOptions>(oauth: LiteralUnion<BuiltInOAuthProvider>, options?: Options) => {
+        const refresh = await api.refreshUserInfo(oauth, {
+            headers: await headers(),
+            ...options,
+        })
+        await setCookies(refresh.headers)
+        return refresh
+    }
+}
+
+export const revokeToken = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
+    return async <Options extends RevokeTokenAPIOptions>(oauth: LiteralUnion<BuiltInOAuthProvider>, options?: Options) => {
+        const revoke = await api.revokeToken(oauth, {
+            headers: await headers(),
+            ...options,
+        })
+        await setCookies(revoke.headers)
+        return revoke
+    }
+}
+
+export const disconnectProvider = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
+    return async <Options extends DisconnectProviderAPIOptions>(oauth: LiteralUnion<BuiltInOAuthProvider>, options?: Options) => {
+        const disconnect = await api.disconnectProvider(oauth, {
+            headers: await headers(),
+            ...options,
+        })
+        await setCookies(disconnect.headers)
+        return disconnect
+    }
+}
+
+export const isProviderConnected = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
+    return async <Options extends ProviderConnectedAPIOptions>(oauth: LiteralUnion<BuiltInOAuthProvider>, options?: Options) => {
+        return await api.isProviderConnected(oauth, {
+            headers: await headers(),
+            ...options,
+        })
     }
 }
 
@@ -245,5 +309,86 @@ export const api = <DefaultUser extends User = User>(config: AuthInstance<Defaul
          * })
          */
         signOut: signOut<DefaultUser>(config),
-    }
+        /**
+         * Signs up a new user on the server-side. It requires a `payload` with the necessary information for
+         * user creation and a callback function configured in `signUp.onCreateUser` to handle the actual user
+         * creation logic.
+         *
+         * @param options - Options for the API call, including the sign-up payload, headers, and redirect behavior.
+         * @returns The object returned by the API call {@link SignUpAPIReturn}
+         * @example
+         * import { headers } from "next/headers"
+         *
+         * const response = await api.signUp({
+         *   payload: {
+         *     name: "John",
+         *     email: "john.doe@example.com",
+         *     password: "1234567890"
+         *   },
+         *   redirectTo: "/dashboard",
+         *   headers: await headers()
+         * })
+         */
+        signUp: signUp<DefaultUser>(config),
+        /**
+         * Refreshes user information from the OAuth provider on the server-side. It retrieves the latest
+         * user information from the provider and updates the session accordingly.
+         *
+         * @param oauth - The OAuth provider to refresh user information from (e.g., "github", "gitlab", "bitbucket").
+         * @param options - Optional parameters for the refresh operation, including headers.
+         * @returns The object returned by the API call {@link RefreshUserInfoAPIReturn}
+         * @example
+         * import { headers } from "next/headers"
+         *
+         * const response = await api.refreshUserInfo("github", {
+         *   headers: await headers()
+         * })
+         */
+        refreshUserInfo: refreshUserInfo<DefaultUser>(config),
+        /**
+         * Revokes the OAuth provider token on the server-side. It invalidates the access token for the specified
+         * provider, effectively disconnecting the user from that provider.
+         *
+         * @param oauth - The OAuth provider to revoke the token for (e.g., "github", "gitlab", "bitbucket").
+         * @param options - Optional parameters for the revoke operation, including headers.
+         * @returns The object returned by the API call {@link RevokeTokenAPIReturn}
+         * @example
+         * import { headers } from "next/headers"
+         *
+         * const response = await api.revokeToken("github", {
+         *   headers: await headers()
+         * })
+         */
+        revokeToken: revokeToken<DefaultUser>(config),
+        /**
+         * Disconnects the OAuth provider on the server-side. It revokes the access token and removes the provider
+         * connection from the user's session.
+         *
+         * @param oauth - The OAuth provider to disconnect (e.g., "github", "gitlab", "bitbucket").
+         * @param options - Optional parameters for the disconnect operation, including headers.
+         * @returns The object returned by the API call {@link DisconnectProviderAPIReturn}
+         * @example
+         * import { headers } from "next/headers"
+         *
+         * const response = await api.disconnectProvider("github", {
+         *   headers: await headers()
+         * })
+         */
+        disconnectProvider: disconnectProvider<DefaultUser>(config),
+        /**
+         * Checks if the OAuth provider is connected on the server-side. It returns a boolean indicating whether
+         * the user has an active connection with the specified provider.
+         *
+         * @param oauth - The OAuth provider to check connection status for (e.g., "github", "gitlab", "bitbucket").
+         * @param options - Optional parameters for the check operation, including headers.
+         * @returns The object returned by the API call {@link ProviderConnectedAPIReturn}
+         * @example
+         * import { headers } from "next/headers"
+         *
+         * const { connected } = await api.isProviderConnected("github", {
+         *   headers: await headers()
+         * })
+         */
+        isProviderConnected: isProviderConnected<DefaultUser>(config),
+    } satisfies NextAPI<DefaultUser>
 }

--- a/packages/next/test/app-router/api/disconnectProvider.test.ts
+++ b/packages/next/test/app-router/api/disconnectProvider.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockHeaders, mockCookiesSet, mockParseSetCookie } = vi.hoisted(() => ({
+    mockHeaders: vi.fn(),
+    mockCookiesSet: vi.fn(),
+    mockParseSetCookie: vi.fn((cookieStr: string) => {
+        const [nameValue, ...parts] = cookieStr.split("; ").map((part) => part.trim())
+        const [name, ...valueParts] = nameValue.split("=")
+        const value = valueParts.join("=")
+        const options: Record<string, unknown> = {}
+
+        for (const part of parts) {
+            const lower = part.toLowerCase()
+            if (lower === "httponly") options.httpOnly = true
+            else if (lower.startsWith("path=")) options.path = part.slice(5)
+        }
+
+        return { name, value, ...options }
+    }),
+}))
+
+vi.mock("next/headers", () => ({
+    headers: mockHeaders,
+    cookies: () => Promise.resolve({ set: mockCookiesSet }),
+}))
+
+vi.mock("@aura-stack/react/cookies", () => ({
+    parseSetCookie: mockParseSetCookie,
+}))
+
+import { disconnectProvider } from "@/lib/api"
+import type { AuthInstance } from "@aura-stack/react"
+
+const makeResponseHeaders = (...setCookies: string[]) =>
+    ({
+        getSetCookie: () => setCookies,
+    }) as unknown as Headers
+
+const makeAuth = (apiOverrides: Partial<AuthInstance["api"]> = {}): AuthInstance => {
+    return {
+        api: {
+            getSession: vi.fn().mockResolvedValue({ success: false }),
+            signIn: vi.fn().mockResolvedValue({ success: false }),
+            signInCredentials: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            updateSession: vi
+                .fn()
+                .mockResolvedValue({ success: false, session: null, redirectURL: null, headers: new Headers() }),
+            getProviderTokens: vi.fn().mockResolvedValue({ success: false }),
+            getAccessToken: vi.fn().mockResolvedValue({ success: false }),
+            signOut: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            signUp: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            refreshUserInfo: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            revokeToken: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            disconnectProvider: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            isProviderConnected: vi.fn().mockResolvedValue({ success: false, connected: false }),
+            ...apiOverrides,
+        },
+    } as unknown as AuthInstance
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    mockHeaders.mockResolvedValue(new Headers())
+})
+
+describe("disconnectProvider", () => {
+    test("forwards headers and syncs cookies on success", async () => {
+        const headers = new Headers({ "x-test": "value" })
+        mockHeaders.mockResolvedValue(headers)
+
+        const responseHeaders = makeResponseHeaders("connected=false; Path=/; HttpOnly")
+        const apiDisconnectProvider = vi.fn().mockResolvedValue({
+            success: true,
+            headers: responseHeaders,
+        })
+        const auth = makeAuth({ disconnectProvider: apiDisconnectProvider })
+
+        const result = await disconnectProvider(auth)("github", { cache: "no-store" } as any)
+
+        expect(result).toEqual({
+            success: true,
+            headers: responseHeaders,
+        })
+        expect(apiDisconnectProvider).toHaveBeenCalledWith("github", {
+            headers,
+            cache: "no-store",
+        })
+        expect(mockCookiesSet).toHaveBeenCalledWith("connected", "false", expect.objectContaining({ path: "/", httpOnly: true }))
+    })
+
+    test("returns failure responses without writing cookies", async () => {
+        const apiDisconnectProvider = vi.fn().mockResolvedValue({
+            success: false,
+            headers: makeResponseHeaders(),
+        })
+        const auth = makeAuth({ disconnectProvider: apiDisconnectProvider })
+
+        await expect(disconnectProvider(auth)("github")).resolves.toEqual({
+            success: false,
+            headers: expect.any(Object),
+        })
+        expect(mockCookiesSet).not.toHaveBeenCalled()
+    })
+})

--- a/packages/next/test/app-router/api/getAccessToken.test.ts
+++ b/packages/next/test/app-router/api/getAccessToken.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockHeaders } = vi.hoisted(() => ({
+    mockHeaders: vi.fn(),
+}))
+
+vi.mock("next/headers", () => ({
+    headers: mockHeaders,
+    cookies: vi.fn(),
+}))
+
+import { getAccessToken } from "@/lib/api"
+import type { AuthInstance } from "@aura-stack/react"
+
+const makeAuth = (apiOverrides: Partial<AuthInstance["api"]> = {}): AuthInstance => {
+    return {
+        api: {
+            getSession: vi.fn().mockResolvedValue({ success: false }),
+            signIn: vi.fn().mockResolvedValue({ success: false }),
+            signInCredentials: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            updateSession: vi
+                .fn()
+                .mockResolvedValue({ success: false, session: null, redirectURL: null, headers: new Headers() }),
+            getProviderTokens: vi.fn().mockResolvedValue({ success: false }),
+            getAccessToken: vi.fn().mockResolvedValue({ success: false }),
+            signOut: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            signUp: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            refreshUserInfo: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            revokeToken: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            disconnectProvider: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            isProviderConnected: vi.fn().mockResolvedValue({ success: false, connected: false }),
+            ...apiOverrides,
+        },
+    } as unknown as AuthInstance
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    mockHeaders.mockResolvedValue(new Headers())
+})
+
+describe("getAccessToken", () => {
+    test("forwards headers and options to the API", async () => {
+        const headers = new Headers({ "x-request-id": "req-1" })
+        mockHeaders.mockResolvedValue(headers)
+
+        const apiGetAccessToken = vi.fn().mockResolvedValue({ success: true, accessToken: "token" })
+        const auth = makeAuth({ getAccessToken: apiGetAccessToken })
+
+        const result = await getAccessToken(auth)("github", { cache: "no-store" } as any)
+
+        expect(result).toEqual({ success: true, accessToken: "token" })
+        expect(apiGetAccessToken).toHaveBeenCalledWith("github", {
+            headers,
+            cache: "no-store",
+        })
+    })
+
+    test("returns failure responses as-is", async () => {
+        const auth = makeAuth({
+            getAccessToken: vi.fn().mockResolvedValue({ success: false, accessToken: null }),
+        })
+
+        await expect(getAccessToken(auth)("github")).resolves.toEqual({
+            success: false,
+            accessToken: null,
+        })
+    })
+})

--- a/packages/next/test/app-router/api/isProviderConnected.test.ts
+++ b/packages/next/test/app-router/api/isProviderConnected.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockHeaders } = vi.hoisted(() => ({
+    mockHeaders: vi.fn(),
+}))
+
+vi.mock("next/headers", () => ({
+    headers: mockHeaders,
+    cookies: vi.fn(),
+}))
+
+import { isProviderConnected } from "@/lib/api"
+import type { AuthInstance } from "@aura-stack/react"
+
+const makeAuth = (apiOverrides: Partial<AuthInstance["api"]> = {}): AuthInstance => {
+    return {
+        api: {
+            getSession: vi.fn().mockResolvedValue({ success: false }),
+            signIn: vi.fn().mockResolvedValue({ success: false }),
+            signInCredentials: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            updateSession: vi
+                .fn()
+                .mockResolvedValue({ success: false, session: null, redirectURL: null, headers: new Headers() }),
+            getProviderTokens: vi.fn().mockResolvedValue({ success: false }),
+            getAccessToken: vi.fn().mockResolvedValue({ success: false }),
+            signOut: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            signUp: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            refreshUserInfo: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            revokeToken: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            disconnectProvider: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            isProviderConnected: vi.fn().mockResolvedValue({ success: false, connected: false }),
+            ...apiOverrides,
+        },
+    } as unknown as AuthInstance
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    mockHeaders.mockResolvedValue(new Headers())
+})
+
+describe("isProviderConnected", () => {
+    test("forwards headers and returns a connected response", async () => {
+        const headers = new Headers({ "x-request-id": "req-1" })
+        mockHeaders.mockResolvedValue(headers)
+
+        const apiIsProviderConnected = vi.fn().mockResolvedValue({ success: true, connected: true })
+        const auth = makeAuth({ isProviderConnected: apiIsProviderConnected })
+
+        const result = await isProviderConnected(auth)("github", { cache: "no-store" } as any)
+
+        expect(result).toEqual({ success: true, connected: true })
+        expect(apiIsProviderConnected).toHaveBeenCalledWith("github", {
+            headers,
+            cache: "no-store",
+        })
+    })
+
+    test("returns false when the API reports no connection", async () => {
+        const auth = makeAuth({
+            isProviderConnected: vi.fn().mockResolvedValue({ success: true, connected: false }),
+        })
+
+        await expect(isProviderConnected(auth)("github")).resolves.toEqual({
+            success: true,
+            connected: false,
+        })
+    })
+})

--- a/packages/next/test/app-router/api/refreshUserInfo.test.ts
+++ b/packages/next/test/app-router/api/refreshUserInfo.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockHeaders, mockCookiesSet, mockParseSetCookie } = vi.hoisted(() => ({
+    mockHeaders: vi.fn(),
+    mockCookiesSet: vi.fn(),
+    mockParseSetCookie: vi.fn((cookieStr: string) => {
+        const [nameValue, ...parts] = cookieStr.split("; ").map((part) => part.trim())
+        const [name, ...valueParts] = nameValue.split("=")
+        const value = valueParts.join("=")
+        const options: Record<string, unknown> = {}
+
+        for (const part of parts) {
+            const lower = part.toLowerCase()
+            if (lower === "httponly") options.httpOnly = true
+            else if (lower === "secure") options.secure = true
+            else if (lower.startsWith("path=")) options.path = part.slice(5)
+        }
+
+        return { name, value, ...options }
+    }),
+}))
+
+vi.mock("next/headers", () => ({
+    headers: mockHeaders,
+    cookies: () => Promise.resolve({ set: mockCookiesSet }),
+}))
+
+vi.mock("@aura-stack/react/cookies", () => ({
+    parseSetCookie: mockParseSetCookie,
+}))
+
+import { refreshUserInfo } from "@/lib/api"
+import type { AuthInstance } from "@aura-stack/react"
+
+const makeResponseHeaders = (...setCookies: string[]) =>
+    ({
+        getSetCookie: () => setCookies,
+    }) as unknown as Headers
+
+const makeAuth = (apiOverrides: Partial<AuthInstance["api"]> = {}): AuthInstance => {
+    return {
+        api: {
+            getSession: vi.fn().mockResolvedValue({ success: false }),
+            signIn: vi.fn().mockResolvedValue({ success: false }),
+            signInCredentials: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            updateSession: vi
+                .fn()
+                .mockResolvedValue({ success: false, session: null, redirectURL: null, headers: new Headers() }),
+            getProviderTokens: vi.fn().mockResolvedValue({ success: false }),
+            getAccessToken: vi.fn().mockResolvedValue({ success: false }),
+            signOut: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            signUp: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            refreshUserInfo: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            revokeToken: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            disconnectProvider: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            isProviderConnected: vi.fn().mockResolvedValue({ success: false, connected: false }),
+            ...apiOverrides,
+        },
+    } as unknown as AuthInstance
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    mockHeaders.mockResolvedValue(new Headers())
+})
+
+describe("refreshUserInfo", () => {
+    test("forwards headers, returns response, and syncs cookies", async () => {
+        const headers = new Headers({ "x-test": "value" })
+        mockHeaders.mockResolvedValue(headers)
+
+        const responseHeaders = makeResponseHeaders("profile=updated; Path=/; HttpOnly")
+        const apiRefreshUserInfo = vi.fn().mockResolvedValue({
+            success: true,
+            headers: responseHeaders,
+            user: { name: "Jane" },
+        })
+        const auth = makeAuth({ refreshUserInfo: apiRefreshUserInfo })
+
+        const result = await refreshUserInfo(auth)("github", { cache: "no-store" } as any)
+
+        expect(result).toEqual({
+            success: true,
+            headers: responseHeaders,
+            user: { name: "Jane" },
+        })
+        expect(apiRefreshUserInfo).toHaveBeenCalledWith("github", {
+            headers,
+            cache: "no-store",
+        })
+        expect(mockCookiesSet).toHaveBeenCalledWith("profile", "updated", expect.objectContaining({ path: "/", httpOnly: true }))
+    })
+
+    test("returns failure responses without writing cookies", async () => {
+        const apiRefreshUserInfo = vi.fn().mockResolvedValue({
+            success: false,
+            headers: makeResponseHeaders(),
+        })
+        const auth = makeAuth({ refreshUserInfo: apiRefreshUserInfo })
+
+        await expect(refreshUserInfo(auth)("github")).resolves.toEqual({
+            success: false,
+            headers: expect.any(Object),
+        })
+        expect(mockCookiesSet).not.toHaveBeenCalled()
+    })
+})

--- a/packages/next/test/app-router/api/revokeToken.test.ts
+++ b/packages/next/test/app-router/api/revokeToken.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockHeaders, mockCookiesSet, mockParseSetCookie } = vi.hoisted(() => ({
+    mockHeaders: vi.fn(),
+    mockCookiesSet: vi.fn(),
+    mockParseSetCookie: vi.fn((cookieStr: string) => {
+        const [nameValue, ...parts] = cookieStr.split("; ").map((part) => part.trim())
+        const [name, ...valueParts] = nameValue.split("=")
+        const value = valueParts.join("=")
+        const options: Record<string, unknown> = {}
+
+        for (const part of parts) {
+            const lower = part.toLowerCase()
+            if (lower === "httponly") options.httpOnly = true
+            else if (lower.startsWith("path=")) options.path = part.slice(5)
+        }
+
+        return { name, value, ...options }
+    }),
+}))
+
+vi.mock("next/headers", () => ({
+    headers: mockHeaders,
+    cookies: () => Promise.resolve({ set: mockCookiesSet }),
+}))
+
+vi.mock("@aura-stack/react/cookies", () => ({
+    parseSetCookie: mockParseSetCookie,
+}))
+
+import { revokeToken } from "@/lib/api"
+import type { AuthInstance } from "@aura-stack/react"
+
+const makeResponseHeaders = (...setCookies: string[]) =>
+    ({
+        getSetCookie: () => setCookies,
+    }) as unknown as Headers
+
+const makeAuth = (apiOverrides: Partial<AuthInstance["api"]> = {}): AuthInstance => {
+    return {
+        api: {
+            getSession: vi.fn().mockResolvedValue({ success: false }),
+            signIn: vi.fn().mockResolvedValue({ success: false }),
+            signInCredentials: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            updateSession: vi
+                .fn()
+                .mockResolvedValue({ success: false, session: null, redirectURL: null, headers: new Headers() }),
+            getProviderTokens: vi.fn().mockResolvedValue({ success: false }),
+            getAccessToken: vi.fn().mockResolvedValue({ success: false }),
+            signOut: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            signUp: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            refreshUserInfo: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            revokeToken: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            disconnectProvider: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            isProviderConnected: vi.fn().mockResolvedValue({ success: false, connected: false }),
+            ...apiOverrides,
+        },
+    } as unknown as AuthInstance
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    mockHeaders.mockResolvedValue(new Headers())
+})
+
+describe("revokeToken", () => {
+    test("forwards headers and syncs cookies on success", async () => {
+        const headers = new Headers({ "x-test": "value" })
+        mockHeaders.mockResolvedValue(headers)
+
+        const responseHeaders = makeResponseHeaders("token=revoked; Path=/; HttpOnly")
+        const apiRevokeToken = vi.fn().mockResolvedValue({
+            success: true,
+            headers: responseHeaders,
+        })
+        const auth = makeAuth({ revokeToken: apiRevokeToken })
+
+        const result = await revokeToken(auth)("github", { cache: "no-store" } as any)
+
+        expect(result).toEqual({
+            success: true,
+            headers: responseHeaders,
+        })
+        expect(apiRevokeToken).toHaveBeenCalledWith("github", {
+            headers,
+            cache: "no-store",
+        })
+        expect(mockCookiesSet).toHaveBeenCalledWith("token", "revoked", expect.objectContaining({ path: "/", httpOnly: true }))
+    })
+
+    test("returns failure responses without writing cookies", async () => {
+        const apiRevokeToken = vi.fn().mockResolvedValue({
+            success: false,
+            headers: makeResponseHeaders(),
+        })
+        const auth = makeAuth({ revokeToken: apiRevokeToken })
+
+        await expect(revokeToken(auth)("github")).resolves.toEqual({
+            success: false,
+            headers: expect.any(Object),
+        })
+        expect(mockCookiesSet).not.toHaveBeenCalled()
+    })
+})

--- a/packages/next/test/app-router/api/signUp.test.ts
+++ b/packages/next/test/app-router/api/signUp.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockRedirect, mockHeaders, mockCookiesSet, mockParseSetCookie } = vi.hoisted(() => ({
+    mockRedirect: vi.fn((url: string) => `redirect:${url}`),
+    mockHeaders: vi.fn(),
+    mockCookiesSet: vi.fn(),
+    mockParseSetCookie: vi.fn((cookieStr: string) => {
+        const [nameValue, ...parts] = cookieStr.split("; ").map((part) => part.trim())
+        const [name, ...valueParts] = nameValue.split("=")
+        const value = valueParts.join("=")
+        const options: Record<string, unknown> = {}
+
+        for (const part of parts) {
+            const lower = part.toLowerCase()
+            if (lower === "httponly") options.httpOnly = true
+            else if (lower === "secure") options.secure = true
+            else if (lower.startsWith("path=")) options.path = part.slice(5)
+            else if (lower.startsWith("samesite=")) options.sameSite = part.slice(9).toLowerCase()
+        }
+
+        return { name, value, ...options }
+    }),
+}))
+
+vi.mock("next/navigation", () => ({
+    redirect: mockRedirect,
+}))
+
+vi.mock("next/headers", () => ({
+    headers: mockHeaders,
+    cookies: () => Promise.resolve({ set: mockCookiesSet }),
+}))
+
+vi.mock("@aura-stack/react/cookies", () => ({
+    parseSetCookie: mockParseSetCookie,
+}))
+
+import { signUp } from "@/lib/api"
+import type { AuthInstance } from "@aura-stack/react"
+
+const makeResponseHeaders = (...setCookies: string[]) =>
+    ({
+        getSetCookie: () => setCookies,
+    }) as unknown as Headers
+
+const makeAuth = (apiOverrides: Partial<AuthInstance["api"]> = {}): AuthInstance => {
+    return {
+        api: {
+            getSession: vi.fn().mockResolvedValue({ success: false }),
+            signIn: vi.fn().mockResolvedValue({ success: false }),
+            signInCredentials: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            updateSession: vi
+                .fn()
+                .mockResolvedValue({ success: false, session: null, redirectURL: null, headers: new Headers() }),
+            getProviderTokens: vi.fn().mockResolvedValue({ success: false }),
+            getAccessToken: vi.fn().mockResolvedValue({ success: false }),
+            signOut: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            signUp: vi.fn().mockResolvedValue({ success: false, redirectURL: null, headers: new Headers() }),
+            refreshUserInfo: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            revokeToken: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            disconnectProvider: vi.fn().mockResolvedValue({ success: false, headers: new Headers() }),
+            isProviderConnected: vi.fn().mockResolvedValue({ success: false, connected: false }),
+            ...apiOverrides,
+        },
+    } as unknown as AuthInstance
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    mockHeaders.mockResolvedValue(new Headers())
+})
+
+describe("signUp", () => {
+    test("redirects and syncs cookies when sign-up succeeds with redirectURL", async () => {
+        const responseHeaders = makeResponseHeaders(
+            "session_token=abc123; Path=/; HttpOnly; Secure",
+            "state=xyz; Path=/; HttpOnly"
+        )
+        const apiSignUp = vi.fn().mockResolvedValue({
+            success: true,
+            redirectURL: "/welcome",
+            headers: responseHeaders,
+        })
+        const auth = makeAuth({ signUp: apiSignUp })
+
+        const result = await signUp(auth)({
+            payload: {
+                name: "Jane",
+                email: "jane@example.com",
+                password: "secret",
+            },
+        } as any)
+
+        expect(result).toBe("redirect:/welcome")
+        expect(apiSignUp).toHaveBeenCalledWith({
+            headers: expect.any(Headers),
+            payload: {
+                name: "Jane",
+                email: "jane@example.com",
+                password: "secret",
+            },
+            redirect: false,
+        })
+        expect(mockCookiesSet).toHaveBeenCalledWith(
+            "session_token",
+            "abc123",
+            expect.objectContaining({ path: "/", httpOnly: true, secure: true })
+        )
+        expect(mockCookiesSet).toHaveBeenCalledWith("state", "xyz", expect.objectContaining({ path: "/", httpOnly: true }))
+        expect(mockRedirect).toHaveBeenCalledWith("/welcome")
+    })
+
+    test("returns the API response when sign-up succeeds without redirectURL", async () => {
+        const apiSignUp = vi.fn().mockResolvedValue({
+            success: true,
+            redirectURL: null,
+            headers: makeResponseHeaders(),
+        })
+        const auth = makeAuth({ signUp: apiSignUp })
+
+        await expect(
+            signUp(auth)({
+                payload: {
+                    name: "Jane",
+                    email: "jane@example.com",
+                    password: "secret",
+                },
+            } as any)
+        ).resolves.toEqual({
+            success: true,
+            redirectURL: null,
+            headers: expect.any(Object),
+        })
+        expect(mockRedirect).not.toHaveBeenCalled()
+    })
+
+    test("does not redirect when sign-up fails even if redirectURL exists", async () => {
+        const apiSignUp = vi.fn().mockResolvedValue({
+            success: false,
+            redirectURL: "/welcome",
+            headers: makeResponseHeaders(),
+        })
+        const auth = makeAuth({ signUp: apiSignUp })
+
+        await signUp(auth)({
+            payload: {
+                name: "Jane",
+                email: "jane@example.com",
+                password: "secret",
+            },
+        } as any)
+
+        expect(mockRedirect).not.toHaveBeenCalled()
+    })
+})

--- a/packages/react-router/src/@types/api.ts
+++ b/packages/react-router/src/@types/api.ts
@@ -19,6 +19,16 @@ import type {
     GetProviderTokensAPIReturn,
     AccessTokenAPIOptions,
     AccessTokenAPIReturn,
+    SignUpAPIOptions,
+    SignUpAPIReturn,
+    RefreshUserInfoAPIOptions,
+    RefreshUserInfoAPIReturn,
+    RevokeTokenAPIOptions,
+    RevokeTokenAPIReturn,
+    DisconnectProviderAPIOptions,
+    DisconnectProviderAPIReturn,
+    ProviderConnectedAPIOptions,
+    ProviderConnectedAPIReturn,
 } from "@aura-stack/react/types"
 import type { BuiltInOAuthProvider, LiteralUnion } from "@aura-stack/react/types"
 
@@ -78,6 +88,22 @@ export type ReactRouterUpdateSessionReturn<
     ? UpdateSessionAPIReturn<DefaultUser>
     : Response
 
+export type ReactRouterSignUpAPIOptions = Prettify<SignUpAPIOptions & { request: Request }>
+
+export type ReactRouterSignUpReturn<Options extends ReactRouterSignUpAPIOptions> = Options extends {
+    redirect: false
+}
+    ? SignUpAPIReturn
+    : Response
+
+export type ReactRouterRefreshUserInfoAPIOptions = Prettify<RefreshUserInfoAPIOptions & { request: Request }>
+
+export type ReactRouterRevokeTokenAPIOptions = Prettify<RevokeTokenAPIOptions & { request: Request }>
+
+export type ReactRouterDisconnectProviderAPIOptions = Prettify<DisconnectProviderAPIOptions & { request: Request }>
+
+export type ReactRouterProviderConnectedAPIOptions = Prettify<ProviderConnectedAPIOptions & { request: Request }>
+
 export interface ReactRouterAPI<DefaultUser extends User = User> {
     getSession: (options: GetSessionAPIOptions) => Promise<Session<DefaultUser> | null>
     signIn: <Options extends ReactRouterSignInAPIOptions>(
@@ -93,4 +119,21 @@ export interface ReactRouterAPI<DefaultUser extends User = User> {
     getProviderTokens: (oauth: LiteralUnion<BuiltInOAuthProvider>) => Promise<GetProviderTokensAPIReturn>
     getAccessToken: (oauth: LiteralUnion<BuiltInOAuthProvider>, options?: AccessTokenAPIOptions) => Promise<AccessTokenAPIReturn>
     signOut: <Options extends ReactRouterSignOutAPIOptions>(options: Options) => Promise<ReactRouterSignOutReturn<Options>>
+    signUp: <Options extends ReactRouterSignUpAPIOptions>(options: Options) => Promise<ReactRouterSignUpReturn<Options>>
+    refreshUserInfo: <Options extends ReactRouterRefreshUserInfoAPIOptions>(
+        oauth: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Options
+    ) => Promise<RefreshUserInfoAPIReturn>
+    revokeToken: <Options extends ReactRouterRevokeTokenAPIOptions>(
+        oauth: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Options
+    ) => Promise<RevokeTokenAPIReturn>
+    disconnectProvider: <Options extends ReactRouterDisconnectProviderAPIOptions>(
+        oauth: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Options
+    ) => Promise<DisconnectProviderAPIReturn>
+    isProviderConnected: <Options extends ReactRouterProviderConnectedAPIOptions>(
+        oauth: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Options
+    ) => Promise<ProviderConnectedAPIReturn>
 }

--- a/packages/react-router/src/@types/api.ts
+++ b/packages/react-router/src/@types/api.ts
@@ -122,18 +122,18 @@ export interface ReactRouterAPI<DefaultUser extends User = User> {
     signUp: <Options extends ReactRouterSignUpAPIOptions>(options: Options) => Promise<ReactRouterSignUpReturn<Options>>
     refreshUserInfo: <Options extends ReactRouterRefreshUserInfoAPIOptions>(
         oauth: LiteralUnion<BuiltInOAuthProvider>,
-        options?: Options
-    ) => Promise<RefreshUserInfoAPIReturn>
+        options: Options
+    ) => Promise<RefreshUserInfoAPIReturn<DefaultUser>>
     revokeToken: <Options extends ReactRouterRevokeTokenAPIOptions>(
         oauth: LiteralUnion<BuiltInOAuthProvider>,
-        options?: Options
+        options: Options
     ) => Promise<RevokeTokenAPIReturn>
     disconnectProvider: <Options extends ReactRouterDisconnectProviderAPIOptions>(
         oauth: LiteralUnion<BuiltInOAuthProvider>,
-        options?: Options
+        options: Options
     ) => Promise<DisconnectProviderAPIReturn>
     isProviderConnected: <Options extends ReactRouterProviderConnectedAPIOptions>(
         oauth: LiteralUnion<BuiltInOAuthProvider>,
-        options?: Options
+        options: Options
     ) => Promise<ProviderConnectedAPIReturn>
 }

--- a/packages/react-router/src/lib/api.ts
+++ b/packages/react-router/src/lib/api.ts
@@ -8,6 +8,12 @@ import type {
     ReactRouterSignOutReturn,
     ReactRouterUpdateSessionReturn,
     ReactRouterUpdateSessionAPIOptions,
+    ReactRouterSignUpAPIOptions,
+    ReactRouterSignUpReturn,
+    ReactRouterRefreshUserInfoAPIOptions,
+    ReactRouterRevokeTokenAPIOptions,
+    ReactRouterDisconnectProviderAPIOptions,
+    ReactRouterProviderConnectedAPIOptions,
 } from "@/@types/api"
 import type { AuthInstance, Session, User } from "@aura-stack/react"
 import type {
@@ -18,6 +24,10 @@ import type {
     GetProviderTokensAPIReturn,
     GetSessionAPIOptions,
     LiteralUnion,
+    RefreshUserInfoAPIReturn,
+    RevokeTokenAPIReturn,
+    DisconnectProviderAPIReturn,
+    ProviderConnectedAPIReturn,
 } from "@aura-stack/react/types"
 
 export const getSession = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
@@ -100,6 +110,71 @@ export const signOut = <DefaultUser extends User = User>({ api }: AuthInstance<D
             return out as ReactRouterSignOutReturn<Options>
         }
         return out.toResponse() as ReactRouterSignOutReturn<Options>
+    }
+}
+
+export const signUp = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
+    return async <Options extends ReactRouterSignUpAPIOptions>(options: Options): Promise<ReactRouterSignUpReturn<Options>> => {
+        const signUp = await api.signUp({
+            headers: options.request.headers,
+            ...options,
+        })
+        if (options?.redirect === false) {
+            return signUp as ReactRouterSignUpReturn<Options>
+        }
+        return signUp.toResponse() as ReactRouterSignUpReturn<Options>
+    }
+}
+
+export const refreshUserInfo = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
+    return async <Options extends ReactRouterRefreshUserInfoAPIOptions>(
+        oauth: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Options
+    ): Promise<RefreshUserInfoAPIReturn> => {
+        const refresh = await api.refreshUserInfo(oauth, {
+            headers: options?.request.headers,
+            ...options,
+        })
+        return refresh
+    }
+}
+
+export const revokeToken = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
+    return async <Options extends ReactRouterRevokeTokenAPIOptions>(
+        oauth: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Options
+    ): Promise<RevokeTokenAPIReturn> => {
+        const revoke = await api.revokeToken(oauth, {
+            headers: options?.request.headers,
+            ...options,
+        })
+        return revoke
+    }
+}
+
+export const disconnectProvider = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
+    return async <Options extends ReactRouterDisconnectProviderAPIOptions>(
+        oauth: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Options
+    ): Promise<DisconnectProviderAPIReturn> => {
+        const disconnect = await api.disconnectProvider(oauth, {
+            headers: options?.request.headers,
+            ...options,
+        })
+        return disconnect
+    }
+}
+
+export const isProviderConnected = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
+    return async <Options extends ReactRouterProviderConnectedAPIOptions>(
+        oauth: LiteralUnion<BuiltInOAuthProvider>,
+        options?: Options
+    ): Promise<ProviderConnectedAPIReturn> => {
+        const connected = await api.isProviderConnected(oauth, {
+            headers: options?.request.headers,
+            ...options,
+        })
+        return connected
     }
 }
 
@@ -239,5 +314,92 @@ export const api = <DefaultUser extends User = User>(config: AuthInstance<Defaul
          * }
          */
         signOut: signOut<DefaultUser>(config),
+        /**
+         * Signs up a new user on the server-side. It requires a `payload` with the necessary information for
+         * user creation and a callback function configured in `signUp.onCreateUser` to handle the actual user
+         * creation logic.
+         *
+         * @param options - Options for the API call, including the sign-up payload, headers, and redirect behavior.
+         * @returns The object returned by the API call {@link ReactRouterSignUpReturn}
+         * @example
+         * export const action = async ({ request }) => {
+         *   const formData = await request.formData()
+         *   const name = formData.get("name") as string
+         *   const email = formData.get("email") as string
+         *   const password = formData.get("password") as string
+         *
+         *   return await api.signUp({
+         *     payload: {
+         *       name,
+         *       email,
+         *       password
+         *     },
+         *     request,
+         *     redirectTo: "/dashboard",
+         *   })
+         * }
+         */
+        signUp: signUp<DefaultUser>(config),
+        /**
+         * Refreshes user information from the OAuth provider on the server-side. It retrieves the latest
+         * user information from the provider and updates the session accordingly.
+         *
+         * @param oauth - The OAuth provider to refresh user information from (e.g., "github", "gitlab", "bitbucket").
+         * @param options - Optional parameters for the refresh operation, including headers and redirect behavior.
+         * @returns The object returned by the API call {@link ReactRouterRefreshUserInfoReturn}
+         * @example
+         * export const action = async ({ request }) => {
+         *   return await api.refreshUserInfo("github", {
+         *     request,
+         *   })
+         * }
+         */
+        refreshUserInfo: refreshUserInfo<DefaultUser>(config),
+        /**
+         * Revokes the OAuth provider token on the server-side. It invalidates the access token for the specified
+         * provider, effectively disconnecting the user from that provider.
+         *
+         * @param oauth - The OAuth provider to revoke the token for (e.g., "github", "gitlab", "bitbucket").
+         * @param options - Optional parameters for the revoke operation, including headers and redirect behavior.
+         * @returns The object returned by the API call {@link ReactRouterRevokeTokenReturn}
+         * @example
+         * export const action = async ({ request }) => {
+         *   return await api.revokeToken("github", {
+         *     request,
+         *   })
+         * }
+         */
+        revokeToken: revokeToken<DefaultUser>(config),
+        /**
+         * Disconnects the OAuth provider on the server-side. It revokes the access token and removes the provider
+         * connection from the user's session.
+         *
+         * @param oauth - The OAuth provider to disconnect (e.g., "github", "gitlab", "bitbucket").
+         * @param options - Optional parameters for the disconnect operation, including headers and redirect behavior.
+         * @returns The object returned by the API call {@link ReactRouterDisconnectProviderReturn}
+         * @example
+         * export const action = async ({ request }) => {
+         *   return await api.disconnectProvider("github", {
+         *     request,
+         *   })
+         * }
+         */
+        disconnectProvider: disconnectProvider<DefaultUser>(config),
+        /**
+         * Checks if the OAuth provider is connected on the server-side. It returns a boolean indicating whether
+         * the user has an active connection with the specified provider.
+         *
+         * @param oauth - The OAuth provider to check connection status for (e.g., "github", "gitlab", "bitbucket").
+         * @param options - Optional parameters for the check operation, including headers and redirect behavior.
+         * @returns The object returned by the API call {@link ReactRouterProviderConnectedReturn}
+         * @example
+         * export const loader = async ({ request }) => {
+         *   const { connected } = await api.isProviderConnected("github", {
+         *     request,
+         *   })
+         *   return Response.json({ connected })
+         * }
+         */
+        isProviderConnected: isProviderConnected<DefaultUser>(config),
     } satisfies ReactRouterAPI<DefaultUser>
 }

--- a/packages/react-router/src/lib/api.ts
+++ b/packages/react-router/src/lib/api.ts
@@ -129,10 +129,10 @@ export const signUp = <DefaultUser extends User = User>({ api }: AuthInstance<De
 export const refreshUserInfo = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
     return async <Options extends ReactRouterRefreshUserInfoAPIOptions>(
         oauth: LiteralUnion<BuiltInOAuthProvider>,
-        options?: Options
-    ): Promise<RefreshUserInfoAPIReturn> => {
+        options: Options
+    ): Promise<RefreshUserInfoAPIReturn<DefaultUser>> => {
         const refresh = await api.refreshUserInfo(oauth, {
-            headers: options?.request.headers,
+            headers: options.request.headers,
             ...options,
         })
         return refresh
@@ -142,10 +142,10 @@ export const refreshUserInfo = <DefaultUser extends User = User>({ api }: AuthIn
 export const revokeToken = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
     return async <Options extends ReactRouterRevokeTokenAPIOptions>(
         oauth: LiteralUnion<BuiltInOAuthProvider>,
-        options?: Options
+        options: Options
     ): Promise<RevokeTokenAPIReturn> => {
         const revoke = await api.revokeToken(oauth, {
-            headers: options?.request.headers,
+            headers: options.request.headers,
             ...options,
         })
         return revoke
@@ -155,10 +155,10 @@ export const revokeToken = <DefaultUser extends User = User>({ api }: AuthInstan
 export const disconnectProvider = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
     return async <Options extends ReactRouterDisconnectProviderAPIOptions>(
         oauth: LiteralUnion<BuiltInOAuthProvider>,
-        options?: Options
+        options: Options
     ): Promise<DisconnectProviderAPIReturn> => {
         const disconnect = await api.disconnectProvider(oauth, {
-            headers: options?.request.headers,
+            headers: options.request.headers,
             ...options,
         })
         return disconnect
@@ -168,10 +168,10 @@ export const disconnectProvider = <DefaultUser extends User = User>({ api }: Aut
 export const isProviderConnected = <DefaultUser extends User = User>({ api }: AuthInstance<DefaultUser>) => {
     return async <Options extends ReactRouterProviderConnectedAPIOptions>(
         oauth: LiteralUnion<BuiltInOAuthProvider>,
-        options?: Options
+        options: Options
     ): Promise<ProviderConnectedAPIReturn> => {
         const connected = await api.isProviderConnected(oauth, {
-            headers: options?.request.headers,
+            headers: options.request.headers,
             ...options,
         })
         return connected
@@ -345,7 +345,7 @@ export const api = <DefaultUser extends User = User>(config: AuthInstance<Defaul
          * user information from the provider and updates the session accordingly.
          *
          * @param oauth - The OAuth provider to refresh user information from (e.g., "github", "gitlab", "bitbucket").
-         * @param options - Optional parameters for the refresh operation, including headers and redirect behavior.
+         * @param options - Optional parameters for the refresh operation, including headers and request object.
          * @returns The object returned by the API call {@link ReactRouterRefreshUserInfoReturn}
          * @example
          * export const action = async ({ request }) => {
@@ -360,7 +360,7 @@ export const api = <DefaultUser extends User = User>(config: AuthInstance<Defaul
          * provider, effectively disconnecting the user from that provider.
          *
          * @param oauth - The OAuth provider to revoke the token for (e.g., "github", "gitlab", "bitbucket").
-         * @param options - Optional parameters for the revoke operation, including headers and redirect behavior.
+         * @param options - Optional parameters for the revoke operation, including headers and request object.
          * @returns The object returned by the API call {@link ReactRouterRevokeTokenReturn}
          * @example
          * export const action = async ({ request }) => {
@@ -375,7 +375,7 @@ export const api = <DefaultUser extends User = User>(config: AuthInstance<Defaul
          * connection from the user's session.
          *
          * @param oauth - The OAuth provider to disconnect (e.g., "github", "gitlab", "bitbucket").
-         * @param options - Optional parameters for the disconnect operation, including headers and redirect behavior.
+         * @param options - Optional parameters for the disconnect operation, including headers and request object.
          * @returns The object returned by the API call {@link ReactRouterDisconnectProviderReturn}
          * @example
          * export const action = async ({ request }) => {
@@ -390,7 +390,7 @@ export const api = <DefaultUser extends User = User>(config: AuthInstance<Defaul
          * the user has an active connection with the specified provider.
          *
          * @param oauth - The OAuth provider to check connection status for (e.g., "github", "gitlab", "bitbucket").
-         * @param options - Optional parameters for the check operation, including headers and redirect behavior.
+         * @param options - Optional parameters for the check operation, including headers and request object.
          * @returns The object returned by the API call {@link ReactRouterProviderConnectedReturn}
          * @example
          * export const loader = async ({ request }) => {


### PR DESCRIPTION
## Description

This pull request implements the remaining authentication APIs for the `@aura-stack/next` and `@aura-stack/react-router` packages.

The following APIs have been added to both framework integrations:

- `revokeToken`
- `disconnectProvider`
- `isProviderConnected`
- `refreshUserInfo`

These APIs complete the provider management functionality available in the framework-specific packages, allowing applications to manage OAuth and OpenID Connect (OIDC) provider connections and user profile data without interacting directly with the core package.

Each implementation is built on top of the framework's native features, providing a seamless developer experience while preserving the behavior of the corresponding APIs in `@aura-stack/auth`.

### Key Changes

- Added `revokeToken` support to `@aura-stack/next` and `@aura-stack/react-router`.
- Added `disconnectProvider` support to `@aura-stack/next` and `@aura-stack/react-router`.
- Added `isProviderConnected` support to `@aura-stack/next` and `@aura-stack/react-router`.
- Added `refreshUserInfo` support to `@aura-stack/next` and `@aura-stack/react-router`.