### PR TITLE
feat: add `/types` entry point to backend integrations

### DIFF
--- a/packages/elysia/CHANGELOG.md
+++ b/packages/elysia/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added the `/types` entry point to re-export the public types from `@aura-stack/auth` and expose the integration-specific `ElysiaInstance` type. [#257](https://github.com/aura-stack-ts/auth/pull/257)
+
+### Fixed
+
+- Fixed type inference for `signUp.schema` and `identity.schema` across authentication instances. The configured Zod, Valibot, TypeBox, or ArkType schema is now correctly propagated through the auth instance. Updated `InferUser`, `InferSession`, and `InferSignUp` to correctly derive their types from the corresponding auth instance. [#256](https://github.com/aura-stack-ts/auth/pull/256)
+
 ---
 
 ## [0.3.0] - 2026-08-05

--- a/packages/elysia/deno.json
+++ b/packages/elysia/deno.json
@@ -35,7 +35,8 @@
     "./oauth/spotify": "./src/oauth/spotify.ts",
     "./oauth/strava": "./src/oauth/strava.ts",
     "./oauth/twitch": "./src/oauth/twitch.ts",
-    "./oauth/x": "./src/oauth/x.ts"
+    "./oauth/x": "./src/oauth/x.ts",
+    "./types": "./src/@types/index.ts"
   },
   "imports": {
     "@/": "./src/",

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -125,7 +125,8 @@
       "types": "./dist/_core/cookies.d.ts",
       "import": "./dist/_core/cookies.js",
       "require": "./dist/_core/cookies.cjs"
-    }
+    },
+    "./types": "./dist/@types/index.d.ts"
   },
   "packageManager": "pnpm@10.15.0"
 }

--- a/packages/elysia/src/@types/index.ts
+++ b/packages/elysia/src/@types/index.ts
@@ -3,6 +3,11 @@ import type { WithAuthContext } from "@/lib/with-auth"
 import type { zod } from "@aura-stack/auth/identity/zod"
 import type { AuthInstance, InferSchema, Prettify, RemoveIndexSignature, SchemaTypes, User } from "@aura-stack/auth/types"
 
+/**
+ * Re-exports all types from the `@aura-stack/auth/types` module, which includes the core types used in Aura Auth.
+ */
+export type * from "@aura-stack/auth/types"
+
 export interface ElysiaInstance<
     DefaultUser extends User = User,
     SignUpSchema extends SchemaTypes = zod.ZodObject<any>,

--- a/packages/elysia/tsdown.config.ts
+++ b/packages/elysia/tsdown.config.ts
@@ -12,5 +12,6 @@ export default defineConfig({
         "src/_core/crypto.ts",
         "src/_core/shared.ts",
         "src/_core/cookies.ts",
+        "src/@types/index.ts",
     ],
 })

--- a/packages/express/CHANGELOG.md
+++ b/packages/express/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added the `/types` entry point to re-export the public types from `@aura-stack/auth` and expose the integration-specific `ExpressInstance` type. [#257](https://github.com/aura-stack-ts/auth/pull/257)
+
+### Fixed
+
+- Fixed type inference for `signUp.schema` and `identity.schema` across authentication instances. The configured Zod, Valibot, TypeBox, or ArkType schema is now correctly propagated through the auth instance. Updated `InferUser`, `InferSession`, and `InferSignUp` to correctly derive their types from the corresponding auth instance. [#256](https://github.com/aura-stack-ts/auth/pull/256)
+
 ---
 
 ## [0.3.0] - 2026-08-05

--- a/packages/express/deno.json
+++ b/packages/express/deno.json
@@ -35,7 +35,8 @@
     "./oauth/spotify": "./src/oauth/spotify.ts",
     "./oauth/strava": "./src/oauth/strava.ts",
     "./oauth/twitch": "./src/oauth/twitch.ts",
-    "./oauth/x": "./src/oauth/x.ts"
+    "./oauth/x": "./src/oauth/x.ts",
+    "./types": "./src/@types/index.ts"
   },
   "imports": {
     "@/": "./src/",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -121,7 +121,8 @@
       "types": "./dist/_core/cookies.d.ts",
       "import": "./dist/_core/cookies.js",
       "require": "./dist/_core/cookies.cjs"
-    }
+    },
+    "./types": "./dist/@types/index.d.ts"
   },
   "packageManager": "pnpm@10.15.0"
 }

--- a/packages/express/src/@types/index.ts
+++ b/packages/express/src/@types/index.ts
@@ -5,6 +5,8 @@ import type { LocalsWithSession } from "@/lib/with-auth.ts"
 import type { InferSchema, SchemaTypes } from "@aura-stack/auth/identity"
 import type { Prettify, RemoveIndexSignature } from "@aura-stack/auth/types"
 
+export type * from "@aura-stack/auth/types"
+
 /**
  * The ExpressInstance type represents the shape of the object returned by the `createAuth`
  * function in the Express integration of Aura Auth. It was implemented due to errors related

--- a/packages/express/tsdown.config.ts
+++ b/packages/express/tsdown.config.ts
@@ -12,5 +12,6 @@ export default defineConfig({
         "src/_core/crypto.ts",
         "src/_core/shared.ts",
         "src/_core/cookies.ts",
+        "src/@types/index.ts",
     ],
 })

--- a/packages/hono/CHANGELOG.md
+++ b/packages/hono/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added the `/types` entry point to re-export the public types from `@aura-stack/auth` and expose the integration-specific `HonoInstance` type. [#257](https://github.com/aura-stack-ts/auth/pull/257)
+
+### Fixed
+
+- Fixed type inference for `signUp.schema` and `identity.schema` across authentication instances. The configured Zod, Valibot, TypeBox, or ArkType schema is now correctly propagated through the auth instance. Updated `InferUser`, `InferSession`, and `InferSignUp` to correctly derive their types from the corresponding auth instance. [#256](https://github.com/aura-stack-ts/auth/pull/256)
+
 ---
 
 ## [0.3.0] - 2026-08-05

--- a/packages/hono/deno.json
+++ b/packages/hono/deno.json
@@ -35,7 +35,8 @@
     "./oauth/spotify": "./src/oauth/spotify.ts",
     "./oauth/strava": "./src/oauth/strava.ts",
     "./oauth/twitch": "./src/oauth/twitch.ts",
-    "./oauth/x": "./src/oauth/x.ts"
+    "./oauth/x": "./src/oauth/x.ts",
+    "./types": "./src/@types/index.ts"
   },
   "imports": {
     "@/": "./src/",

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -119,7 +119,8 @@
       "types": "./dist/_core/cookies.d.ts",
       "import": "./dist/_core/cookies.js",
       "require": "./dist/_core/cookies.cjs"
-    }
+    },
+    "./types": "./dist/@types/index.d.ts"
   },
   "packageManager": "pnpm@10.15.0"
 }

--- a/packages/hono/src/@types/index.ts
+++ b/packages/hono/src/@types/index.ts
@@ -4,6 +4,8 @@ import type { Prettify } from "@aura-stack/jose"
 import type { EnvWithSession } from "@/lib/with-auth"
 import type { SchemaTypes, AuthInstance, RemoveIndexSignature, InferSchema, User } from "@aura-stack/auth/types"
 
+export type * from "@aura-stack/auth/types"
+
 export interface HonoInstance<
     DefaultUser extends User = User,
     SignUpSchema extends SchemaTypes = zod.ZodObject<any>,

--- a/packages/hono/tsdown.config.ts
+++ b/packages/hono/tsdown.config.ts
@@ -12,5 +12,6 @@ export default defineConfig({
         "src/_core/crypto.ts",
         "src/_core/shared.ts",
         "src/_core/cookies.ts",
+        "src/@types/index.ts",
     ],
 })

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added the `NextAppInstance` type to expose the auth instance type for Next.js App Router integration. [#257](https://github.com/aura-stack-ts/auth/pull/257)
+
+### Fixed
+
+- Fixed type inference for `signUp.schema` and `identity.schema` across authentication instances. The configured Zod, Valibot, TypeBox, or ArkType schema is now correctly propagated through the auth instance. Updated `InferUser`, `InferSession`, and `InferSignUp` to correctly derive their types from the corresponding auth instance. [#256](https://github.com/aura-stack-ts/auth/pull/256)
+
 ---
 
 ## [0.3.0] - 2026-08-05

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1,2 +1,3 @@
 export { createAuth } from "@/createAuth"
+export type { NextAppInstance, NextInstance } from "@/@types/index"
 export type { User, Session, AuthConfig, AuthInstance } from "@/@types/core.ts"

--- a/packages/oak/CHANGELOG.md
+++ b/packages/oak/CHANGELOG.md
@@ -10,6 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Added the `/types` entry point to re-export the public types from `@aura-stack/auth` and expose the integration-specific `ElysiaInstance` type. [#257](https://github.com/aura-stack-ts/auth/pull/257)
+- Added the `/types` entry point to re-export the public types from `@aura-stack/auth` and expose the integration-specific `OakInstance` type. [#257](https://github.com/aura-stack-ts/auth/pull/257)
 
 - Introduced a seamless Oak integration package that encapsulates the core authentication logic into middleware and handlers for session management and authentication flows. [#253](https://github.com/aura-stack-ts/auth/pull/253)

--- a/packages/oak/CHANGELOG.md
+++ b/packages/oak/CHANGELOG.md
@@ -10,4 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the `/types` entry point to re-export the public types from `@aura-stack/auth` and expose the integration-specific `ElysiaInstance` type. [#257](https://github.com/aura-stack-ts/auth/pull/257)
+
 - Introduced a seamless Oak integration package that encapsulates the core authentication logic into middleware and handlers for session management and authentication flows. [#253](https://github.com/aura-stack-ts/auth/pull/253)

--- a/packages/oak/deno.json
+++ b/packages/oak/deno.json
@@ -42,7 +42,8 @@
     "./oauth/spotify": "./src/oauth/spotify.ts",
     "./oauth/strava": "./src/oauth/strava.ts",
     "./oauth/twitch": "./src/oauth/twitch.ts",
-    "./oauth/x": "./src/oauth/x.ts"
+    "./oauth/x": "./src/oauth/x.ts",
+    "./types": "./src/@types/index.ts"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/_core", "src/oauth", "src/identity", "README.md", "CHANGELOG.md"],

--- a/packages/oak/deno.json
+++ b/packages/oak/deno.json
@@ -43,7 +43,7 @@
     "./oauth/strava": "./src/oauth/strava.ts",
     "./oauth/twitch": "./src/oauth/twitch.ts",
     "./oauth/x": "./src/oauth/x.ts",
-    "./types": "./src/@types/index.ts"
+    "./types": "./src/types/index.ts"
   },
   "publish": {
     "include": ["src/**/*.ts", "src/_core", "src/oauth", "src/identity", "README.md", "CHANGELOG.md"],

--- a/packages/oak/package.json
+++ b/packages/oak/package.json
@@ -86,7 +86,8 @@
       "types": "./dist/_core/cookies.d.ts",
       "import": "./dist/_core/cookies.js",
       "require": "./dist/_core/cookies.cjs"
-    }
+    },
+    "./types": "./dist/types/index.d.ts"
   },
   "packageManager": "pnpm@10.15.0"
 }

--- a/packages/oak/tsdown.config.ts
+++ b/packages/oak/tsdown.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
         "src/_core/crypto.ts",
         "src/_core/shared.ts",
         "src/_core/cookies.ts",
+        "src/types/index.ts",
     ],
 })

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- Fixed type inference for `signUp.schema` across authentication instances. The configured Zod, Valibot, TypeBox, or ArkType schema is now correctly propagated through the auth instance. Updated `InferUser`, `InferSession`, and `InferSignUp` to correctly derive their types from the corresponding auth instance. [#256](https://github.com/aura-stack-ts/auth/pull/256)
+- Fixed type inference for `signUp.schema` and `identity.schema` across authentication instances. The configured Zod, Valibot, TypeBox, or ArkType schema is now correctly propagated through the auth instance. Updated `InferUser`, `InferSession`, and `InferSignUp` to correctly derive their types from the corresponding auth instance. [#256](https://github.com/aura-stack-ts/auth/pull/256)
 
 ---
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed type inference for `signUp.schema` and `identity.schema` across authentication instances. The configured Zod, Valibot, TypeBox, or ArkType schema is now correctly propagated through the auth instance. Updated `InferUser`, `InferSession`, and `InferSignUp` to correctly derive their types from the corresponding auth instance. [#256](https://github.com/aura-stack-ts/auth/pull/256)
+
 ---
 
 ## [0.3.0] - 2026-08-05


### PR DESCRIPTION
## Description

This pull request adds a dedicated `/types` entry point to the backend integrations, including Hono, Elysia, Express, and Oak.

The new entry point re-exports the public types from `@aura-stack/auth/types` alongside the types specific to each framework integration. This provides a consistent and discoverable way to access the core authentication types and framework-specific types without importing them from internal modules.

Previously, the `/types` entry point was intentionally omitted because exposing public types from backend integrations was considered unnecessary. However, after the type inference improvements introduced in previous PRs, it became clear that having a dedicated types entry point is useful for consumers who need to work directly with the primitive authentication types or the dedicated Auth Instance types provided by each integration.

Additionally, the dedicated Auth Instance types are now exported from the **main entry point** of each integration as well as from the `/types` entry point. This allows users to import types such as `ElysiaInstance`, `OakInstance`, and `HonoInstance` directly from the package without requiring a `/types` import.


### Key Changes

- Added `/types` entry points to:
  - `@aura-stack/hono`
  - `@aura-stack/elysia`
  - `@aura-stack/express`
  - `@aura-stack/oak`
- Re-exported the public types from `@aura-stack/auth/types`.
- Re-exported framework-specific types from each integration.
- Exposed dedicated Auth Instance types through the integration packages.
- Standardized type imports across backend integrations.

### Usage

```ts
import type { HonoInstance } from "@aura-stack/hono/types"
import type { ExpressInstance } from "@aura-stack/express/types"
import type { ElysiaInstance } from "@aura-stack/elysia/types"
import type { OakInstance } from "@aura-stack/oak/types"
```

### Related PRs
- #256 


@coderabbitai ignore
@coderabbitai ignore